### PR TITLE
Phase B–D: KB taxonomy, semantic Q&A cache, Moderator orchestrator + workers

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -1,0 +1,216 @@
+/**
+ * Concurrency simulation for the Moderator cache pre-check + worker layer.
+ *
+ * Drives the cache + worker pipeline directly with parallel callers:
+ *   A. Cache stampede     — 10x same Q, same scope (correctness under contention)
+ *   B. Cross-scope        — 5 scopes × same Q (parallelism)
+ *   C. Viewer isolation   — private-scoped row should not leak across users
+ *   D. Mixed load         — random queries, some hits some misses
+ *   E. Phase D round-trip — N parallel worker dispatches → cache write-back → all
+ *                           subsequent same-Q precheck hits at L1 (proves the
+ *                           closed loop works under concurrency without dupe rows)
+ */
+
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+import { buildEmbeddingClientFromConfig } from "./dist/src/embedding/client.js";
+import { buildModeratorLlm } from "./dist/src/moderator/llm-client.js";
+import { tryCachePrecheck, clearL0Cache, l0Stats } from "./dist/src/moderator/cache-precheck.js";
+import { dispatchWorker, writeAnswerToCache } from "./dist/src/moderator/workers.js";
+import { storeCachedAnswer } from "./dist/src/cache/qa.js";
+
+const PG_URL = "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw";
+const AGENT = "main";
+const SCOPE = "tg:chat:-1003789981008";
+
+const pool = new pg.Pool({ connectionString: PG_URL });
+const embedding = buildEmbeddingClientFromConfig({
+  format: "openai",
+  baseUrl: "http://100.79.97.110:8800/v1/proxy/local-embed",
+  model: "qwen3-embedding:0.6b",
+});
+const deps = { pool, embedding, agentId: AGENT };
+
+function pct(arr, p) {
+  const s = [...arr].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor((s.length - 1) * p))];
+}
+function summary(label, latencies) {
+  const sum = latencies.reduce((a, b) => a + b, 0);
+  console.log(`  ${label}: n=${latencies.length}  p50=${pct(latencies, 0.5)}ms  p95=${pct(latencies, 0.95)}ms  max=${Math.max(...latencies)}ms  sum=${sum}ms`);
+}
+
+async function scenarioA_stampede() {
+  console.log("\n=== A. Cache stampede — 10× '@Yao_zhua_bot 1/3 + 1/4 等于多少' same scope, parallel ===");
+  clearL0Cache();
+  const Q = "@Yao_zhua_bot 1/3 + 1/4 等于多少";
+  const t0 = Date.now();
+  const results = await Promise.all(
+    Array.from({ length: 10 }, (_, i) =>
+      tryCachePrecheck(deps, { scopeKey: SCOPE, questionText: Q, viewer: { userId: `u${i}`, chatId: "-1003789981008" } }),
+    ),
+  );
+  const wall = Date.now() - t0;
+  const hits = results.filter((r) => r.hit);
+  const byKind = hits.reduce((acc, r) => ((acc[r.hitKind] = (acc[r.hitKind] ?? 0) + 1), acc), {});
+  console.log(`  wall=${wall}ms  hits=${hits.length}/10  by-kind=${JSON.stringify(byKind)}`);
+  summary("latency", results.map((r) => r.latencyMs));
+  const answers = new Set(hits.map((h) => h.answer));
+  console.log(`  distinct answers seen: ${answers.size} (expect 1)`);
+  console.log(`  L0 size after: ${l0Stats().size}`);
+}
+
+async function scenarioB_crossScope() {
+  console.log("\n=== B. Cross-scope parallelism — 5 scopes × same Q, parallel ===");
+  clearL0Cache();
+  const Q = "退货政策是多少天";
+  const scopes = Array.from({ length: 5 }, (_, i) => `tg:chat:-100${1000 + i}`);
+  const t0 = Date.now();
+  const results = await Promise.all(
+    scopes.map((s, i) =>
+      tryCachePrecheck(deps, { scopeKey: s, questionText: Q, viewer: { userId: `u${i}`, chatId: s.replace("tg:chat:", "") } }),
+    ),
+  );
+  const wall = Date.now() - t0;
+  const hits = results.filter((r) => r.hit);
+  console.log(`  wall=${wall}ms  hits=${hits.length}/5  if truly parallel: wall ≈ max(latency)`);
+  summary("latency", results.map((r) => r.latencyMs));
+  // True parallelism check: wall should be close to max individual latency, not sum.
+  const maxLat = Math.max(...results.map((r) => r.latencyMs));
+  const sumLat = results.reduce((a, r) => a + r.latencyMs, 0);
+  console.log(`  parallelism = sum/wall = ${(sumLat / wall).toFixed(2)}x  (5.0 = perfect parallel; 1.0 = serial)`);
+}
+
+async function scenarioC_viewerIsolation() {
+  console.log("\n=== C. Viewer isolation — private TA row must not leak ===");
+  clearL0Cache();
+  const Q = `secret question for user A ${randomUUID().slice(0, 8)}`;
+  const owner = "user-A-123";
+  const stranger = "user-B-456";
+  // Embed once for the seed.
+  const er = await embedding.embed({ inputs: [Q], taskPrefix: "passage" });
+  const id = await storeCachedAnswer(pool, {
+    agentId: AGENT,
+    questionText: Q,
+    questionEmbedding: er.embeddings[0],
+    embeddingModel: "qwen3-embedding:0.6b",
+    answerText: "私密答案：只有 user-A 该看到",
+    scope: { senderId: owner, visibility: "private" },
+    source: "manual",
+    ttlDays: 1,
+  });
+  console.log(`  seeded TA row id=${id} owner=${owner}`);
+
+  const ownerRes = await tryCachePrecheck(deps, { scopeKey: SCOPE, questionText: Q, viewer: { userId: owner, chatId: "-1003789981008" } });
+  const strangerRes = await tryCachePrecheck(deps, { scopeKey: SCOPE, questionText: Q, viewer: { userId: stranger, chatId: "-1003789981008" } });
+  console.log(`  owner sees:    hit=${ownerRes.hit}${ownerRes.hit ? " kind=" + ownerRes.hitKind : ""}`);
+  console.log(`  stranger sees: hit=${strangerRes.hit}${strangerRes.hit ? " kind=" + strangerRes.hitKind + " LEAK!" : " ← correct"}`);
+  // Cleanup.
+  await pool.query("DELETE FROM cache.qa WHERE id = $1", [id]);
+}
+
+async function scenarioD_mixed() {
+  console.log("\n=== D. Mixed load — 20 concurrent across hit/miss mix ===");
+  clearL0Cache();
+  const queries = [
+    "@Yao_zhua_bot 1/3 + 1/4 等于多少",   // L2 hit
+    "退货政策是多少天?",                    // L1 exact hit
+    "怎么算 1/3 + 1/4",                    // L1 exact hit
+    "通分是什么意思?",                      // L1 exact hit
+    "今天天气怎样",                         // miss
+    "约分是什么?",                          // L1 exact hit
+    "1/3 + 1/4 等于多少",                  // L2 hit
+    "什么叫最大公约数?",                    // L1 exact hit
+    "什么是机器学习",                       // miss
+    "你好",                                 // too short (< 4 cleaned)
+  ];
+  const batch = [];
+  for (let i = 0; i < 20; i++) {
+    const q = queries[i % queries.length];
+    batch.push(tryCachePrecheck(deps, { scopeKey: SCOPE, questionText: q, viewer: { userId: `u${i % 5}`, chatId: "-1003789981008" } }));
+  }
+  const t0 = Date.now();
+  const results = await Promise.all(batch);
+  const wall = Date.now() - t0;
+  const hits = results.filter((r) => r.hit);
+  const byKind = hits.reduce((acc, r) => ((acc[r.hitKind] = (acc[r.hitKind] ?? 0) + 1), acc), {});
+  console.log(`  wall=${wall}ms  hits=${hits.length}/20  by-kind=${JSON.stringify(byKind)}`);
+  summary("latency", results.map((r) => r.latencyMs));
+  console.log(`  L0 size after: ${l0Stats().size}`);
+}
+
+async function scenarioE_workerRoundtrip() {
+  console.log("\n=== E. Phase D round-trip — 5 parallel worker dispatches → write-back → cache ===");
+  clearL0Cache();
+  const llm = buildModeratorLlm({
+    format: "gemini",
+    baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini",
+    model: "gemini-2.5-flash",
+  });
+  const cfg = {
+    pluginId: "memory-postgres",
+    storage: { schema: "public", chunksTable: "chunks", chunkIndexesTable: "chunk_indexes" },
+    embedding: { model: "qwen3-embedding:0.6b" },
+  };
+  const logger = { info: () => {}, warn: () => {} }; // quiet
+  const wkDeps = { pool, llm, embedding, cfg, agentId: AGENT, logger };
+
+  // 5 *different* novel questions (UUID suffix), so each must call the LLM,
+  // then write back. After write-back, a second precheck for each must hit.
+  const uid = randomUUID().slice(0, 8);
+  const tasks = Array.from({ length: 5 }, (_, i) => ({
+    taskId: `t_sim_${uid}_${i}`,
+    roleKey: "default",
+    taskPrompt: `用一句话回答：${i + 1} 加 ${i + 1} 等于多少？(${uid}-${i})`,
+    memoryScope: { topic: "arith.concurrency-test" },
+    canParallel: true,
+  }));
+
+  const t0 = Date.now();
+  const results = await Promise.all(
+    tasks.map((t) => dispatchWorker(wkDeps, t, { userId: "u-test", chatId: "-1003789981008" }, t.taskPrompt)),
+  );
+  const dispatchWall = Date.now() - t0;
+  console.log(`  5 parallel dispatches: wall=${dispatchWall}ms, individual latencies=${results.map((r) => r.llm.latencyMs).join("/")}ms`);
+  console.log(`  all answers ok? ${results.every((r) => r.ok)}`);
+
+  // Write-back all (parallel).
+  const wT0 = Date.now();
+  const ids = await Promise.all(results.map((r, i) => writeAnswerToCache(wkDeps, r, tasks[i])));
+  console.log(`  5 parallel writes: wall=${Date.now() - wT0}ms, ids=${ids.filter(Boolean).length}/5`);
+
+  // Re-precheck each — every one should now hit L1-exact (cleaned questionText hashed).
+  clearL0Cache();
+  const recheckT0 = Date.now();
+  const rechecks = await Promise.all(
+    tasks.map((t) =>
+      tryCachePrecheck(deps, { scopeKey: SCOPE, questionText: t.taskPrompt, viewer: { userId: "u-test", chatId: "-1003789981008" } }),
+    ),
+  );
+  console.log(`  5 parallel rechecks: wall=${Date.now() - recheckT0}ms`);
+  const hitCount = rechecks.filter((r) => r.hit).length;
+  console.log(`  rechecks hit: ${hitCount}/5 ${hitCount === 5 ? "✓ closed loop" : "✗ round-trip broken"}`);
+
+  // Cleanup.
+  for (const id of ids) {
+    if (id) {await pool.query("DELETE FROM cache.qa WHERE id = $1", [id]);}
+  }
+}
+
+async function main() {
+  console.log("Concurrency simulation — Moderator cache + worker pipeline");
+  console.log("==========================================================");
+  try {
+    await scenarioA_stampede();
+    await scenarioB_crossScope();
+    await scenarioC_viewerIsolation();
+    await scenarioD_mixed();
+    await scenarioE_workerRoundtrip();
+  } finally {
+    await pool.end();
+  }
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/docs/KB_TAXONOMY.md
+++ b/docs/KB_TAXONOMY.md
@@ -1,0 +1,192 @@
+# KB filesystem taxonomy
+
+> Every file the bot ever sees — whether uploaded via Telegram, dropped
+> in by the teacher with `scp`, or fed in by a future web upload UI —
+> lives under one root directory with one set of rules. The rules are
+> mechanical, not LLM-decided, so the bot's storage stays tidy without
+> us trusting the agent to "be neat."
+
+## Root
+
+```
+/home/ubuntu/.openclaw/kb/         ← OPENCLAW_KB_ROOT env var (default)
+```
+
+A single tree under one user-owned dir. Easy to back up (`pg_dump` + a
+single `tar` of this dir is a full snapshot of agent memory + raw
+sources).
+
+## Top-level layout
+
+```
+kb/
+├── _meta/                         meta / index files (NOT ingested)
+│   ├── upload-log.jsonl           append-only audit log of every intake
+│   ├── aliases.json               numeric-id → human-name map
+│   │                              (e.g. tg-1001234567890 → "5年级数学群")
+│   ├── versions.json              { "<doc-id>": { "current": "v3", "history": [...] } }
+│   └── purgatory/                 files quarantined for review
+│
+├── inbox/                         freshly-received, not yet classified
+│   └── 2026-05-16/                date-bucketed, auto-rotated
+│       └── <original-filename>
+│
+├── courses/                       teacher-uploaded curriculum (global scope)
+│   └── <course-id>/
+│       ├── _info.md               course description (manually written)
+│       └── <topic>/               e.g. "week1", "fractions", "essay-writing"
+│           ├── <file>
+│           └── ...
+│
+├── groups/                        per-Telegram-group shared materials
+│   └── tg-<chat_id>/              (chat-id is numeric, negative for groups)
+│       ├── _info.md               who's in this group, what's the focus
+│       ├── shared/                visible to everyone in the group
+│       │   └── <file>
+│       └── teacher-only/          visible only to the teacher viewer
+│           └── <file>
+│
+└── students/                      per-student private files
+    └── tg-<user_id>/              (telegram user_id)
+        ├── homework/
+        │   └── YYYY-MM-DD__<title>.<ext>
+        ├── notes/
+        └── shared-with-teacher/   student opts to share with teacher only
+```
+
+## Naming convention
+
+### File names
+
+```
+<base-name>__<doc-id>__v<N>.<ext>
+```
+
+- **base-name**: the original filename (slugged: lowercase, spaces → `-`,
+  drop CJK punctuation, keep ASCII + CJK chars).
+- **doc-id**: stable identifier across versions. Defaults to the slug of
+  the base-name; can be overridden via `--doc-id` flag. Used as the
+  `anchor_kb_doc` value.
+- **vN**: version. The intake tool computes this by counting existing
+  files with the same `doc-id` in the same folder; first upload is `v1`.
+
+Example:
+```
+courses/ai-course/week1/00-overview__ai-course-week1-00__v1.md
+courses/ai-course/week1/00-overview__ai-course-week1-00__v2.md   ← later upload
+```
+
+Old versions stay on disk for audit; their chunks in `semantic.chunks`
+get `superseded_by` pointing at the newer chunks so recall never
+returns them.
+
+### Directory names
+
+- Group / user / student folders: `tg-<numeric-id>` always. The numeric
+  id is stable; human-readable aliases live in `_meta/aliases.json` so
+  renaming a group in Telegram doesn't break paths.
+- Course folders: `<slug>` of the course name (lowercase, spaces → `-`,
+  CJK kept).
+- Topic folders: same slug rule.
+
+## Routing rules (mechanical)
+
+Given an upload `(file, sender_user_id, chat_id, chat_type, caption)`:
+
+1. **If `chat_type` is private (DM):**
+   - If sender is the bot owner (`commands.ownerAllowFrom` matches):
+     - If caption has `#course <course-id>` → `courses/<course-id>/inbox/`
+     - Else → `inbox/<date>/` (teacher reviews later)
+   - If sender is a known student:
+     - If caption has `#share` → `students/tg-<user_id>/shared-with-teacher/`
+     - Else → `students/tg-<user_id>/inbox/`
+   - Otherwise (unknown sender): `_meta/purgatory/<date>/` (review required)
+
+2. **If `chat_type` is group / supergroup:**
+   - If sender is the bot owner:
+     - If caption has `#teacher-only` → `groups/tg-<chat_id>/teacher-only/`
+     - Else → `groups/tg-<chat_id>/shared/`
+   - If sender is a student:
+     - If caption has `#share` → `groups/tg-<chat_id>/shared/`
+     - Default → `students/tg-<user_id>/inbox/` (treat as personal
+       homework even though uploaded in a group; opt-in to share)
+
+3. **Caption hints (in addition to the above):**
+   - `#week<N>` → puts into `week<N>` subfolder
+   - `#homework` → puts into `homework/` subfolder
+   - `#topic <slug>` → puts into `<slug>/` subfolder
+   - `#doc-id <slug>` → overrides the auto-derived doc-id
+   - `#version <N>` → manual version override (else auto-incremented)
+
+## Ingest eligibility
+
+Not every uploaded file becomes a chunk. The intake tool decides:
+
+| Format | Behavior |
+|---|---|
+| `.md / .markdown` | parse + chunk + embed + insert |
+| `.txt` | treat like markdown but no heading splits |
+| `.pdf` | (Phase B++.2) pdf-parse → chunk + embed + insert |
+| `.docx` | (Phase B++.2) mammoth → markdown → chunk + insert |
+| `.csv` (with Q,A columns) | (Phase B++.2) row → cache.qa pre-seed + chunk |
+| `.html / .htm` | (Phase B++.2) html-to-text → chunk + insert |
+| `.png / .jpg / .heic` | store only; no ingest (until multimodal) |
+| `.mp3 / .ogg / .wav / .m4a` | (later) credbroker ASR → chunk |
+| `.mp4 / .mov` | store only |
+| anything else | store only; flag as "unsupported" in `_meta/upload-log.jsonl` |
+
+## Anchor mapping
+
+Every chunk written from a KB file carries these anchors (from
+`anchor_kind=value` in `semantic.chunk_indexes`):
+
+| Anchor kind | Value |
+|---|---|
+| `anchor_kb_doc` | the doc-id (stable across versions) |
+| `anchor_kb_version` | `v<N>` |
+| `anchor_kb_path` | the rel path under `kb/` for traceability |
+| `anchor_sender_id` | `tg-<uploader_user_id>` (for student uploads only; teacher uploads stay sender-anonymous for global discoverability) |
+| `anchor_chat_id` | `tg-<chat_id>` if upload is group-scoped |
+| `anchor_visibility` | `public` / `private` / `teacher-only` per routing |
+| `anchor_topic` | from caption hint, or first heading of the file |
+| `anchor_category` | derived by Stage 0 categorizer |
+
+This means the same `viewer-scope` filter Phase B built works on KB
+content for free: students can't see another student's homework even
+if they ingest the same `kb/students/tg-X/homework/` tree.
+
+## Audit log
+
+Every intake appends one JSON line to `_meta/upload-log.jsonl`:
+
+```json
+{
+  "ts": "2026-05-16T19:36:00Z",
+  "source": "telegram",
+  "sender_user_id": "8064984663",
+  "chat_id": "-1001234567890",
+  "chat_type": "supergroup",
+  "caption": "#share #week3 homework explanation",
+  "original_filename": "homework-week3.pdf",
+  "saved_path": "groups/tg-1001234567890/shared/homework-week3__week3-homework__v1.pdf",
+  "format": "pdf",
+  "doc_id": "week3-homework",
+  "version": "v1",
+  "chunks_written": 0,
+  "chunks_status": "pending-pdf-support",
+  "errors": []
+}
+```
+
+This log is the source of truth for "what files are where" and "who
+uploaded what when." The dashboard `/kb` view reads from it.
+
+## Garbage / rotation policy
+
+- `inbox/` entries older than 30 days move to `_meta/purgatory/`
+- `_meta/purgatory/` entries older than 90 days are deleted (chunks
+  in PG keep `superseded_by` chain — disk freed, memory intact)
+- `courses/*/` and `groups/*/shared/` are never auto-deleted; only
+  manually via `nextclaw kb remove <doc-id>`
+- `students/*/inbox/` is per-student, opt-in cleanup (student's data,
+  student decides)

--- a/index.ts
+++ b/index.ts
@@ -114,69 +114,60 @@ export default definePluginEntry({
       { names: ["memory_forget"] },
     );
 
-    // Moderator event hook — registered as `inbound_claim` (not the older
-    // `message_received` observer) so we can CLAIM the message and prevent
-    // codex's parallel reply on Telegram group @-mentions.
+    // Moderator suppression hook — `before_dispatch` (NOT `inbound_claim`).
     //
-    // Why this is necessary: before this change, the Moderator handled the
-    // group @-mention and replied via direct Telegram API calls, but the
-    // codex per-channel agent ALSO replied because `message_received` is a
-    // fire-and-forget observer and openclaw's dispatcher kept running. The
-    // user saw two answers per group question — one from the Moderator
-    // worker (gemini-flash, no web tools) and one from codex (gpt-5.5 with
-    // tavily). With inbound_claim we return `{handled:true}` to stop
-    // codex's downstream path; DMs are unaffected because we only claim
-    // group/supergroup channels.
-    api.on("inbound_claim", async (event, hookCtx) => {
-      const ctxObj = hookCtx as { channelId?: string; conversationId?: string; senderId?: string };
-      const channelId = ctxObj?.channelId;
-      if (channelId !== "telegram") {return;}
-      if (!MODULE_MODERATOR_HANDLE) {return;}
+    // Why before_dispatch and not inbound_claim:
+    //   - inbound_claim only fires for conversations that have a
+    //     PluginConversationBinding linking the chat to a specific plugin
+    //     (see dispatch-CvimgVpK.js: runInboundClaimForPluginOutcome is
+    //     only called inside `if (pluginOwnedBinding)`). Our telegram
+    //     chats are bound to codex (the default agent), not to
+    //     memory-postgres, so our inbound_claim handler would silently
+    //     never fire — the previous attempt failed exactly here.
+    //   - before_dispatch is unconditional: `if (hookRunner?.hasHooks
+    //     ("before_dispatch"))` then run, no binding required. Returning
+    //     `{handled: true}` short-circuits the dispatcher before codex
+    //     gets the message.
+    //
+    // The companion observer hook below (message_received) is what actually
+    // forwards the inbound event into the Moderator pipeline; before_dispatch
+    // only decides whether to suppress codex.
+    api.on("before_dispatch", async (event, hookCtx) => {
+      const ctxObj = hookCtx as { channelId?: string; conversationId?: string };
+      if (ctxObj?.channelId !== "telegram") {return;}
+      // event.isGroup is set directly by the dispatcher (see
+      // hook-types: PluginHookBeforeDispatchEvent), preferred over
+      // re-parsing the conversation id.
+      const ev = event as { content?: string; isGroup?: boolean };
+      const isGroup = ev.isGroup === true ||
+        (ctxObj.conversationId ?? "")
+          .replace(/^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/, "")
+          .startsWith("-");
+      if (!isGroup) {return;} // DMs continue to codex
+      const addressed = /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(ev.content ?? "");
+      if (!addressed) {return;} // group chatter not for the bot — codex won't reply anyway
+      api.logger.info(
+        `[moderator/hook] before_dispatch CLAIMED: conv=${ctxObj.conversationId} ` +
+          `(group + mention — codex suppressed; Moderator replies out-of-band)`,
+      );
+      return { handled: true };
+    });
 
-      // Always forward to the Moderator so its state machine tracks every
-      // message (it filters DM internally). Construct the
-      // PluginMessageEvent shape the service expects.
-      const mEv = {
-        from: event.senderId,
-        senderId: event.senderId,
-        content: event.content,
-        timestamp: event.timestamp ? new Date(event.timestamp).toISOString() : undefined,
-        threadId: event.threadId,
-        messageId: event.messageId,
-        metadata: {
-          senderName: event.senderName,
-          senderUsername: event.senderUsername,
-          threadId: event.threadId,
-        },
-      };
+    // Observer hook — runs after before_dispatch (whether or not codex was
+    // suppressed) so the Moderator's state machine sees every telegram
+    // event. DM filtering happens inside the service.
+    api.on("message_received", async (event, hookCtx) => {
+      const ctxObj = hookCtx as { channelId?: string };
+      if (ctxObj?.channelId !== "telegram") {return;}
+      if (!MODULE_MODERATOR_HANDLE) {return;}
       try {
         MODULE_MODERATOR_HANDLE.onMessageReceived(
-          mEv as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
+          event as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
           hookCtx as Parameters<ModeratorServiceHandle["onMessageReceived"]>[1],
         );
       } catch (err) {
-        api.logger.warn(`memory-postgres: moderator inbound_claim hook threw: ${(err as Error).message}`);
+        api.logger.warn(`memory-postgres: moderator message_received hook threw: ${(err as Error).message}`);
       }
-
-      // Decide whether to CLAIM. The rule MUST match the Moderator's own
-      // group-and-addressed filter in service.ts (looksAddressed +
-      // inferChatTypeFromId), otherwise we'd either:
-      //   - claim a DM the Moderator won't actually answer → user silence
-      //   - leave a group mention un-claimed → double reply (the original bug)
-      const conv = (ctxObj.conversationId ?? "").replace(
-        /^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/,
-        "",
-      );
-      const isGroup = conv.startsWith("-");
-      if (!isGroup) {return;}
-      const addressed = /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(event.content ?? "");
-      if (!addressed) {return;}
-
-      api.logger.info(
-        `[moderator/hook] inbound_claim CLAIMED: conv=${ctxObj.conversationId} sender=${ctxObj.senderId} ` +
-          `(group mention — codex skipped)`,
-      );
-      return { handled: true };
     });
 
     /**

--- a/index.ts
+++ b/index.ts
@@ -114,30 +114,69 @@ export default definePluginEntry({
       { names: ["memory_forget"] },
     );
 
-    // Moderator event hook: must be registered at the SYNCHRONOUS top
-    // of register() so openclaw wires it before any messages route.
-    // The actual moderatorHandle is created inside registerService below
-    // (it needs pg pool + llm client + telegram token which only become
-    // available after start(ctx) fires). The hook captures the handle
-    // by closure and no-ops until start() completes.
-    api.on("message_received", async (event, hookCtx) => {
+    // Moderator event hook — registered as `inbound_claim` (not the older
+    // `message_received` observer) so we can CLAIM the message and prevent
+    // codex's parallel reply on Telegram group @-mentions.
+    //
+    // Why this is necessary: before this change, the Moderator handled the
+    // group @-mention and replied via direct Telegram API calls, but the
+    // codex per-channel agent ALSO replied because `message_received` is a
+    // fire-and-forget observer and openclaw's dispatcher kept running. The
+    // user saw two answers per group question — one from the Moderator
+    // worker (gemini-flash, no web tools) and one from codex (gpt-5.5 with
+    // tavily). With inbound_claim we return `{handled:true}` to stop
+    // codex's downstream path; DMs are unaffected because we only claim
+    // group/supergroup channels.
+    api.on("inbound_claim", async (event, hookCtx) => {
       const ctxObj = hookCtx as { channelId?: string; conversationId?: string; senderId?: string };
-      // TEMP debug — verify the hook is firing at all (next commit will
-      // demote this to debug level after we've confirmed the wiring).
-      api.logger.info(
-        `[moderator/hook] message_received fired: channel=${ctxObj?.channelId} ` +
-          `conv=${ctxObj?.conversationId} sender=${ctxObj?.senderId} ` +
-          `handle=${MODULE_MODERATOR_HANDLE ? "bound" : "unbound"}`,
-      );
+      const channelId = ctxObj?.channelId;
+      if (channelId !== "telegram") {return;}
       if (!MODULE_MODERATOR_HANDLE) {return;}
+
+      // Always forward to the Moderator so its state machine tracks every
+      // message (it filters DM internally). Construct the
+      // PluginMessageEvent shape the service expects.
+      const mEv = {
+        from: event.senderId,
+        senderId: event.senderId,
+        content: event.content,
+        timestamp: event.timestamp ? new Date(event.timestamp).toISOString() : undefined,
+        threadId: event.threadId,
+        messageId: event.messageId,
+        metadata: {
+          senderName: event.senderName,
+          senderUsername: event.senderUsername,
+          threadId: event.threadId,
+        },
+      };
       try {
         MODULE_MODERATOR_HANDLE.onMessageReceived(
-          event as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
+          mEv as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
           hookCtx as Parameters<ModeratorServiceHandle["onMessageReceived"]>[1],
         );
       } catch (err) {
-        api.logger.warn(`memory-postgres: moderator hook threw: ${(err as Error).message}`);
+        api.logger.warn(`memory-postgres: moderator inbound_claim hook threw: ${(err as Error).message}`);
       }
+
+      // Decide whether to CLAIM. The rule MUST match the Moderator's own
+      // group-and-addressed filter in service.ts (looksAddressed +
+      // inferChatTypeFromId), otherwise we'd either:
+      //   - claim a DM the Moderator won't actually answer → user silence
+      //   - leave a group mention un-claimed → double reply (the original bug)
+      const conv = (ctxObj.conversationId ?? "").replace(
+        /^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/,
+        "",
+      );
+      const isGroup = conv.startsWith("-");
+      if (!isGroup) {return;}
+      const addressed = /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(event.content ?? "");
+      if (!addressed) {return;}
+
+      api.logger.info(
+        `[moderator/hook] inbound_claim CLAIMED: conv=${ctxObj.conversationId} sender=${ctxObj.senderId} ` +
+          `(group mention — codex skipped)`,
+      );
+      return { handled: true };
     });
 
     /**

--- a/index.ts
+++ b/index.ts
@@ -104,6 +104,25 @@ export default definePluginEntry({
       { names: ["memory_forget"] },
     );
 
+    // Moderator event hook: must be registered at the SYNCHRONOUS top
+    // of register() so openclaw wires it before any messages route.
+    // The actual moderatorHandle is created inside registerService below
+    // (it needs pg pool + llm client + telegram token which only become
+    // available after start(ctx) fires). The hook captures the handle
+    // by closure and no-ops until start() completes.
+    let activeModeratorHandle: ModeratorServiceHandle | null = null;
+    api.on("message_received", async (event, hookCtx) => {
+      if (!activeModeratorHandle) {return;}
+      try {
+        activeModeratorHandle.onMessageReceived(
+          event as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
+          hookCtx as Parameters<ModeratorServiceHandle["onMessageReceived"]>[1],
+        );
+      } catch (err) {
+        api.logger.warn(`memory-postgres: moderator hook threw: ${(err as Error).message}`);
+      }
+    });
+
     /**
      * Background service: dashboard + scheduled workers.
      *
@@ -382,15 +401,9 @@ export default definePluginEntry({
                 logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
                 debounceMs: cfg.moderator.debounceMs,
               });
-              // Hook openclaw's telegram message_received event.
-              // Same surface thread-ownership uses; per-channel id check
-              // filters non-telegram channels inside the handler.
-              api.on("message_received", async (event: unknown, hookCtx: unknown) => {
-                moderatorHandle?.onMessageReceived(
-                  event as Parameters<NonNullable<typeof moderatorHandle>["onMessageReceived"]>[0],
-                  hookCtx as Parameters<NonNullable<typeof moderatorHandle>["onMessageReceived"]>[1],
-                );
-              });
+              // Bind the closure variable so the top-level api.on hook
+              // starts forwarding events from now on.
+              activeModeratorHandle = moderatorHandle;
               api.logger.info(
                 `memory-postgres: moderator service started — model=${cfg.moderator.model.format}:${cfg.moderator.model.model} ` +
                   `debounceMs=${cfg.moderator.debounceMs} owner=${ownerUserId ?? "(none)"}`,
@@ -440,6 +453,7 @@ export default definePluginEntry({
           try { moderatorHandle.stop(); } catch { /* ignore */ }
           moderatorHandle = null;
         }
+        activeModeratorHandle = null;
         if (moderatorEventUnsub) {
           try { moderatorEventUnsub(); } catch { /* ignore */ }
           moderatorEventUnsub = null;

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,16 @@ import {
 } from "./src/workers/reflection.js";
 import { buildModeratorLlm } from "./src/moderator/llm-client.js";
 import { startModeratorService, type ModeratorServiceHandle } from "./src/moderator/service.js";
+
+/**
+ * Module-level handle for the moderator service. `api.on(...)` hook
+ * handlers and the registerService start() callback may be invoked in
+ * DIFFERENT register(api) closures (cli-metadata pass / tool-discovery
+ * pass / real runtime pass), so the closure-captured variable approach
+ * doesn't reliably let the hook see the handle the service installs.
+ * Module-level state side-steps that.
+ */
+let MODULE_MODERATOR_HANDLE: ModeratorServiceHandle | null = null;
 import { startTranscriptWatcherDaemon, type TranscriptWatcherHandle } from "./src/workers/transcript-watcher.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
@@ -110,11 +120,18 @@ export default definePluginEntry({
     // (it needs pg pool + llm client + telegram token which only become
     // available after start(ctx) fires). The hook captures the handle
     // by closure and no-ops until start() completes.
-    let activeModeratorHandle: ModeratorServiceHandle | null = null;
     api.on("message_received", async (event, hookCtx) => {
-      if (!activeModeratorHandle) {return;}
+      const ctxObj = hookCtx as { channelId?: string; conversationId?: string; senderId?: string };
+      // TEMP debug — verify the hook is firing at all (next commit will
+      // demote this to debug level after we've confirmed the wiring).
+      api.logger.info(
+        `[moderator/hook] message_received fired: channel=${ctxObj?.channelId} ` +
+          `conv=${ctxObj?.conversationId} sender=${ctxObj?.senderId} ` +
+          `handle=${MODULE_MODERATOR_HANDLE ? "bound" : "unbound"}`,
+      );
+      if (!MODULE_MODERATOR_HANDLE) {return;}
       try {
-        activeModeratorHandle.onMessageReceived(
+        MODULE_MODERATOR_HANDLE.onMessageReceived(
           event as Parameters<ModeratorServiceHandle["onMessageReceived"]>[0],
           hookCtx as Parameters<ModeratorServiceHandle["onMessageReceived"]>[1],
         );
@@ -401,9 +418,10 @@ export default definePluginEntry({
                 logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
                 debounceMs: cfg.moderator.debounceMs,
               });
-              // Bind the closure variable so the top-level api.on hook
-              // starts forwarding events from now on.
-              activeModeratorHandle = moderatorHandle;
+              // Publish to module-level state so the top-level api.on
+              // hook (which may live in a DIFFERENT register() closure)
+              // can forward events to us.
+              MODULE_MODERATOR_HANDLE = moderatorHandle;
               api.logger.info(
                 `memory-postgres: moderator service started — model=${cfg.moderator.model.format}:${cfg.moderator.model.model} ` +
                   `debounceMs=${cfg.moderator.debounceMs} owner=${ownerUserId ?? "(none)"}`,
@@ -453,7 +471,7 @@ export default definePluginEntry({
           try { moderatorHandle.stop(); } catch { /* ignore */ }
           moderatorHandle = null;
         }
-        activeModeratorHandle = null;
+        MODULE_MODERATOR_HANDLE = null;
         if (moderatorEventUnsub) {
           try { moderatorEventUnsub(); } catch { /* ignore */ }
           moderatorEventUnsub = null;

--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,8 @@ import {
   startReflectionDaemon,
   type ReflectionDaemonHandle,
 } from "./src/workers/reflection.js";
+import { buildModeratorLlm } from "./src/moderator/llm-client.js";
+import { startModeratorService, type ModeratorServiceHandle } from "./src/moderator/service.js";
 import { startTranscriptWatcherDaemon, type TranscriptWatcherHandle } from "./src/workers/transcript-watcher.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
@@ -116,6 +118,8 @@ export default definePluginEntry({
     let transcriptWatcherHandles: TranscriptWatcherHandle[] = [];
     let shadowHandles: Array<{ stop: () => void }> = [];
     let reflectionHandle: ReflectionDaemonHandle | null = null;
+    let moderatorHandle: ModeratorServiceHandle | null = null;
+    let moderatorEventUnsub: (() => void) | null = null;
     let activePoolCfg: ResolvedPoolConfig | null = null;
 
     api.registerService({
@@ -332,6 +336,77 @@ export default definePluginEntry({
           );
         }
 
+        // Moderator service (Phase C) — hooks Telegram message_received and
+        // runs the orchestrator-worker decision loop per (chat, user) with
+        // 1.5s debounce. Off by default; opt in via config.moderator.enabled.
+        if (cfg.moderator.enabled && cfg.moderator.model.baseUrl) {
+          try {
+            const pool = await getPool(activePoolCfg);
+            const llm = buildModeratorLlm({
+              format: cfg.moderator.model.format,
+              baseUrl: cfg.moderator.model.baseUrl,
+              model: cfg.moderator.model.model,
+              apiKeyEnv: cfg.moderator.model.apiKeyEnv,
+            });
+            // Pull live config for telegram token + ownerAllowFrom.
+            const live = ctx.config as unknown as {
+              channels?: { telegram?: { botToken?: string } };
+              commands?: { ownerAllowFrom?: string[] };
+              gateway?: { auth?: { token?: string } };
+            };
+            const botToken = live.channels?.telegram?.botToken ?? "";
+            const ownerEntry = (live.commands?.ownerAllowFrom ?? [])
+              .find((s) => typeof s === "string" && s.startsWith("telegram:"));
+            const ownerUserId = ownerEntry ? ownerEntry.replace(/^telegram:/, "") : undefined;
+            const dashTokenEnv = cfg.dashboard.tokenEnv;
+            const ingestToken = dashTokenEnv ? (process.env[dashTokenEnv] ?? "") : "";
+
+            if (!botToken) {
+              api.logger.warn(
+                "memory-postgres: moderator.enabled=true but channels.telegram.botToken empty — service NOT started.",
+              );
+            } else if (!ingestToken) {
+              api.logger.warn(
+                "memory-postgres: moderator.enabled=true but dashboard.tokenEnv unresolved — service NOT started (memory-writes would fail).",
+              );
+            } else {
+              moderatorHandle = startModeratorService({
+                enabled: true,
+                llm,
+                telegramBotToken: botToken,
+                ownerUserId,
+                ingestUrl: `http://${cfg.dashboard.host}:${cfg.dashboard.port}/api/ingest`,
+                ingestToken,
+                cfg,
+                pool,
+                logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
+                debounceMs: cfg.moderator.debounceMs,
+              });
+              // Hook openclaw's telegram message_received event.
+              // Same surface thread-ownership uses; per-channel id check
+              // filters non-telegram channels inside the handler.
+              api.on("message_received", async (event: unknown, hookCtx: unknown) => {
+                moderatorHandle?.onMessageReceived(
+                  event as Parameters<NonNullable<typeof moderatorHandle>["onMessageReceived"]>[0],
+                  hookCtx as Parameters<NonNullable<typeof moderatorHandle>["onMessageReceived"]>[1],
+                );
+              });
+              api.logger.info(
+                `memory-postgres: moderator service started — model=${cfg.moderator.model.format}:${cfg.moderator.model.model} ` +
+                  `debounceMs=${cfg.moderator.debounceMs} owner=${ownerUserId ?? "(none)"}`,
+              );
+            }
+          } catch (err) {
+            api.logger.warn(
+              `memory-postgres: moderator service failed to start: ${(err as Error).message}`,
+            );
+          }
+        } else if (cfg.moderator.enabled) {
+          api.logger.warn(
+            "memory-postgres: moderator.enabled=true but model.baseUrl is empty — service NOT started.",
+          );
+        }
+
         // Shadow comparators — for every gpt-5.5 turn we observe in the
         // trajectory, replay the same prompt against a challenger model
         // (qwen3.6-35B by default) and store both sides side-by-side. Lets
@@ -360,6 +435,14 @@ export default definePluginEntry({
         if (reflectionHandle) {
           try { reflectionHandle.stop(); } catch { /* ignore */ }
           reflectionHandle = null;
+        }
+        if (moderatorHandle) {
+          try { moderatorHandle.stop(); } catch { /* ignore */ }
+          moderatorHandle = null;
+        }
+        if (moderatorEventUnsub) {
+          try { moderatorEventUnsub(); } catch { /* ignore */ }
+          moderatorEventUnsub = null;
         }
         tuningTimer = null;
         compactorTimer = null;

--- a/index.ts
+++ b/index.ts
@@ -406,9 +406,18 @@ export default definePluginEntry({
                 "memory-postgres: moderator.enabled=true but dashboard.tokenEnv unresolved — service NOT started (memory-writes would fail).",
               );
             } else {
+              // Embedding client for cache.qa L2 semantic lookup (pre-Moderator)
+              const embeddingClient = buildEmbeddingClientFromConfig({
+                baseUrl: cfg.embedding.baseUrl,
+                model: cfg.embedding.model,
+                apiKeyEnv: cfg.embedding.apiKeyEnv,
+                format: cfg.embedding.format,
+                path: cfg.embedding.path,
+              });
               moderatorHandle = startModeratorService({
                 enabled: true,
                 llm,
+                embedding: embeddingClient,
                 telegramBotToken: botToken,
                 ownerUserId,
                 ingestUrl: `http://${cfg.dashboard.host}:${cfg.dashboard.port}/api/ingest`,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -555,6 +555,31 @@
           }
         }
       },
+      "moderator": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Phase C orchestrator-worker Moderator. When enabled, hooks Telegram message_received events for groups + DMs (DMs continue through the existing per-DM agent path; groups get routed via the Moderator). Off by default.",
+        "properties": {
+          "enabled": { "type": "boolean", "default": false },
+          "debounceMs": {
+            "type": "number",
+            "minimum": 100,
+            "default": 1500,
+            "description": "Per (scope,user) burst window — multiple messages within this window coalesce into one decision."
+          },
+          "model": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["format", "baseUrl"],
+            "properties": {
+              "format": { "type": "string", "enum": ["openai", "gemini"] },
+              "baseUrl": { "type": "string" },
+              "model": { "type": "string" },
+              "apiKeyEnv": { "type": "string" }
+            }
+          }
+        }
+      },
       "reflection": {
         "type": "object",
         "additionalProperties": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "memory-postgres",
   "activation": {
+    "onStartup": true
+  },
+  "activation": {
     "onStartup": false
   },
   "kind": "memory",

--- a/src/cache/qa.test.ts
+++ b/src/cache/qa.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  lookupCachedAnswerExact,
+  lookupCachedAnswerSemantic,
+  storeCachedAnswer,
+  recordCacheHit,
+  recordCacheFeedback,
+} from "./qa.js";
+
+function mockPool(rows: Array<Record<string, unknown>>) {
+  return {
+    query: vi.fn(async () => ({ rows, rowCount: rows.length })),
+  } as unknown as Parameters<typeof lookupCachedAnswerExact>[0];
+}
+
+describe("cache.qa lookup — exact path", () => {
+  it("returns null when no row matches", async () => {
+    const pool = mockPool([]);
+    const r = await lookupCachedAnswerExact(pool, {
+      questionText: "what is 1/3 + 1/4",
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns a hit with similarity=1.0 on match", async () => {
+    const pool = mockPool([
+      {
+        id: "abc-id",
+        question_text: "what is 1/3 + 1/4",
+        answer_text: "7/12",
+        answer_format: "plain",
+        topic_tag: "math.fractions",
+        use_count: 5,
+        upvotes: 2,
+        downvotes: 0,
+        scope_chat_id: null,
+        scope_sender_id: null,
+        scope_visibility: "public",
+        source: "agent",
+        source_doc_id: null,
+      },
+    ]);
+    const r = await lookupCachedAnswerExact(pool, {
+      questionText: "what is 1/3 + 1/4",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.id).toBe("abc-id");
+    expect(r!.similarity).toBe(1.0);
+    expect(r!.hitKind).toBe("exact");
+    expect(r!.answerText).toBe("7/12");
+  });
+
+  it("hashes the question lowercased + trimmed", async () => {
+    const pool = mockPool([]);
+    const spy = pool.query as ReturnType<typeof vi.fn>;
+    await lookupCachedAnswerExact(pool, { questionText: "  WHAT IS 1/3 + 1/4  " });
+    const callArgs = spy.mock.calls[0];
+    const sql = callArgs[0] as string;
+    expect(sql).toContain("question_hash = $2");
+    // Bind value $2 is the hash buffer — can't read raw, but its presence
+    // implies normalisation happened in `hashQuestion`.
+    expect(callArgs[1]).toBeDefined();
+  });
+});
+
+describe("cache.qa lookup — semantic path", () => {
+  it("returns null when no embedding provided", async () => {
+    const pool = mockPool([]);
+    const r = await lookupCachedAnswerSemantic(pool, {
+      questionText: "x",
+      questionEmbedding: undefined,
+    });
+    expect(r).toBeNull();
+    expect((pool.query as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("returns null when best match is below threshold", async () => {
+    const pool = mockPool([
+      { id: "row1", question_text: "x", answer_text: "x", answer_format: "plain", topic_tag: null,
+        use_count: 0, upvotes: 0, downvotes: 0, scope_chat_id: null, scope_sender_id: null,
+        scope_visibility: "public", source: "agent", source_doc_id: null,
+        similarity: 0.7 },  // below default 0.85
+    ]);
+    const r = await lookupCachedAnswerSemantic(pool, {
+      questionText: "1/3 + 1/4",
+      questionEmbedding: [0.1, 0.2, 0.3],
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns top hit when above threshold", async () => {
+    const pool = mockPool([
+      { id: "row1", question_text: "x", answer_text: "the answer", answer_format: "plain",
+        topic_tag: "math.fractions", use_count: 3, upvotes: 1, downvotes: 0,
+        scope_chat_id: null, scope_sender_id: null, scope_visibility: "public",
+        source: "agent", source_doc_id: null, similarity: 0.91 },
+    ]);
+    const r = await lookupCachedAnswerSemantic(pool, {
+      questionText: "1/3 + 1/4",
+      questionEmbedding: [0.1, 0.2, 0.3],
+    });
+    expect(r).not.toBeNull();
+    expect(r!.similarity).toBeCloseTo(0.91);
+    expect(r!.hitKind).toBe("semantic");
+    expect(r!.answerText).toBe("the answer");
+  });
+});
+
+describe("cache.qa viewer-scope embedded in SQL", () => {
+  it("emits no scope clause when viewer omitted", async () => {
+    const pool = mockPool([]);
+    await lookupCachedAnswerExact(pool, { questionText: "x" });
+    const sql = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    // No scope clause means the SQL just has the TRUE noop guard
+    expect(sql).toMatch(/AND\s+TRUE/);
+  });
+
+  it("emits the three-tier scope clause when viewer set", async () => {
+    const pool = mockPool([]);
+    await lookupCachedAnswerExact(pool, {
+      questionText: "x",
+      viewer: { userId: "8064984663", chatId: "-1001234567890" },
+    });
+    const sql = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain("scope_chat_id IS NULL AND scope_sender_id IS NULL"); // T0
+    expect(sql).toContain("scope_sender_id = $3");                                 // TA
+    expect(sql).toContain("scope_chat_id = $4");                                   // TC
+    expect(sql).toContain("scope_visibility = 'private'");                          // BLOCK
+  });
+});
+
+describe("cache.qa write + ops", () => {
+  it("storeCachedAnswer issues a single INSERT with bind values in the right order", async () => {
+    const pool = mockPool([{ id: "newid" }]);
+    const id = await storeCachedAnswer(pool, {
+      questionText: "what is 1/3 + 1/4",
+      questionEmbedding: [0.1, 0.2, 0.3, 0.4],
+      embeddingModel: "qwen3-embedding:0.6b",
+      answerText: "7/12",
+      topicTag: "math.fractions",
+      ttlDays: 30,
+    });
+    expect(id).toBe("newid");
+    const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain("INSERT INTO cache.qa");
+    // ttlDays threaded through as the last bind
+    expect(call[1][call[1].length - 1]).toBe("30");
+  });
+
+  it("recordCacheHit bumps use_count + last_used_at", async () => {
+    const pool = mockPool([]);
+    await recordCacheHit(pool, "id-1");
+    const sql = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain("use_count = use_count + 1");
+    expect(sql).toContain("last_used_at = now()");
+  });
+
+  it("recordCacheFeedback writes the vote + auto-invalidates on net-negative", async () => {
+    const pool = mockPool([]);
+    await recordCacheFeedback(pool, "id-1", "down");
+    const spy = pool.query as ReturnType<typeof vi.fn>;
+    // First call increments downvotes; second call may auto-invalidate.
+    expect(spy.mock.calls.length).toBe(2);
+    expect((spy.mock.calls[0][0] as string)).toContain("downvotes = downvotes + 1");
+    expect((spy.mock.calls[1][0] as string)).toContain("invalidated = true");
+  });
+});

--- a/src/cache/qa.ts
+++ b/src/cache/qa.ts
@@ -1,0 +1,337 @@
+/**
+ * cache.qa — semantic Q&A cache (GPTCache-style).
+ *
+ * Two lookup paths and one write path, all viewer-scoped:
+ *
+ *   - `lookupCachedAnswerExact` — sha256(question_text) match; sub-5ms
+ *   - `lookupCachedAnswerSemantic` — HNSW cosine match against
+ *     question_embedding; ~50ms with the existing pgvector index
+ *   - `storeCachedAnswer` — write a new (Q, A, scope) tuple after a
+ *     worker answer or a CSV pre-seed
+ *
+ * Viewer-scope rules are STRUCTURALLY parallel to the chat-memory
+ * viewer-scope filter (src/recall/viewer-scope.ts) but evaluate on
+ * the cache.qa columns directly rather than on chunk_indexes joins
+ * — the cache table is wider on purpose so a hot-path lookup is one
+ * indexed scan with no extra EXISTS subqueries.
+ *
+ * VISIBILITY:
+ *   T0  scope_chat_id IS NULL AND scope_sender_id IS NULL  (global / system)
+ *   TA  scope_sender_id == viewer.userId                   (the asker's own)
+ *   TC  scope_chat_id   == viewer.chatId AND not private  (group-public)
+ *   BLOCK  visibility = 'private' AND scope_sender_id != viewer.userId
+ */
+
+import { createHash } from "node:crypto";
+import type { Pool } from "pg";
+import pgvector from "pgvector/pg";
+import type { ViewerScope } from "../recall/viewer-scope.js";
+
+export type CacheHit = {
+  id: string;
+  questionText: string;
+  answerText: string;
+  answerFormat: string;
+  topicTag: string | null;
+  similarity: number; // 1.0 for exact-hash hits, cosine sim for semantic
+  hitKind: "exact" | "semantic";
+  useCount: number;
+  upvotes: number;
+  downvotes: number;
+  scopeChatId: string | null;
+  scopeSenderId: string | null;
+  scopeVisibility: string;
+  source: string;
+  sourceDocId: string | null;
+};
+
+const DEFAULT_MIN_SIMILARITY = 0.85;
+const DEFAULT_TTL_DAYS = 90;
+
+export type LookupParams = {
+  agentId?: string;
+  questionText: string;
+  /** Optional precomputed embedding to skip the embed call. */
+  questionEmbedding?: number[];
+  viewer?: ViewerScope;
+  /** Cosine min for semantic hit; default 0.85. */
+  minSimilarity?: number;
+  /** topic_tag filter (e.g. force "math.fractions" if known). */
+  topicTag?: string;
+};
+
+export type StoreParams = {
+  agentId?: string;
+  questionText: string;
+  questionEmbedding: number[];
+  embeddingModel: string;
+  answerText: string;
+  answerFormat?: "plain" | "markdown" | "latex";
+  scope?: {
+    chatId?: string;
+    senderId?: string;
+    visibility?: "public" | "private" | "chat-only";
+  };
+  topicTag?: string;
+  workerRoleId?: string;
+  source?: "agent" | "csv-seed" | "manual";
+  sourceDocId?: string;
+  ttlDays?: number;
+};
+
+function hashQuestion(text: string): Buffer {
+  return createHash("sha256").update(text.trim().toLowerCase(), "utf8").digest();
+}
+
+/* ---------------------------- viewer-scope WHERE --------------------------- */
+
+function viewerScopeWhere(viewer: ViewerScope | undefined, paramStart: number): {
+  whereSql: string;
+  params: string[];
+  count: number;
+} {
+  // Without a viewer, anything-goes (legacy / system caller).
+  if (!viewer || (!viewer.userId && !viewer.chatId)) {
+    return { whereSql: "TRUE", params: [], count: 0 };
+  }
+  const viewerUser = viewer.userId ?? "__no_user__";
+  const viewerChat = viewer.chatId ?? "__no_chat__";
+  const p1 = `$${paramStart}`;
+  const p2 = `$${paramStart + 1}`;
+  const whereSql = `
+    (
+      (scope_chat_id IS NULL AND scope_sender_id IS NULL)         -- T0 global
+      OR scope_sender_id = ${p1}                                   -- TA viewer's own
+      OR (scope_chat_id = ${p2} AND scope_visibility != 'private') -- TC group-public
+    )
+    AND NOT (
+      scope_visibility = 'private' AND scope_sender_id IS DISTINCT FROM ${p1}
+    )
+  `;
+  return { whereSql, params: [viewerUser, viewerChat], count: 2 };
+}
+
+/* --------------------------------- lookup --------------------------------- */
+
+export async function lookupCachedAnswerExact(
+  pool: Pool,
+  params: LookupParams,
+): Promise<CacheHit | null> {
+  const agentId = params.agentId ?? "main";
+  const hash = hashQuestion(params.questionText);
+  const viewerFrag = viewerScopeWhere(params.viewer, 3);
+
+  const sql = `
+    SELECT id, question_text, answer_text, answer_format, topic_tag,
+           use_count, upvotes, downvotes,
+           scope_chat_id, scope_sender_id, scope_visibility,
+           source, source_doc_id
+      FROM cache.qa
+     WHERE agent_id = $1
+       AND question_hash = $2
+       AND NOT invalidated
+       AND cacheable
+       AND expires_at > now()
+       ${params.topicTag ? `AND topic_tag = $${3 + viewerFrag.count}` : ""}
+       AND ${viewerFrag.whereSql}
+     ORDER BY (upvotes - downvotes) DESC, use_count DESC, created_at DESC
+     LIMIT 1`;
+  const args: unknown[] = [agentId, hash, ...viewerFrag.params];
+  if (params.topicTag) {args.push(params.topicTag);}
+
+  const r = await pool.query(sql, args);
+  if (r.rowCount === 0) {return null;}
+  const row = r.rows[0];
+  return rowToHit(row, 1.0, "exact");
+}
+
+export async function lookupCachedAnswerSemantic(
+  pool: Pool,
+  params: LookupParams,
+): Promise<CacheHit | null> {
+  if (!params.questionEmbedding || params.questionEmbedding.length === 0) {return null;}
+  const agentId = params.agentId ?? "main";
+  const minSim = params.minSimilarity ?? DEFAULT_MIN_SIMILARITY;
+  const viewerFrag = viewerScopeWhere(params.viewer, 3);
+
+  const sql = `
+    SELECT id, question_text, answer_text, answer_format, topic_tag,
+           use_count, upvotes, downvotes,
+           scope_chat_id, scope_sender_id, scope_visibility,
+           source, source_doc_id,
+           1 - (question_embedding <=> $2::vector) AS similarity
+      FROM cache.qa
+     WHERE agent_id = $1
+       AND NOT invalidated
+       AND cacheable
+       AND expires_at > now()
+       ${params.topicTag ? `AND topic_tag = $${3 + viewerFrag.count}` : ""}
+       AND ${viewerFrag.whereSql}
+     ORDER BY question_embedding <=> $2::vector
+     LIMIT 5`;
+  const args: unknown[] = [agentId, pgvector.toSql(params.questionEmbedding), ...viewerFrag.params];
+  if (params.topicTag) {args.push(params.topicTag);}
+
+  const r = await pool.query<{ similarity: number } & Record<string, unknown>>(sql, args);
+  if (r.rowCount === 0) {return null;}
+  // Take the best hit, but only if it clears the threshold.
+  const best = r.rows[0];
+  if ((best.similarity ?? 0) < minSim) {return null;}
+  return rowToHit(best, best.similarity, "semantic");
+}
+
+export async function lookupCachedAnswer(
+  pool: Pool,
+  params: LookupParams,
+): Promise<CacheHit | null> {
+  // Try exact first (cheap), fall back to semantic if we have an embedding.
+  const exact = await lookupCachedAnswerExact(pool, params);
+  if (exact) {return exact;}
+  return lookupCachedAnswerSemantic(pool, params);
+}
+
+function rowToHit(row: Record<string, unknown>, similarity: number, kind: "exact" | "semantic"): CacheHit {
+  return {
+    id: String(row.id),
+    questionText: String(row.question_text),
+    answerText: String(row.answer_text),
+    answerFormat: String(row.answer_format ?? "plain"),
+    topicTag: row.topic_tag ? String(row.topic_tag) : null,
+    similarity,
+    hitKind: kind,
+    useCount: Number(row.use_count ?? 0),
+    upvotes: Number(row.upvotes ?? 0),
+    downvotes: Number(row.downvotes ?? 0),
+    scopeChatId: row.scope_chat_id ? String(row.scope_chat_id) : null,
+    scopeSenderId: row.scope_sender_id ? String(row.scope_sender_id) : null,
+    scopeVisibility: String(row.scope_visibility ?? "public"),
+    source: String(row.source ?? "agent"),
+    sourceDocId: row.source_doc_id ? String(row.source_doc_id) : null,
+  };
+}
+
+/* ---------------------------------- write --------------------------------- */
+
+export async function storeCachedAnswer(pool: Pool, params: StoreParams): Promise<string> {
+  const agentId = params.agentId ?? "main";
+  const hash = hashQuestion(params.questionText);
+  const ttlDays = Math.max(1, params.ttlDays ?? DEFAULT_TTL_DAYS);
+  const scope = params.scope ?? {};
+  const r = await pool.query<{ id: string }>(
+    `INSERT INTO cache.qa (
+       id, agent_id, question_text, question_hash, question_embedding, embedding_model,
+       answer_text, answer_format,
+       scope_chat_id, scope_sender_id, scope_visibility, cacheable,
+       topic_tag, worker_role_id, source, source_doc_id,
+       expires_at
+     )
+     VALUES (
+       gen_random_uuid(), $1, $2, $3, $4::vector, $5,
+       $6, $7,
+       $8, $9, $10, TRUE,
+       $11, $12, $13, $14,
+       now() + ($15 || ' days')::interval
+     )
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    [
+      agentId,
+      params.questionText,
+      hash,
+      pgvector.toSql(params.questionEmbedding),
+      params.embeddingModel,
+      params.answerText,
+      params.answerFormat ?? "plain",
+      scope.chatId ?? null,
+      scope.senderId ?? null,
+      scope.visibility ?? "public",
+      params.topicTag ?? null,
+      params.workerRoleId ?? null,
+      params.source ?? "agent",
+      params.sourceDocId ?? null,
+      String(ttlDays),
+    ],
+  );
+  return r.rows[0]?.id ?? "";
+}
+
+/* ---------------------------------- ops ----------------------------------- */
+
+export async function recordCacheHit(pool: Pool, id: string): Promise<void> {
+  await pool
+    .query(
+      `UPDATE cache.qa
+         SET use_count = use_count + 1, last_used_at = now()
+       WHERE id = $1`,
+      [id],
+    )
+    .catch(() => undefined);
+}
+
+export async function invalidateCachedAnswer(
+  pool: Pool,
+  id: string,
+  reason: string,
+): Promise<void> {
+  await pool.query(
+    `UPDATE cache.qa SET invalidated = true, invalidated_reason = $2 WHERE id = $1`,
+    [id, reason],
+  );
+}
+
+export async function recordCacheFeedback(
+  pool: Pool,
+  id: string,
+  vote: "up" | "down",
+): Promise<void> {
+  await pool.query(
+    vote === "up"
+      ? `UPDATE cache.qa SET upvotes = upvotes + 1 WHERE id = $1`
+      : `UPDATE cache.qa SET downvotes = downvotes + 1 WHERE id = $1`,
+    [id],
+  );
+  // Auto-invalidate when net feedback goes negative and at least 3 downvotes.
+  await pool.query(
+    `UPDATE cache.qa
+        SET invalidated = true, invalidated_reason = 'auto: downvotes > upvotes + 3'
+      WHERE id = $1
+        AND NOT invalidated
+        AND downvotes - upvotes > 3`,
+    [id],
+  );
+}
+
+/* --------------------------------- stats ---------------------------------- */
+
+export type CacheStatsRow = {
+  topicTag: string | null;
+  entries: number;
+  totalUses: number;
+  avgQuality: number;
+};
+
+export async function cacheStats(pool: Pool, agentId: string = "main"): Promise<CacheStatsRow[]> {
+  const r = await pool.query<{
+    topic_tag: string | null;
+    entries: string;
+    total_uses: string;
+    avg_quality: string | null;
+  }>(
+    `SELECT topic_tag,
+            count(*)::text AS entries,
+            sum(use_count)::text AS total_uses,
+            avg(upvotes - downvotes)::text AS avg_quality
+       FROM cache.qa
+      WHERE agent_id = $1 AND NOT invalidated AND cacheable
+      GROUP BY topic_tag
+      ORDER BY sum(use_count) DESC NULLS LAST
+      LIMIT 50`,
+    [agentId],
+  );
+  return r.rows.map((row) => ({
+    topicTag: row.topic_tag,
+    entries: parseInt(row.entries, 10),
+    totalUses: parseInt(row.total_uses, 10),
+    avgQuality: parseFloat(row.avg_quality ?? "0"),
+  }));
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,27 @@ export type MemoryPostgresConfig = {
    * and pointing `model` at an OpenAI-compat or native-Gemini endpoint.
    */
   reflection?: ReflectionConfig;
+  /**
+   * Moderator service (Phase C). When enabled, hooks openclaw's
+   * Telegram `message_received` event and runs an orchestrator-worker
+   * decision loop for every inbound message in a group / supergroup
+   * (DMs pass through unchanged so the existing per-DM agent path
+   * keeps working). Off by default — opt in.
+   */
+  moderator?: ModeratorConfig;
+};
+
+export type ModeratorConfig = {
+  enabled?: boolean;
+  /** LLM transport — mirrors reflection.model. Default: gpt-5.5 via OpenAI. */
+  model?: {
+    format: "openai" | "gemini";
+    baseUrl: string;
+    model: string;
+    apiKeyEnv?: string;
+  };
+  /** Per (scope, user) burst-collapse window. Default 1500ms. */
+  debounceMs?: number;
 };
 
 export type ReflectionConfig = {
@@ -264,6 +285,18 @@ export type ResolvedMemoryPostgresConfig = {
   transcriptWatchers: ResolvedTranscriptWatcher[];
   shadowComparators: ResolvedShadowComparator[];
   reflection: ResolvedReflectionConfig;
+  moderator: ResolvedModeratorConfig;
+};
+
+export type ResolvedModeratorConfig = {
+  enabled: boolean;
+  debounceMs: number;
+  model: {
+    format: "openai" | "gemini";
+    baseUrl: string;
+    model: string;
+    apiKeyEnv?: string;
+  };
 };
 
 export type ResolvedReflectionConfig = {
@@ -404,6 +437,24 @@ export function resolveConfig(raw: MemoryPostgresConfig): ResolvedMemoryPostgres
     transcriptWatchers: (raw.transcriptWatchers ?? []).map(resolveTranscriptWatcher),
     shadowComparators: (raw.shadowComparators ?? []).map(resolveShadowComparator),
     reflection: resolveReflectionConfig(raw.reflection),
+    moderator: resolveModeratorConfig(raw.moderator),
+  };
+}
+
+function resolveModeratorConfig(raw: ModeratorConfig | undefined): ResolvedModeratorConfig {
+  const block = raw ?? ({} as ModeratorConfig);
+  const modelBlock = block.model ?? ({} as NonNullable<ModeratorConfig["model"]>);
+  const format = modelBlock.format === "gemini" ? "gemini" : "openai";
+  return {
+    enabled: bool(block.enabled, false),
+    debounceMs: Math.max(100, num(block.debounceMs, 1500)),
+    model: {
+      format,
+      baseUrl: isString(modelBlock.baseUrl) ? modelBlock.baseUrl : "",
+      model: isString(modelBlock.model) ? modelBlock.model
+        : format === "gemini" ? "gemini-2.5-flash" : "gpt-5.5",
+      apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
+    },
   };
 }
 

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -22,6 +22,14 @@ import { fileURLToPath } from "node:url";
 import type { Pool, PoolClient } from "pg";
 import type { ResolvedMemoryPostgresConfig } from "../config.js";
 import { buildEmbeddingClientFromConfig } from "../embedding/client.js";
+import {
+  cacheStats,
+  invalidateCachedAnswer,
+  lookupCachedAnswer,
+  recordCacheFeedback,
+  recordCacheHit,
+  storeCachedAnswer,
+} from "../cache/qa.js";
 import { ingestOne, type IngestInput } from "../ingest/pipeline.js";
 import { recall as recallFn, type RecallInput } from "../recall/router.js";
 import { readBotStats } from "./bot-stats.js";
@@ -309,6 +317,152 @@ async function handleRecall(
  * populated by the shadow-comparator worker. Returns aggregate stats per
  * challenger model + the recent N turns for the dashboard panel.
  */
+/* ----------------------------- cache.qa routes ---------------------------- */
+
+async function handleCacheLookup(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pool: Pool,
+  cfg: ResolvedMemoryPostgresConfig,
+): Promise<void> {
+  if (req.method !== "POST") {return send(res, 405, "method not allowed", "text/plain");}
+  let body: unknown;
+  try { body = await readJsonBody(req); } catch (err) {
+    return sendJson(res, 400, { ok: false, error: (err as Error).message });
+  }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return sendJson(res, 400, { ok: false, error: "body must be a JSON object" });
+  }
+  const b = body as Record<string, unknown>;
+  const questionText = asStr(b["question"]);
+  if (!questionText) {return sendJson(res, 400, { ok: false, error: "question is required" });}
+
+  const viewerRaw = typeof b["viewer"] === "object" && b["viewer"] !== null && !Array.isArray(b["viewer"])
+    ? (b["viewer"] as Record<string, unknown>) : {};
+  const viewer = {
+    userId: asStr(viewerRaw["userId"]),
+    chatId: asStr(viewerRaw["chatId"]),
+  };
+  const minSim = asNum(b["minSimilarity"]);
+  const topicTag = asStr(b["topicTag"]);
+  const agentId = asStr(b["agentId"]) ?? "main";
+
+  // For semantic path we need an embedding; if caller didn't precompute,
+  // we embed locally using the same embed client the recall path uses.
+  let questionEmbedding: number[] | undefined;
+  if (Array.isArray(b["questionEmbedding"])) {
+    questionEmbedding = b["questionEmbedding"] as number[];
+  } else if (b["embed"] !== false) {
+    const embedClient = buildEmbeddingClientFromConfig({
+      baseUrl: cfg.embedding.baseUrl,
+      model: cfg.embedding.model,
+      apiKeyEnv: cfg.embedding.apiKeyEnv,
+      format: cfg.embedding.format,
+      path: cfg.embedding.path,
+    });
+    const r = await embedClient.embed({ inputs: [questionText.slice(0, cfg.embedding.maxEmbedChars)], taskPrefix: "query" });
+    questionEmbedding = r.embeddings[0];
+  }
+
+  const hit = await lookupCachedAnswer(pool, {
+    agentId,
+    questionText,
+    questionEmbedding,
+    viewer: viewer.userId || viewer.chatId ? viewer : undefined,
+    minSimilarity: minSim,
+    topicTag,
+  });
+  if (hit) {
+    await recordCacheHit(pool, hit.id);
+  }
+  sendJson(res, 200, { ok: true, hit });
+}
+
+async function handleCacheStore(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pool: Pool,
+  cfg: ResolvedMemoryPostgresConfig,
+): Promise<void> {
+  if (req.method !== "POST") {return send(res, 405, "method not allowed", "text/plain");}
+  let body: unknown;
+  try { body = await readJsonBody(req); } catch (err) {
+    return sendJson(res, 400, { ok: false, error: (err as Error).message });
+  }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return sendJson(res, 400, { ok: false, error: "body must be a JSON object" });
+  }
+  const b = body as Record<string, unknown>;
+  const questionText = asStr(b["question"]);
+  const answerText = asStr(b["answer"]);
+  if (!questionText || !answerText) {
+    return sendJson(res, 400, { ok: false, error: "question and answer required" });
+  }
+  const embedClient = buildEmbeddingClientFromConfig({
+    baseUrl: cfg.embedding.baseUrl,
+    model: cfg.embedding.model,
+    apiKeyEnv: cfg.embedding.apiKeyEnv,
+    format: cfg.embedding.format,
+    path: cfg.embedding.path,
+  });
+  const embedRes = await embedClient.embed({ inputs: [questionText.slice(0, cfg.embedding.maxEmbedChars)] });
+  const scopeRaw = typeof b["scope"] === "object" && b["scope"] !== null && !Array.isArray(b["scope"])
+    ? (b["scope"] as Record<string, unknown>) : {};
+  const id = await storeCachedAnswer(pool, {
+    agentId: asStr(b["agentId"]) ?? "main",
+    questionText,
+    questionEmbedding: embedRes.embeddings[0] ?? [],
+    embeddingModel: embedRes.model,
+    answerText,
+    answerFormat: (asStr(b["answerFormat"]) as "plain" | "markdown" | "latex") ?? "plain",
+    scope: {
+      chatId: asStr(scopeRaw["chatId"]),
+      senderId: asStr(scopeRaw["senderId"]),
+      visibility: (asStr(scopeRaw["visibility"]) as "public" | "private" | "chat-only") ?? "public",
+    },
+    topicTag: asStr(b["topicTag"]),
+    source: (asStr(b["source"]) as "agent" | "csv-seed" | "manual") ?? "manual",
+    sourceDocId: asStr(b["sourceDocId"]),
+    ttlDays: asNum(b["ttlDays"]),
+  });
+  sendJson(res, 200, { ok: true, id });
+}
+
+async function handleCacheFeedback(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pool: Pool,
+): Promise<void> {
+  if (req.method !== "POST") {return send(res, 405, "method not allowed", "text/plain");}
+  const body = await readJsonBody(req) as Record<string, unknown>;
+  const id = asStr(body["id"]);
+  const vote = asStr(body["vote"]);
+  if (!id || (vote !== "up" && vote !== "down")) {
+    return sendJson(res, 400, { ok: false, error: "id and vote=up|down required" });
+  }
+  await recordCacheFeedback(pool, id, vote);
+  sendJson(res, 200, { ok: true });
+}
+
+async function handleCacheInvalidate(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pool: Pool,
+): Promise<void> {
+  if (req.method !== "POST") {return send(res, 405, "method not allowed", "text/plain");}
+  const body = await readJsonBody(req) as Record<string, unknown>;
+  const id = asStr(body["id"]);
+  const reason = asStr(body["reason"]) ?? "manual";
+  if (!id) {return sendJson(res, 400, { ok: false, error: "id required" });}
+  await invalidateCachedAnswer(pool, id, reason);
+  sendJson(res, 200, { ok: true });
+}
+
+async function handleCacheStatsRoute(res: ServerResponse, pool: Pool): Promise<void> {
+  const rows = await cacheStats(pool, "main");
+  sendJson(res, 200, { ok: true, byTopic: rows });
+}
+
 async function handleModelCompare(res: ServerResponse, pool: Pool): Promise<void> {
   // Aggregates per challenger model, last 24h.
   const agg = await pool.query(
@@ -544,6 +698,21 @@ export async function startDashboardServer(
           return;
         case "/api/ingest":
           await handleIngest(req, res, pool, cfg);
+          return;
+        case "/api/cache/lookup":
+          await handleCacheLookup(req, res, pool, cfg);
+          return;
+        case "/api/cache/store":
+          await handleCacheStore(req, res, pool, cfg);
+          return;
+        case "/api/cache/feedback":
+          await handleCacheFeedback(req, res, pool);
+          return;
+        case "/api/cache/invalidate":
+          await handleCacheInvalidate(req, res, pool);
+          return;
+        case "/api/cache/stats":
+          await handleCacheStatsRoute(res, pool);
           return;
         default:
           send(res, 404, "not found", "text/plain");

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -255,6 +255,11 @@ async function handleRecall(
   const anchorsRaw = (typeof b["anchors"] === "object" && b["anchors"] !== null && !Array.isArray(b["anchors"]))
     ? (b["anchors"] as Record<string, unknown>)
     : {};
+  const viewerRaw = typeof b["viewer"] === "object" && b["viewer"] !== null && !Array.isArray(b["viewer"])
+    ? (b["viewer"] as Record<string, unknown>)
+    : {};
+  const viewerUserId = asStr(viewerRaw["userId"]);
+  const viewerChatId = asStr(viewerRaw["chatId"]);
   const input: RecallInput = {
     query,
     maxResults: asNum(b["k"]) ?? asNum(b["maxResults"]),
@@ -272,6 +277,9 @@ async function handleRecall(
       scope: asStr(anchorsRaw["scope"]),
     },
     timeBucket: asStr(b["timeBucket"]),
+    viewer: viewerUserId || viewerChatId
+      ? { userId: viewerUserId, chatId: viewerChatId }
+      : undefined,
   };
   const embedding = buildEmbeddingClientFromConfig({
     baseUrl: cfg.embedding.baseUrl,

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -463,6 +463,73 @@ async function handleCacheStatsRoute(res: ServerResponse, pool: Pool): Promise<v
   sendJson(res, 200, { ok: true, byTopic: rows });
 }
 
+async function handleCacheRecent(res: ServerResponse, pool: Pool): Promise<void> {
+  // Top entries by use_count for the dashboard "popular Q&A" panel.
+  const r = await pool.query<{
+    id: string;
+    question_text: string;
+    answer_text: string;
+    topic_tag: string | null;
+    use_count: number;
+    upvotes: number;
+    downvotes: number;
+    scope_visibility: string;
+    scope_chat_id: string | null;
+    source: string;
+    source_doc_id: string | null;
+    last_used_at: Date | null;
+  }>(
+    `SELECT id, question_text, answer_text, topic_tag,
+            use_count, upvotes, downvotes, scope_visibility, scope_chat_id,
+            source, source_doc_id, last_used_at
+       FROM cache.qa
+      WHERE agent_id = 'main' AND NOT invalidated AND cacheable
+      ORDER BY use_count DESC, (upvotes - downvotes) DESC, created_at DESC
+      LIMIT 50`,
+  );
+  sendJson(res, 200, {
+    ok: true,
+    entries: r.rows.map((row) => ({
+      id: row.id,
+      question: row.question_text,
+      answer: row.answer_text.length > 240 ? row.answer_text.slice(0, 237) + "..." : row.answer_text,
+      topicTag: row.topic_tag,
+      useCount: row.use_count,
+      net: row.upvotes - row.downvotes,
+      scope: row.scope_chat_id ? `chat:${row.scope_chat_id}` : row.scope_visibility,
+      source: row.source_doc_id ? `${row.source}:${row.source_doc_id}` : row.source,
+      lastUsedAt: row.last_used_at,
+    })),
+  });
+}
+
+async function handleKbList(res: ServerResponse): Promise<void> {
+  // Read the most-recent N entries from the KB upload audit log.
+  // Source of truth lives under OPENCLAW_KB_ROOT / _meta / upload-log.jsonl.
+  // We don't hold the log open — read-then-close keeps the endpoint cheap.
+  const kbRoot = process.env.OPENCLAW_KB_ROOT
+    || path.join(homedir(), ".openclaw", "kb");
+  const logPath = path.join(kbRoot, "_meta", "upload-log.jsonl");
+  let raw = "";
+  try {
+    raw = await readFile(logPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      sendJson(res, 500, { ok: false, error: `read kb log: ${(err as Error).message}` });
+      return;
+    }
+    raw = "";
+  }
+  const lines = raw.split(/\n+/).filter((l) => l.trim().length > 0);
+  // Newest last; show last 100, newest first.
+  const recent = lines.slice(-100).reverse();
+  const entries: unknown[] = [];
+  for (const l of recent) {
+    try {entries.push(JSON.parse(l));} catch { /* skip malformed */ }
+  }
+  sendJson(res, 200, { ok: true, entries, total: lines.length, kbRoot });
+}
+
 async function handleModelCompare(res: ServerResponse, pool: Pool): Promise<void> {
   // Aggregates per challenger model, last 24h.
   const agg = await pool.query(
@@ -713,6 +780,12 @@ export async function startDashboardServer(
           return;
         case "/api/cache/stats":
           await handleCacheStatsRoute(res, pool);
+          return;
+        case "/api/cache/recent":
+          await handleCacheRecent(res, pool);
+          return;
+        case "/api/kb/list":
+          await handleKbList(res);
           return;
         default:
           send(res, 404, "not found", "text/plain");

--- a/src/moderator/cache-precheck.ts
+++ b/src/moderator/cache-precheck.ts
@@ -1,0 +1,214 @@
+/**
+ * Pre-Moderator cache lookup — L0 (in-process LRU) + L1 (PG exact-hash) +
+ * L2 (PG semantic HNSW). When a hit lands, we send the cached answer
+ * directly and SKIP the Moderator + worker entirely → 0 Gemini tokens,
+ * ~50ms latency instead of ~6s.
+ *
+ * Why an in-process L0 in front of L1 (PG):
+ *   - True hot-path ("same question 3 times in 30 sec, e.g. a student
+ *     spam-clicking send") gets sub-millisecond response.
+ *   - Saves PG round-trips on the burstiest cases.
+ *   - LRU bounded; memory cost negligible (~50KB at 200 entries).
+ *
+ * Why not Redis:
+ *   - PG cache.qa already does the durable cross-restart cache.
+ *   - L0 covers the only path where Redis would beat PG (sub-ms).
+ *   - One fewer service to operate.
+ */
+
+import type { Pool } from "pg";
+import type { EmbeddingClient } from "../embedding/client.js";
+import {
+  lookupCachedAnswerExact,
+  lookupCachedAnswerSemantic,
+  recordCacheHit,
+  type CacheHit,
+} from "../cache/qa.js";
+import type { ViewerScope } from "../recall/viewer-scope.js";
+
+/* ----------------------------- L0 in-process ------------------------------ */
+
+type L0Entry = { hit: CacheHit; cachedAt: number; key: string };
+const L0_CAP = 200;
+const L0_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const L0: Map<string, L0Entry> = new Map(); // scope-aware Map<key, L0Entry>
+
+function l0Key(scopeKey: string, questionTextNormalized: string, viewerUserId?: string): string {
+  return `${scopeKey}|${viewerUserId ?? ""}|${questionTextNormalized}`;
+}
+
+/**
+ * Strip Telegram bot mentions + collapse whitespace before hashing/embedding.
+ *
+ * Why this matters: a user message in a group looks like
+ *   "@Yao_zhua_bot 1/3 + 1/4 等于多少"
+ * but the cached row was stored as
+ *   "1/3 + 1/4 等于多少"
+ * Without stripping, the cosine similarity drops from 0.88 → 0.76 because the
+ * @-handle dominates a quarter of the token budget on short questions.
+ *
+ * We strip ALL @-mentions (not just the bot's own) because:
+ *   - addressing a peer (`@alice ...`) shouldn't change the cache key
+ *   - we don't know the bot's username at this layer without plumbing config
+ *     (telegram-api.ts has botToken, not username)
+ */
+function cleanQuestionText(text: string): string {
+  return text
+    .replace(/@[A-Za-z0-9_]{3,32}/g, " ") // Telegram username spec: 5-32 chars, but be lenient
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeQuestion(text: string): string {
+  return cleanQuestionText(text).toLowerCase();
+}
+
+function l0Get(key: string): CacheHit | null {
+  const entry = L0.get(key);
+  if (!entry) {return null;}
+  if (Date.now() - entry.cachedAt > L0_TTL_MS) {
+    L0.delete(key);
+    return null;
+  }
+  // LRU bump — re-insert moves to MRU position in JS Map iteration order
+  L0.delete(key);
+  L0.set(key, entry);
+  return entry.hit;
+}
+
+function l0Set(key: string, hit: CacheHit): void {
+  if (L0.size >= L0_CAP) {
+    // Evict LRU (first key in iteration order)
+    const oldest = L0.keys().next().value;
+    if (oldest !== undefined) {L0.delete(oldest);}
+  }
+  L0.set(key, { hit, cachedAt: Date.now(), key });
+}
+
+export function clearL0Cache(): void {
+  L0.clear();
+}
+
+export function l0Stats(): { size: number; capacity: number } {
+  return { size: L0.size, capacity: L0_CAP };
+}
+
+/* ------------------------------ public API -------------------------------- */
+
+export type CachePrecheckDeps = {
+  pool: Pool;
+  embedding: EmbeddingClient;
+  agentId: string;
+  minSimilarity?: number;
+};
+
+export type CachePrecheckParams = {
+  /** Scope (`tg:chat:<chat_id>` / `tg:dm:<user_id>`). */
+  scopeKey: string;
+  /** The user's message text (raw — we normalise internally). */
+  questionText: string;
+  /** Viewer for the 3-tier scope filter (so other-user private cache
+   *  rows stay hidden even if a question text matches). */
+  viewer?: ViewerScope;
+  /** Optional caller topic hint to narrow lookup. */
+  topicTag?: string;
+};
+
+export type CachePrecheckResult =
+  | { hit: true; hitKind: "L0" | "L1-exact" | "L2-semantic"; answer: string; cacheId: string; similarity: number; latencyMs: number }
+  | { hit: false; latencyMs: number };
+
+/**
+ * Walks L0 → L1 (exact) → L2 (semantic) in order. First hit wins. On hit:
+ *  - L0 returns straight away
+ *  - L1/L2 hits get warmed into L0 for next time
+ *  - cache.qa.use_count gets bumped (async, fire-and-forget)
+ *
+ * Returns { hit: false } on miss. Caller continues to Moderator.
+ */
+export async function tryCachePrecheck(
+  deps: CachePrecheckDeps,
+  params: CachePrecheckParams,
+): Promise<CachePrecheckResult> {
+  const startedAt = Date.now();
+  // Cleaned form (mention-stripped, single-spaced). Used for L0 key, L1 hash,
+  // and L2 embedding. Original questionText is kept ONLY for logging /
+  // cache-write of NEW rows (so we don't lose the verbatim input there).
+  const cleaned = cleanQuestionText(params.questionText);
+  const norm = cleaned.toLowerCase();
+  if (norm.length < 4) {
+    return { hit: false, latencyMs: 0 };
+  }
+
+  const key = l0Key(params.scopeKey, norm, params.viewer?.userId);
+
+  // L0 — in-process LRU
+  const fromL0 = l0Get(key);
+  if (fromL0) {
+    void recordCacheHit(deps.pool, fromL0.id).catch(() => undefined);
+    return {
+      hit: true,
+      hitKind: "L0",
+      answer: fromL0.answerText,
+      cacheId: fromL0.id,
+      similarity: 1.0,
+      latencyMs: Date.now() - startedAt,
+    };
+  }
+
+  // L1 — PG cache.qa exact-hash (uses the cleaned form so "@bot foo" and
+  // "foo" hash to the same bucket)
+  const exact = await lookupCachedAnswerExact(deps.pool, {
+    agentId: deps.agentId,
+    questionText: cleaned,
+    viewer: params.viewer,
+    topicTag: params.topicTag,
+  });
+  if (exact) {
+    l0Set(key, exact);
+    return {
+      hit: true,
+      hitKind: "L1-exact",
+      answer: exact.answerText,
+      cacheId: exact.id,
+      similarity: 1.0,
+      latencyMs: Date.now() - startedAt,
+    };
+  }
+
+  // L2 — PG cache.qa semantic (HNSW). Needs the embedding first.
+  // Worth the ~100ms embed call because we'll skip a ~6s Gemini call on hit.
+  let questionEmbedding: number[] | undefined;
+  try {
+    const embedRes = await deps.embedding.embed({
+      inputs: [cleaned],
+      taskPrefix: "query",
+    });
+    questionEmbedding = embedRes.embeddings[0];
+  } catch {
+    // Embedding broke — fall through to miss; the Moderator path handles
+    // the question without cache assistance.
+    return { hit: false, latencyMs: Date.now() - startedAt };
+  }
+  const semantic = await lookupCachedAnswerSemantic(deps.pool, {
+    agentId: deps.agentId,
+    questionText: cleaned,
+    questionEmbedding,
+    viewer: params.viewer,
+    minSimilarity: deps.minSimilarity ?? 0.85,
+    topicTag: params.topicTag,
+  });
+  if (semantic) {
+    l0Set(key, semantic);
+    return {
+      hit: true,
+      hitKind: "L2-semantic",
+      answer: semantic.answerText,
+      cacheId: semantic.id,
+      similarity: semantic.similarity,
+      latencyMs: Date.now() - startedAt,
+    };
+  }
+
+  return { hit: false, latencyMs: Date.now() - startedAt };
+}

--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -21,82 +21,44 @@
 import type { ModeratorState, RecentMessage } from "./types.js";
 
 const SYSTEM_PROMPT = `You are the MODERATOR for a Telegram tutoring / customer-service bot.
-You receive a new message in a Telegram scope (group or DM) and must decide
-ONE action. You do NOT answer the question yourself — you decide what
-should happen and what specialist workers to spawn. You always reply with
-exactly ONE JSON object conforming to the schema below.
+Decide ONE routing action per inbound message. You do NOT answer questions
+yourself — you route. Reply with exactly ONE JSON object, no prose.
 
-## Available actions
+Actions (pick one):
+  ignore            — chatter, not addressed, no value to remember
+  write-only        — durable fact about the speaker; remember, don't reply
+  answer-direct     — single question; spawn ONE worker
+  answer-decompose  — TRULY independent sub-questions; parallel workers
+  clarify           — ambiguous; reply asking for more info
+  escalate          — beyond bot / explicit "find a teacher" / sensitive
 
-  "ignore"            — chatter / not addressed to bot / no value to remember
-  "write-only"        — useful info but no reply needed (e.g. "I dislike
-                         verbose explanations" — remember, don't reply)
-  "answer-direct"     — ONE worker spawned to answer one question
-  "answer-decompose"  — multiple INDEPENDENT sub-questions; spawn workers
-                         in parallel; only use when truly orthogonal
-  "clarify"           — question is ambiguous; reply asking, no worker
-  "escalate"          — beyond bot's competence / user explicitly asks
-                         for a human / sensitive content; ping the owner
+Picking rules:
+  • @mention + a real question → answer-direct (default unless decompose)
+  • Multi-step problem, one topic → answer-direct (don't fan out)
+  • Two unrelated Qs in one msg → answer-decompose
+  • Speaker states durable fact ("我是初二的") → write-only
+  • Group chatter, no mention → ignore
+  • "我不懂" x3 OR "找老师" → escalate
+  • Intent unclear → clarify
 
-## Scaling rules (you cannot self-judge effort — apply these)
+memoryWrites scope: "user" = about speaker, "chat" = about this room,
+"global" = world fact. Skip greetings + transient chatter.
 
-  - Simple factual / definitional question → answer-direct, 1 worker
-  - Multi-step problem with one topic → answer-direct (worker decomposes
-    internally; don't fan out)
-  - Two CLEARLY independent questions in one message ("how to add fractions
-    AND what time is class?") → answer-decompose with 2 parallel workers
-  - User states a durable fact about themselves ("我是初二学生") →
-    write-only, memoryWrites=[{ scope: "user", ... }]
-  - User asks in chat but not @mentioning the bot, and topic is small-talk
-    → ignore (no memory, no reply)
-  - User says "我搞不懂" 3+ times on the same topic, or "找老师" / "I want
-    a real teacher" → escalate
-  - You don't know what they're asking, or grammar makes intent unclear
-    → clarify (one short reply)
+When spawning workers, send a "placeholder" telegramAction first; the
+worker's result will replace it via { kind:"edit_placeholder", fromTaskResult:true }.
 
-## Memory writes
-
-When the user states a durable fact, decision, preference, or measurable
-metric, add a memoryWrites entry:
-  scope: "user"   → about the speaker (telegram user) personally
-  scope: "chat"   → about this group / DM context
-  scope: "global" → about the world / curriculum / shared resource
-
-Do NOT write greetings, debug requests, or transient chatter.
-Do NOT write the user's question itself — workers handle Q&A separately.
-
-## Telegram actions
-
-When you spawn a worker, send a "placeholder" first ("⏳ 让我想想...")
-so the user sees acknowledgment. Use kind="edit_placeholder" with
-fromTaskResult=true to splice the worker's output back into that
-placeholder once it completes.
-
-## Output schema (you MUST emit exactly this shape)
-
+Output schema:
 {
-  "action": "ignore" | "write-only" | "answer-direct" | "answer-decompose" | "clarify" | "escalate",
-  "rationale": "one sentence why",
-  "memoryWrites": [ { "text": "...", "scope": "user"|"chat"|"global", "topic": "...", "importance": 0.0..1.0, "visibility": "public"|"private" } ],
-  "answerTasks": [
-    {
-      "taskId": "t1",
-      "roleKey": "math_tutor_grade5",
-      "taskPrompt": "Student asks ... Explain step by step.",
-      "memoryScope": { "topic": "math.fractions" },
-      "canParallel": true
-    }
-  ],
-  "telegramActions": [
-    { "kind": "placeholder", "taskId": "t1", "text": "⏳ 让我想想..." },
-    { "kind": "edit_placeholder", "taskId": "t1", "fromTaskResult": true }
-  ],
-  "escalation": { "reason": "...", "summary": "...", "pauseScope": false },
-  "noteAppend": "optional one-liner to save into Moderator's own notes for next cycle"
+  "action": <one of above>,
+  "rationale": "<one sentence>",
+  "memoryWrites": [{"text":"...","scope":"user"|"chat"|"global","topic":"...","importance":0..1,"visibility":"public"|"private"}],
+  "answerTasks": [{"taskId":"t1","roleKey":"<spec id>","taskPrompt":"...","memoryScope":{"topic":"..."},"canParallel":true}],
+  "telegramActions": [{"kind":"placeholder","taskId":"t1","text":"⏳ ..."},{"kind":"edit_placeholder","taskId":"t1","fromTaskResult":true}],
+  "escalation": {"reason":"...","summary":"...","pauseScope":false},
+  "noteAppend": "<optional one-liner>"
 }
 
-Omit fields that aren't relevant to the chosen action. Always emit
-"action" and "rationale". No prose around the JSON — JSON only.`;
+Omit irrelevant fields. JSON only.`;
 
 const MAX_RECENT_MESSAGES_IN_PROMPT = 30;
 const MAX_MESSAGE_TEXT_LEN = 500;

--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -159,7 +159,11 @@ function serialiseStateForPrompt(state: ModeratorState, knownRoles: string[]): s
       const text = m.text.length > MAX_MESSAGE_TEXT_LEN ? `${m.text.slice(0, MAX_MESSAGE_TEXT_LEN)}…` : m.text;
       const addr = m.isAddressed ? "@" : " ";
       const label = m.fromLabel ? `${m.fromUserId}/${m.fromLabel}` : m.fromUserId;
-      lines.push(`  ${addr} [${m.ts.slice(11, 19)}] ${label}: ${text}`);
+      // Defensive: ts SHOULD be ISO string (service.ts coerces) but
+      // resist crashing on a non-string from a deserialised state row.
+      const tsStr = typeof m.ts === "string" ? m.ts : String(m.ts);
+      const hhmmss = tsStr.length >= 19 ? tsStr.slice(11, 19) : tsStr;
+      lines.push(`  ${addr} [${hhmmss}] ${label}: ${text}`);
     }
   }
 

--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -1,0 +1,180 @@
+/**
+ * Moderator decision prompt builder.
+ *
+ * Constructs the gpt-5.5 prompt that drives one Moderator cycle. The
+ * prompt has three sections:
+ *
+ *   1. System: role definition + the action enum + JSON-only output rule
+ *      + scaling rules (Anthropic "Building effective agents" — agents
+ *        can't self-judge effort, so we encode the heuristics in-prompt)
+ *
+ *   2. State context: condensed snapshot of ModeratorState — recent
+ *      messages (last 30), active topic, active workers, active students,
+ *      Moderator's own notes
+ *
+ *   3. The trigger: the new inbound message OR a cron-tick / worker-result
+ *
+ * The expected response is ONE JSON object conforming to ModeratorDecision
+ * (see types.ts → parseDecision for the defensive parser).
+ */
+
+import type { ModeratorState, RecentMessage } from "./types.js";
+
+const SYSTEM_PROMPT = `You are the MODERATOR for a Telegram tutoring / customer-service bot.
+You receive a new message in a Telegram scope (group or DM) and must decide
+ONE action. You do NOT answer the question yourself — you decide what
+should happen and what specialist workers to spawn. You always reply with
+exactly ONE JSON object conforming to the schema below.
+
+## Available actions
+
+  "ignore"            — chatter / not addressed to bot / no value to remember
+  "write-only"        — useful info but no reply needed (e.g. "I dislike
+                         verbose explanations" — remember, don't reply)
+  "answer-direct"     — ONE worker spawned to answer one question
+  "answer-decompose"  — multiple INDEPENDENT sub-questions; spawn workers
+                         in parallel; only use when truly orthogonal
+  "clarify"           — question is ambiguous; reply asking, no worker
+  "escalate"          — beyond bot's competence / user explicitly asks
+                         for a human / sensitive content; ping the owner
+
+## Scaling rules (you cannot self-judge effort — apply these)
+
+  - Simple factual / definitional question → answer-direct, 1 worker
+  - Multi-step problem with one topic → answer-direct (worker decomposes
+    internally; don't fan out)
+  - Two CLEARLY independent questions in one message ("how to add fractions
+    AND what time is class?") → answer-decompose with 2 parallel workers
+  - User states a durable fact about themselves ("我是初二学生") →
+    write-only, memoryWrites=[{ scope: "user", ... }]
+  - User asks in chat but not @mentioning the bot, and topic is small-talk
+    → ignore (no memory, no reply)
+  - User says "我搞不懂" 3+ times on the same topic, or "找老师" / "I want
+    a real teacher" → escalate
+  - You don't know what they're asking, or grammar makes intent unclear
+    → clarify (one short reply)
+
+## Memory writes
+
+When the user states a durable fact, decision, preference, or measurable
+metric, add a memoryWrites entry:
+  scope: "user"   → about the speaker (telegram user) personally
+  scope: "chat"   → about this group / DM context
+  scope: "global" → about the world / curriculum / shared resource
+
+Do NOT write greetings, debug requests, or transient chatter.
+Do NOT write the user's question itself — workers handle Q&A separately.
+
+## Telegram actions
+
+When you spawn a worker, send a "placeholder" first ("⏳ 让我想想...")
+so the user sees acknowledgment. Use kind="edit_placeholder" with
+fromTaskResult=true to splice the worker's output back into that
+placeholder once it completes.
+
+## Output schema (you MUST emit exactly this shape)
+
+{
+  "action": "ignore" | "write-only" | "answer-direct" | "answer-decompose" | "clarify" | "escalate",
+  "rationale": "one sentence why",
+  "memoryWrites": [ { "text": "...", "scope": "user"|"chat"|"global", "topic": "...", "importance": 0.0..1.0, "visibility": "public"|"private" } ],
+  "answerTasks": [
+    {
+      "taskId": "t1",
+      "roleKey": "math_tutor_grade5",
+      "taskPrompt": "Student asks ... Explain step by step.",
+      "memoryScope": { "topic": "math.fractions" },
+      "canParallel": true
+    }
+  ],
+  "telegramActions": [
+    { "kind": "placeholder", "taskId": "t1", "text": "⏳ 让我想想..." },
+    { "kind": "edit_placeholder", "taskId": "t1", "fromTaskResult": true }
+  ],
+  "escalation": { "reason": "...", "summary": "...", "pauseScope": false },
+  "noteAppend": "optional one-liner to save into Moderator's own notes for next cycle"
+}
+
+Omit fields that aren't relevant to the chosen action. Always emit
+"action" and "rationale". No prose around the JSON — JSON only.`;
+
+const MAX_RECENT_MESSAGES_IN_PROMPT = 30;
+const MAX_MESSAGE_TEXT_LEN = 500;
+
+export type DecisionPromptInput = {
+  state: ModeratorState;
+  trigger:
+    | { kind: "message"; message: RecentMessage }
+    | { kind: "cron"; reason: "self-review" | "stale-worker-sweep" }
+    | { kind: "worker-result"; taskId: string; result: string; success: boolean };
+  /** Optional list of currently-registered worker roles (helps the
+   *  Moderator pick from existing specialists vs creating new ones). */
+  knownRoles?: string[];
+};
+
+export function buildDecisionPrompt(input: DecisionPromptInput): {
+  system: string;
+  user: string;
+} {
+  const ctx = serialiseStateForPrompt(input.state, input.knownRoles ?? []);
+  const trigger = serialiseTrigger(input.trigger);
+  return {
+    system: SYSTEM_PROMPT,
+    user: `## Scope\n${ctx}\n\n## Trigger\n${trigger}\n\nRespond with one JSON object only.`,
+  };
+}
+
+function serialiseStateForPrompt(state: ModeratorState, knownRoles: string[]): string {
+  const lines: string[] = [];
+  lines.push(`scopeKind: ${state.scopeKind}`);
+  if (state.chatId) {lines.push(`chatId: ${state.chatId}`);}
+  if (state.activeTopic) {lines.push(`activeTopic: ${state.activeTopic}`);}
+
+  if (state.activeStudents.length > 0) {
+    lines.push("activeStudents:");
+    for (const s of state.activeStudents.slice(-10)) {
+      lines.push(`  - ${s.userId}${s.label ? ` (${s.label})` : ""}${s.currentTopic ? ` topic=${s.currentTopic}` : ""}`);
+    }
+  }
+
+  if (state.activeWorkers.length > 0) {
+    lines.push("activeWorkers (in-flight):");
+    for (const w of state.activeWorkers) {
+      lines.push(`  - task=${w.taskId} role=${w.roleKey} status=${w.status}${w.placeholderMessageId ? ` placeholder=${w.placeholderMessageId}` : ""}`);
+    }
+  }
+
+  if (knownRoles.length > 0) {
+    lines.push(`knownRoles: ${knownRoles.slice(0, 30).join(", ")}`);
+  }
+
+  if (state.notes.length > 0) {
+    lines.push("notes:");
+    for (const n of state.notes.slice(-10)) {lines.push(`  - ${n}`);}
+  }
+
+  if (state.recentMessages.length > 0) {
+    lines.push(`recentMessages (last ${Math.min(MAX_RECENT_MESSAGES_IN_PROMPT, state.recentMessages.length)}):`);
+    for (const m of state.recentMessages.slice(-MAX_RECENT_MESSAGES_IN_PROMPT)) {
+      const text = m.text.length > MAX_MESSAGE_TEXT_LEN ? `${m.text.slice(0, MAX_MESSAGE_TEXT_LEN)}…` : m.text;
+      const addr = m.isAddressed ? "@" : " ";
+      const label = m.fromLabel ? `${m.fromUserId}/${m.fromLabel}` : m.fromUserId;
+      lines.push(`  ${addr} [${m.ts.slice(11, 19)}] ${label}: ${text}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function serialiseTrigger(trigger: DecisionPromptInput["trigger"]): string {
+  if (trigger.kind === "message") {
+    const m = trigger.message;
+    const text = m.text.length > MAX_MESSAGE_TEXT_LEN ? `${m.text.slice(0, MAX_MESSAGE_TEXT_LEN)}…` : m.text;
+    const addr = m.isAddressed ? "@bot-mention" : "no-mention";
+    return `new message (${addr})\n  from: ${m.fromUserId}${m.fromLabel ? ` (${m.fromLabel})` : ""}\n  at:   ${m.ts}\n  text: ${text}`;
+  }
+  if (trigger.kind === "cron") {
+    return `cron tick: ${trigger.reason}`;
+  }
+  return `worker result: task=${trigger.taskId} success=${trigger.success}\n  result: ${trigger.result.slice(0, 800)}`;
+}

--- a/src/moderator/llm-client.ts
+++ b/src/moderator/llm-client.ts
@@ -1,0 +1,72 @@
+/**
+ * Moderator LLM adapter.
+ *
+ * Wraps the existing `ReflectionClient` (src/embedding/reflection-client.ts)
+ * — same OpenAI-compat + native-Gemini transport pair — and exposes the
+ * `ModeratorLlm` interface that `runOneCycle` expects.
+ *
+ * Why reuse: the reflection worker already has a battle-tested chat
+ * client with both transports (OpenAI compat for gpt-5.5 / OpenAI /
+ * vLLM / Ollama-chat, and native Gemini for credbroker-proxied
+ * google models). The Moderator doesn't need anything new on the wire.
+ *
+ * Config: `cfg.moderator.model` mirrors `cfg.reflection.model`. Default
+ * format=openai, model=gpt-5.5, baseUrl=https://api.openai.com,
+ * apiKeyEnv=OPENAI_API_KEY (the user's existing openclaw OAuth handles
+ * the codex-side gpt-5.5; for non-codex paths an explicit key is needed).
+ */
+
+import {
+  buildReflectionClientFromConfig,
+  type ReflectionApiFormat,
+} from "../embedding/reflection-client.js";
+import type { ModeratorLlm } from "./runner.js";
+
+export type ModeratorLlmConfig = {
+  format: ReflectionApiFormat;
+  baseUrl: string;
+  model: string;
+  apiKeyEnv?: string;
+};
+
+export function buildModeratorLlm(cfg: ModeratorLlmConfig): ModeratorLlm {
+  const client = buildReflectionClientFromConfig({
+    format: cfg.format,
+    baseUrl: cfg.baseUrl,
+    model: cfg.model,
+    apiKeyEnv: cfg.apiKeyEnv,
+  });
+  return {
+    async call({ systemPrompt, userPrompt, maxTokens, temperature }) {
+      const r = await client.chat({
+        systemPrompt,
+        userPrompt,
+        maxOutputTokens: maxTokens ?? 1200,
+        temperature: temperature ?? 0.3,
+      });
+      if (!r.ok) {
+        // Convert the error path into a defensible LLM output: the
+        // Moderator's parseDecision will see this as garbage and fall
+        // back to `ignore`, so a network blip costs us one routing
+        // round but never crashes the service.
+        return {
+          text: JSON.stringify({
+            action: "ignore",
+            rationale: `llm-call-failed: ${r.error.slice(0, 200)}`,
+          }),
+          inputTokens: 0,
+          outputTokens: 0,
+          model: cfg.model,
+          latencyMs: r.latencyMs,
+        };
+      }
+      return {
+        text: r.text,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        model: cfg.model,
+        latencyMs: r.latencyMs,
+      };
+    },
+  };
+}

--- a/src/moderator/runner.test.ts
+++ b/src/moderator/runner.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildDecisionPrompt } from "./decisions.js";
+import { runOneCycle, applyDecisionToState, type ModeratorLlm } from "./runner.js";
+import { newModeratorState, parseDecision } from "./types.js";
+
+describe("parseDecision (defensive parser)", () => {
+  it("returns ignore when input is not an object", () => {
+    expect(parseDecision(null).decision.action).toBe("ignore");
+    expect(parseDecision("string").decision.action).toBe("ignore");
+    expect(parseDecision([1, 2]).decision.action).toBe("ignore");
+  });
+
+  it("returns ignore for unknown action", () => {
+    const r = parseDecision({ action: "do_the_thing", rationale: "?" });
+    expect(r.decision.action).toBe("ignore");
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a well-formed answer-direct decision", () => {
+    const r = parseDecision({
+      action: "answer-direct",
+      rationale: "student asked a math question",
+      answerTasks: [{
+        taskId: "t1",
+        roleKey: "math_tutor_grade5",
+        taskPrompt: "explain 1/3 + 1/4",
+        canParallel: true,
+      }],
+      telegramActions: [{ kind: "placeholder", taskId: "t1", text: "⏳..." }],
+    });
+    expect(r.decision.action).toBe("answer-direct");
+    expect(r.decision.answerTasks?.length).toBe(1);
+    expect(r.decision.answerTasks?.[0].roleKey).toBe("math_tutor_grade5");
+    expect(r.errors.length).toBe(0);
+  });
+
+  it("drops malformed sub-objects but keeps the rest", () => {
+    const r = parseDecision({
+      action: "write-only",
+      rationale: "user shared a fact",
+      memoryWrites: [
+        { text: "Yao 喜欢简洁回复", scope: "user", importance: 0.8 },     // ok
+        { text: "no scope provided" },                                     // dropped (no scope)
+        { scope: "user" },                                                 // dropped (no text)
+        { text: "bad scope", scope: "everywhere" },                        // dropped (bad scope)
+      ],
+    });
+    expect(r.decision.action).toBe("write-only");
+    expect(r.decision.memoryWrites?.length).toBe(1);
+    expect(r.decision.memoryWrites?.[0].importance).toBe(0.8);
+  });
+
+  it("captures escalation when reason + summary are both strings", () => {
+    const r = parseDecision({
+      action: "escalate",
+      rationale: "user is frustrated",
+      escalation: { reason: "stuck-on-topic", summary: "Mason 卡分数 15 分钟", pauseScope: true },
+    });
+    expect(r.decision.escalation?.pauseScope).toBe(true);
+    expect(r.decision.escalation?.summary).toContain("Mason");
+  });
+});
+
+describe("applyDecisionToState", () => {
+  it("appends a message to recentMessages and updates activeStudents", () => {
+    const s = newModeratorState("tg:chat:-100", "group", "-100");
+    const m = {
+      ts: "2026-05-16T20:00:00Z",
+      fromUserId: "8064984663",
+      fromLabel: "Yao",
+      text: "怎么算 1/3 + 1/4",
+      messageId: 42,
+      isAddressed: true,
+    };
+    const out = applyDecisionToState(
+      s,
+      { kind: "message", message: m },
+      { action: "answer-direct", rationale: "math q" },
+    );
+    expect(out.recentMessages.length).toBe(1);
+    expect(out.recentMessages[0].text).toBe(m.text);
+    expect(out.activeStudents.length).toBe(1);
+    expect(out.activeStudents[0].userId).toBe("8064984663");
+    expect(out.messagesSinceLastReview).toBe(1);
+  });
+
+  it("caps recentMessages at 50 entries (FIFO)", () => {
+    let s = newModeratorState("tg:chat:-100", "group");
+    for (let i = 0; i < 60; i += 1) {
+      const m = {
+        ts: `2026-05-16T20:${String(i % 60).padStart(2, "0")}:00Z`,
+        fromUserId: `user-${i}`,
+        text: `msg-${i}`,
+      };
+      s = applyDecisionToState(s, { kind: "message", message: m }, { action: "ignore", rationale: "" });
+    }
+    expect(s.recentMessages.length).toBe(50);
+    expect(s.recentMessages[0].fromUserId).toBe("user-10"); // dropped 0-9
+  });
+
+  it("adds workers from decision.answerTasks", () => {
+    const s = newModeratorState("tg:chat:-100", "group");
+    const out = applyDecisionToState(
+      s,
+      { kind: "message", message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "Q" } },
+      {
+        action: "answer-decompose",
+        rationale: "two questions",
+        answerTasks: [
+          { taskId: "t1", roleKey: "math", taskPrompt: "P1" },
+          { taskId: "t2", roleKey: "english", taskPrompt: "P2" },
+        ],
+      },
+    );
+    expect(out.activeWorkers.length).toBe(2);
+    expect(out.activeWorkers.map((w) => w.roleKey)).toEqual(["math", "english"]);
+    expect(out.activeWorkers.every((w) => w.status === "running")).toBe(true);
+  });
+
+  it("transitions a running worker to completed on worker-result trigger", () => {
+    let s = newModeratorState("tg:chat:-100", "group");
+    s = applyDecisionToState(
+      s,
+      { kind: "message", message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "Q" } },
+      { action: "answer-direct", rationale: "", answerTasks: [{ taskId: "t1", roleKey: "math", taskPrompt: "P" }] },
+    );
+    expect(s.activeWorkers[0].status).toBe("running");
+
+    s = applyDecisionToState(
+      s,
+      { kind: "worker-result", taskId: "t1", result: "7/12", success: true },
+      { action: "ignore", rationale: "result arrived" },
+    );
+    expect(s.activeWorkers[0].status).toBe("completed");
+    expect(s.activeWorkers[0].result).toBe("7/12");
+  });
+
+  it("appends noteAppend to notes (cap 20)", () => {
+    let s = newModeratorState("tg:chat:-100", "group");
+    for (let i = 0; i < 25; i += 1) {
+      s = applyDecisionToState(
+        s,
+        { kind: "cron", reason: "self-review" },
+        { action: "ignore", rationale: "", noteAppend: `note-${i}` },
+      );
+    }
+    expect(s.notes.length).toBe(20);
+    expect(s.notes[0]).toBe("note-5");
+  });
+});
+
+describe("buildDecisionPrompt", () => {
+  it("serializes scope + recent messages + active workers", () => {
+    let s = newModeratorState("tg:chat:-100", "group", "-100");
+    s.activeTopic = "math.fractions";
+    s.recentMessages = [
+      { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", fromLabel: "Yao", text: "hi" },
+      { ts: "2026-05-16T20:01:00Z", fromUserId: "u2", text: "怎么算 1/3" },
+    ];
+    s.activeWorkers = [
+      { taskId: "t1", roleKey: "math", task: "...", startedAt: "now", status: "running" },
+    ];
+    const out = buildDecisionPrompt({
+      state: s,
+      trigger: {
+        kind: "message",
+        message: { ts: "2026-05-16T20:02:00Z", fromUserId: "u2", text: "@bot help me", isAddressed: true },
+      },
+      knownRoles: ["math_tutor_grade5", "english_tutor"],
+    });
+    expect(out.system).toContain("MODERATOR");
+    expect(out.user).toContain("scopeKind: group");
+    expect(out.user).toContain("activeTopic: math.fractions");
+    expect(out.user).toContain("activeWorkers");
+    expect(out.user).toContain("@bot help me");
+    expect(out.user).toContain("@bot-mention");
+    expect(out.user).toContain("math_tutor_grade5, english_tutor");
+  });
+});
+
+describe("runOneCycle (mock LLM)", () => {
+  function mockLlm(responseText: string): ModeratorLlm {
+    return {
+      call: vi.fn(async () => ({
+        text: responseText,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "openai/gpt-5.5",
+        latencyMs: 2500,
+      })),
+    };
+  }
+
+  it("happy path: LLM returns valid JSON, state mutates correctly", async () => {
+    const state = newModeratorState("tg:chat:-100", "group", "-100");
+    const llm = mockLlm(JSON.stringify({
+      action: "answer-direct",
+      rationale: "math q",
+      answerTasks: [{ taskId: "t1", roleKey: "math_tutor_grade5", taskPrompt: "explain 1/3 + 1/4" }],
+      telegramActions: [{ kind: "placeholder", taskId: "t1", text: "⏳..." }],
+    }));
+
+    const out = await runOneCycle(state, {
+      kind: "message",
+      message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "1/3 + 1/4 是多少", isAddressed: true },
+    }, llm);
+
+    expect(out.decision.action).toBe("answer-direct");
+    expect(out.decision.answerTasks?.length).toBe(1);
+    expect(out.parseErrors.length).toBe(0);
+    expect(out.state.recentMessages.length).toBe(1);
+    expect(out.state.activeWorkers.length).toBe(1);
+    expect(out.llm.model).toBe("openai/gpt-5.5");
+  });
+
+  it("tolerates ```json``` code fences around the JSON", async () => {
+    const state = newModeratorState("tg:chat:-100", "group");
+    const llm = mockLlm("```json\n" + JSON.stringify({ action: "ignore", rationale: "chatter" }) + "\n```");
+    const out = await runOneCycle(state, {
+      kind: "message",
+      message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "lol" },
+    }, llm);
+    expect(out.decision.action).toBe("ignore");
+    expect(out.parseErrors.length).toBe(0);
+  });
+
+  it("falls back to ignore on unparseable JSON; parseErrors captured", async () => {
+    const state = newModeratorState("tg:chat:-100", "group");
+    const llm = mockLlm("not json at all");
+    const out = await runOneCycle(state, {
+      kind: "message",
+      message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "Q" },
+    }, llm);
+    expect(out.decision.action).toBe("ignore");
+    expect(out.parseErrors.length).toBeGreaterThan(0);
+    // Even when LLM output is garbage, the message still lands in state.
+    expect(out.state.recentMessages.length).toBe(1);
+  });
+
+  it("falls back to ignore on JSON with unknown action enum", async () => {
+    const state = newModeratorState("tg:chat:-100", "group");
+    const llm = mockLlm(JSON.stringify({ action: "make-coffee", rationale: "🤖" }));
+    const out = await runOneCycle(state, {
+      kind: "message",
+      message: { ts: "2026-05-16T20:00:00Z", fromUserId: "u1", text: "Q" },
+    }, llm);
+    expect(out.decision.action).toBe("ignore");
+    expect(out.parseErrors.some((e) => e.includes("unknown action"))).toBe(true);
+  });
+});

--- a/src/moderator/runner.ts
+++ b/src/moderator/runner.ts
@@ -1,0 +1,194 @@
+/**
+ * Moderator runner — pure function that takes (state, trigger, llm) and
+ * returns (updatedState, decision). The actual SIDE EFFECTS (sending
+ * Telegram messages, spawning workers, writing to nextclaw memory) are
+ * the caller's responsibility — keeping them out of this function makes
+ * the runner unit-testable without any of those moving parts.
+ *
+ * The wiring layer (Phase C+) wraps this with:
+ *   1. loadModeratorState(pool, agentId, scopeKey)
+ *   2. runOneCycle(state, trigger, llmClient)
+ *   3. saveModeratorState(pool, ..., updatedState)
+ *   4. logDecision(pool, ..., decision)
+ *   5. execute side effects implied by decision.telegramActions /
+ *      answerTasks / memoryWrites / escalation
+ *   6. when worker completes, feed result back via a new runOneCycle
+ *      call with trigger.kind = "worker-result"
+ */
+
+import { buildDecisionPrompt, type DecisionPromptInput } from "./decisions.js";
+import { parseDecision, type ModeratorDecision, type ModeratorState, type RecentMessage } from "./types.js";
+
+export interface ModeratorLlm {
+  /** Single non-streaming call returning the raw text response.
+   *  Implementations: codex via openclaw runtime, OpenAI direct, etc. */
+  call(args: { systemPrompt: string; userPrompt: string; maxTokens?: number; temperature?: number }): Promise<{
+    text: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    model?: string;
+    latencyMs?: number;
+  }>;
+}
+
+export type CycleOutput = {
+  decision: ModeratorDecision;
+  /** Errors from the LLM-output parser (if any). The decision is always
+   *  valid (parseDecision falls back to `ignore` on failure) but errors
+   *  are propagated for audit. */
+  parseErrors: string[];
+  /** Updated state to persist. */
+  state: ModeratorState;
+  /** Raw LLM bookkeeping for the decision log. */
+  llm: {
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    latencyMs?: number;
+    rawText: string;
+  };
+};
+
+const RECENT_MESSAGES_CAP = 50;
+const ACTIVE_WORKERS_CAP = 10;
+const NOTES_CAP = 20;
+
+export async function runOneCycle(
+  state: ModeratorState,
+  trigger: DecisionPromptInput["trigger"],
+  llm: ModeratorLlm,
+  knownRoles: string[] = [],
+): Promise<CycleOutput> {
+  const { system, user } = buildDecisionPrompt({ state, trigger, knownRoles });
+
+  const llmResponse = await llm.call({
+    systemPrompt: system,
+    userPrompt: user,
+    maxTokens: 1200,
+    temperature: 0.3,
+  });
+
+  const rawText = llmResponse.text.trim();
+  // The LLM should reply with one JSON object. Tolerate `\`\`\`json` fences.
+  const cleaned = rawText
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+
+  let parsed: { decision: ModeratorDecision; errors: string[] };
+  try {
+    const obj = JSON.parse(cleaned);
+    parsed = parseDecision(obj);
+  } catch (err) {
+    parsed = {
+      decision: {
+        action: "ignore",
+        rationale: `parse-failed: ${(err as Error).message.slice(0, 200)}`,
+      },
+      errors: [`json-parse: ${(err as Error).message}`],
+    };
+  }
+
+  const updated = applyDecisionToState(state, trigger, parsed.decision);
+
+  return {
+    decision: parsed.decision,
+    parseErrors: parsed.errors,
+    state: updated,
+    llm: {
+      model: llmResponse.model,
+      inputTokens: llmResponse.inputTokens,
+      outputTokens: llmResponse.outputTokens,
+      latencyMs: llmResponse.latencyMs,
+      rawText,
+    },
+  };
+}
+
+/**
+ * Pure state transition: apply the trigger + decision and return a new
+ * state. Does NOT do side effects (no DB writes, no Telegram).
+ *
+ * What it updates:
+ *   - recentMessages: append the new trigger message (when trigger is
+ *     a message)
+ *   - activeWorkers: append new entries for decision.answerTasks; mark
+ *     completed/failed when trigger is a worker-result
+ *   - notes: append decision.noteAppend
+ *   - messagesSinceLastReview: increment on message trigger
+ *   - activeStudents: bump lastSeenAt for the trigger sender
+ */
+export function applyDecisionToState(
+  state: ModeratorState,
+  trigger: DecisionPromptInput["trigger"],
+  decision: ModeratorDecision,
+): ModeratorState {
+  const recentMessages = [...state.recentMessages];
+  const activeWorkers = [...state.activeWorkers];
+  const notes = [...state.notes];
+  const activeStudents = [...state.activeStudents];
+  let messagesSinceLastReview = state.messagesSinceLastReview;
+
+  if (trigger.kind === "message") {
+    const m = trigger.message;
+    recentMessages.push(m);
+    while (recentMessages.length > RECENT_MESSAGES_CAP) {recentMessages.shift();}
+    messagesSinceLastReview += 1;
+
+    // Bump activeStudents
+    const idx = activeStudents.findIndex((s) => s.userId === m.fromUserId);
+    if (idx >= 0) {
+      activeStudents[idx] = { ...activeStudents[idx], lastSeenAt: m.ts };
+    } else {
+      activeStudents.push({
+        userId: m.fromUserId,
+        label: m.fromLabel,
+        lastSeenAt: m.ts,
+      });
+    }
+  }
+
+  // Spawn workers declared in this decision.
+  if (decision.answerTasks && decision.answerTasks.length > 0) {
+    const now = new Date().toISOString();
+    for (const t of decision.answerTasks) {
+      const exists = activeWorkers.some((w) => w.taskId === t.taskId);
+      if (exists) {continue;}
+      activeWorkers.push({
+        taskId: t.taskId,
+        roleKey: t.roleKey,
+        task: t.taskPrompt,
+        startedAt: now,
+        status: "running",
+      });
+    }
+    while (activeWorkers.length > ACTIVE_WORKERS_CAP) {activeWorkers.shift();}
+  }
+
+  // Worker result trigger updates the corresponding active worker.
+  if (trigger.kind === "worker-result") {
+    const idx = activeWorkers.findIndex((w) => w.taskId === trigger.taskId);
+    if (idx >= 0) {
+      activeWorkers[idx] = {
+        ...activeWorkers[idx],
+        status: trigger.success ? "completed" : "failed",
+        result: trigger.success ? trigger.result : undefined,
+        error: trigger.success ? undefined : trigger.result,
+      };
+    }
+  }
+
+  if (decision.noteAppend) {
+    notes.push(decision.noteAppend);
+    while (notes.length > NOTES_CAP) {notes.shift();}
+  }
+
+  return {
+    ...state,
+    recentMessages,
+    activeWorkers,
+    activeStudents,
+    notes,
+    messagesSinceLastReview,
+  };
+}

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -290,7 +290,13 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
 /* ----------------------------- small helpers ------------------------------ */
 
 function stripChannelPrefix(value: string): string {
-  return value.replace(/^(?:channel:|chat:|user:|tg-?)/, "");
+  // openclaw conversation/sender ids arrive prefixed in a few ways depending
+  // on the channel: `channel:<id>`, `chat:<id>`, `user:<id>`, `tg-<id>`,
+  // or the channel name itself like `telegram:<id>` / `slack:<id>` etc.
+  // Strip whichever prefix we find. Telegram group ids are negative so
+  // after stripping we want a clean `-100...` so the downstream chat-type
+  // inferrer works.
+  return value.replace(/^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/, "");
 }
 
 function inferChatTypeFromId(rawChatId: string): "private" | "group" | "supergroup" {

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -32,6 +32,7 @@ import { runOneCycle, type ModeratorLlm } from "./runner.js";
 import { executeDecision } from "./side-effects.js";
 import { TelegramBotApi } from "./telegram-api.js";
 import type { RecentMessage } from "./types.js";
+import { runWorkersForDecision, writeAnswerToCache } from "./workers.js";
 
 export type ModeratorServiceConfig = {
   enabled: boolean;
@@ -240,14 +241,75 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
         logger: config.logger,
       });
 
-      // 5. Splice placeholder message_ids back into activeWorkers (so
-      //    edit_placeholder works when workers complete in Phase D).
+      // 5. Splice placeholder message_ids back into activeWorkers.
       const updatedState = { ...out.state };
       if (fx.placeholders.length > 0) {
         updatedState.activeWorkers = updatedState.activeWorkers.map((w) => {
           const ph = fx.placeholders.find((p) => p.taskId === w.taskId);
           return ph ? { ...w, placeholderMessageId: ph.messageId } : w;
         });
+      }
+
+      // 5.5. Phase D — dispatch workers, edit placeholders with answers,
+      //      write answers back to cache.qa.
+      const tasks = out.decision.answerTasks ?? [];
+      if (tasks.length > 0) {
+        const wkDeps = {
+          pool: config.pool,
+          llm: config.llm,
+          embedding: config.embedding,
+          cfg: config.cfg,
+          agentId: "main",
+          logger: config.logger,
+        };
+        const viewer = { userId: senderUserId, chatId };
+        const results = await runWorkersForDecision(wkDeps, tasks, viewer, trigger.text);
+        for (const r of results) {
+          // Find the placeholder message_id for this task: first try
+          // fx.placeholders (this cycle), fall back to activeWorkers
+          // (in case Phase E adds across-cycle workers).
+          const phMessageId =
+            fx.placeholders.find((p) => p.taskId === r.taskId)?.messageId ??
+            updatedState.activeWorkers.find((w) => w.taskId === r.taskId)?.placeholderMessageId ??
+            null;
+          if (phMessageId) {
+            const editRes = await tg.editMessageText({
+              chatId,
+              messageId: phMessageId,
+              text: r.answer.slice(0, 4000), // Telegram cap
+            });
+            if (!editRes.ok) {
+              config.logger.warn(`moderator: edit_placeholder task=${r.taskId} failed: ${editRes.error}`);
+            }
+          } else if (r.ok) {
+            // No placeholder existed — send the answer as a fresh message.
+            await tg.sendMessage({ chatId, text: r.answer.slice(0, 4000), messageThreadId });
+          }
+          // Mark the worker done in state.
+          updatedState.activeWorkers = updatedState.activeWorkers.map((w) =>
+            w.taskId === r.taskId
+              ? { ...w, status: r.ok ? "completed" : "failed", result: r.answer.slice(0, 200) }
+              : w,
+          );
+          // Cache write-back (fire-and-forget — never block the reply).
+          if (r.ok) {
+            const task = tasks.find((t) => t.taskId === r.taskId);
+            if (task) {
+              void writeAnswerToCache(wkDeps, r, task).then((id) => {
+                if (id) {
+                  config.logger.info(
+                    `moderator: scope=${scopeKey} cached answer id=${id} task=${r.taskId} topic=${r.topicTag ?? "-"}`,
+                  );
+                }
+              });
+            }
+          }
+          config.logger.info(
+            `moderator: worker task=${r.taskId} role=${r.roleKey} ok=${r.ok} ` +
+              `tokens=${r.llm.inputTokens ?? "?"}→${r.llm.outputTokens ?? "?"} ` +
+              `latency=${r.llm.latencyMs ?? "?"}ms recall=${r.recallCount}`,
+          );
+        }
       }
 
       // 6. Save state. If escalation asked to pause the scope, flip status.

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -25,6 +25,8 @@
 
 import type { Pool } from "pg";
 import type { ResolvedMemoryPostgresConfig } from "../config.js";
+import type { EmbeddingClient } from "../embedding/client.js";
+import { tryCachePrecheck } from "./cache-precheck.js";
 import { logDecision, loadModeratorState, saveModeratorState } from "./state.js";
 import { runOneCycle, type ModeratorLlm } from "./runner.js";
 import { executeDecision } from "./side-effects.js";
@@ -35,6 +37,9 @@ export type ModeratorServiceConfig = {
   enabled: boolean;
   /** LLM client (typically built via `buildModeratorLlm`). */
   llm: ModeratorLlm;
+  /** Embedding client — needed for cache.qa L2 semantic lookup before
+   *  the Moderator decision. Skips Gemini entirely on cache hits. */
+  embedding: EmbeddingClient;
   /** Telegram bot token, from openclaw `channels.telegram.botToken`. */
   telegramBotToken: string;
   /** Bot owner user id (for escalation), from `commands.ownerAllowFrom[0]`. */
@@ -154,6 +159,61 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
       const status = await readScopeStatus(config.pool, scopeKey);
       if (status === "paused" || status === "archived") {
         config.logger.info(`moderator: scope ${scopeKey} is ${status}, skipping`);
+        return;
+      }
+
+      // 2.5. Cache pre-check (L0 in-process / L1 PG exact / L2 PG semantic).
+      //      On hit: send the cached answer directly and SKIP the LLM call.
+      //      The bulk of repeat-question savings lives here (~50ms vs 6s,
+      //      0 vs 1500 Gemini tokens).
+      const precheck = await tryCachePrecheck(
+        { pool: config.pool, embedding: config.embedding, agentId: "main" },
+        {
+          scopeKey,
+          questionText: trigger.text,
+          viewer: { userId: senderUserId, chatId },
+        },
+      );
+      if (precheck.hit) {
+        config.logger.info(
+          `moderator: scope=${scopeKey} CACHE HIT (${precheck.hitKind} sim=${precheck.similarity.toFixed(2)}) ` +
+            `latency=${precheck.latencyMs}ms — skipping LLM`,
+        );
+        // Send the cached answer.
+        const sendRes = await tg.sendMessage({
+          chatId,
+          text: precheck.answer,
+          messageThreadId,
+        });
+        if (!sendRes.ok) {
+          config.logger.warn(`moderator: cache-hit send failed: ${sendRes.error}`);
+        }
+        // Persist the inbound + a synthetic "cache-hit" decision row for audit.
+        await saveModeratorState(config.pool, "main", scopeKey, {
+          ...state,
+          recentMessages: [...state.recentMessages, trigger].slice(-50),
+          messagesSinceLastReview: state.messagesSinceLastReview + 1,
+        }, {
+          bumpMessageCount: 1,
+          bumpDecisionCount: 0, // cache-hit isn't a "decision" — no LLM ran
+          lastMessageAt: new Date(),
+        });
+        await logDecision(config.pool, {
+          agentId: "main",
+          scopeKey,
+          triggerKind: "message",
+          triggerUserId: senderUserId,
+          triggerText: trigger.text,
+          decision: {
+            action: "answer-direct",
+            rationale: `cache hit (${precheck.hitKind}, sim=${precheck.similarity.toFixed(2)}, id=${precheck.cacheId})`,
+          },
+          model: `cache:${precheck.hitKind}`,
+          inputTokens: 0,
+          outputTokens: 0,
+          latencyMs: precheck.latencyMs,
+          workersSpawned: 0,
+        });
         return;
       }
 

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -250,7 +250,10 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
       const messageThreadId = toIntOrUndef(event.metadata?.threadId ?? event.threadId);
       const messageId = toIntOrUndef(event.messageId);
       const message: RecentMessage = {
-        ts: event.timestamp ?? new Date().toISOString(),
+        // event.timestamp may arrive as ISO string, Date, or unix number
+        // depending on the channel. Normalise to ISO string so all later
+        // formatting (which calls `ts.slice`) is type-safe.
+        ts: coerceIsoString(event.timestamp),
         fromUserId: senderUserId,
         fromLabel: event.metadata?.senderName ?? event.metadata?.senderUsername,
         text,
@@ -310,6 +313,17 @@ function inferChatTypeFromId(rawChatId: string): "private" | "group" | "supergro
 function looksAddressed(text: string, isGroup: boolean): boolean {
   if (!isGroup) {return true;} // DMs are always addressed
   return /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(text);
+}
+
+function coerceIsoString(v: unknown): string {
+  if (typeof v === "string" && v.length > 0) {return v;}
+  if (v instanceof Date) {return v.toISOString();}
+  if (typeof v === "number" && Number.isFinite(v)) {
+    // Telegram delivers unix seconds; multiply if it looks like seconds.
+    const ms = v < 10_000_000_000 ? v * 1000 : v;
+    return new Date(ms).toISOString();
+  }
+  return new Date().toISOString();
 }
 
 function toIntOrUndef(v: string | number | undefined | null): number | undefined {

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -1,0 +1,324 @@
+/**
+ * Moderator service — hooks openclaw's `message_received` event for
+ * Telegram messages, runs ONE Moderator decision cycle (gpt-5.5 by
+ * default), and dispatches the resulting side effects.
+ *
+ * Concurrency model (matches Anthropic's orchestrator-worker pattern):
+ *   1. message_received fires inside openclaw's per-chat sequentialize
+ *      lock. We fire-and-forget so the lock releases immediately,
+ *      letting different students in the same group fan out across
+ *      Moderator workers in parallel (this is the workaround for
+ *      openclaw's single-chat lock that we deferred from Phase A).
+ *   2. Per (scope_key) we hold an in-memory mutex that serializes
+ *      cycle execution for that scope — so a single student's burst
+ *      of messages flows through the decision loop in order, but
+ *      different scopes run concurrently.
+ *   3. Telegram side effects (placeholder, edit, action) happen
+ *      synchronously inside the cycle; memory writes are non-blocking;
+ *      worker dispatch (Phase D) is fully async.
+ *
+ * Per-user debounce 1.5s window: when a student sends multiple lines
+ * within 1.5s, we wait for the buffer to settle, then concatenate them
+ * into ONE trigger message before calling runOneCycle. Saves LLM
+ * round-trips on burst inputs.
+ */
+
+import type { Pool } from "pg";
+import type { ResolvedMemoryPostgresConfig } from "../config.js";
+import { logDecision, loadModeratorState, saveModeratorState } from "./state.js";
+import { runOneCycle, type ModeratorLlm } from "./runner.js";
+import { executeDecision } from "./side-effects.js";
+import { TelegramBotApi } from "./telegram-api.js";
+import type { RecentMessage } from "./types.js";
+
+export type ModeratorServiceConfig = {
+  enabled: boolean;
+  /** LLM client (typically built via `buildModeratorLlm`). */
+  llm: ModeratorLlm;
+  /** Telegram bot token, from openclaw `channels.telegram.botToken`. */
+  telegramBotToken: string;
+  /** Bot owner user id (for escalation), from `commands.ownerAllowFrom[0]`. */
+  ownerUserId?: string;
+  /** Dashboard /api/ingest URL + token, for memoryWrites. */
+  ingestUrl: string;
+  ingestToken: string;
+  /** Resolved nextclaw config (mostly for agentId, pool). */
+  cfg: ResolvedMemoryPostgresConfig;
+  pool: Pool;
+  /** Logger; the api.logger from openclaw works. */
+  logger: { info: (m: string) => void; warn: (m: string) => void };
+  /** Per-user debounce window in ms. Default 1500. */
+  debounceMs?: number;
+};
+
+export type ModeratorServiceHandle = {
+  /** Forward a `message_received` event from openclaw's plugin SDK
+   *  into the Moderator pipeline. Returns immediately; the cycle runs
+   *  asynchronously. */
+  onMessageReceived(event: PluginMessageEvent, ctx: PluginMessageContext): void;
+  /** Stop the service (cancel pending debounces; close timers). */
+  stop(): void;
+};
+
+/** Event shape matches openclaw's plugin SDK (see thread-ownership for
+ *  the same surface). We don't import the openclaw types directly so
+ *  this module can be unit-tested without the SDK on the path. */
+export type PluginMessageEvent = {
+  from?: string;
+  content?: string;
+  timestamp?: string;
+  threadId?: string | number;
+  messageId?: string | number;
+  senderId?: string;
+  metadata?: {
+    senderName?: string;
+    senderUsername?: string;
+    threadId?: string | number;
+    chatType?: "private" | "group" | "supergroup" | "channel";
+  };
+};
+export type PluginMessageContext = {
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  sessionKey?: string;
+  senderId?: string;
+};
+
+export function startModeratorService(config: ModeratorServiceConfig): ModeratorServiceHandle {
+  const tg = new TelegramBotApi({ botToken: config.telegramBotToken });
+  const debounceMs = config.debounceMs ?? 1500;
+
+  // Per-scope serial queue: one in-flight cycle per scopeKey at a time.
+  const scopeMutex = new Map<string, Promise<void>>();
+  // Per (scope, user) debounce buffers.
+  const buffers = new Map<string, { messages: RecentMessage[]; timer: NodeJS.Timeout; chatId: string; messageThreadId?: number }>();
+
+  function bufferKey(scopeKey: string, userId: string): string {
+    return `${scopeKey}::${userId}`;
+  }
+
+  function processBufferFor(key: string): void {
+    const buf = buffers.get(key);
+    if (!buf) {return;}
+    buffers.delete(key);
+    const messages = buf.messages;
+    if (messages.length === 0) {return;}
+    // Concat into ONE trigger. Preserve the most recent timestamp + id.
+    const flat = messages.map((m) => m.text).join("\n");
+    const last = messages[messages.length - 1];
+    const trigger: RecentMessage = {
+      ...last,
+      text: flat,
+    };
+    const [scopeKey, userId] = key.split("::");
+    void runScopeCycle(scopeKey, userId, trigger, buf.chatId, buf.messageThreadId);
+  }
+
+  function enqueueScopeCycle(
+    scopeKey: string,
+    userId: string,
+    trigger: RecentMessage,
+    chatId: string,
+    messageThreadId: number | undefined,
+  ): void {
+    const prev = scopeMutex.get(scopeKey) ?? Promise.resolve();
+    const next = prev.then(() => runScopeCycleInner(scopeKey, userId, trigger, chatId, messageThreadId));
+    scopeMutex.set(scopeKey, next.finally(() => {
+      if (scopeMutex.get(scopeKey) === next) {scopeMutex.delete(scopeKey);}
+    }));
+  }
+
+  async function runScopeCycle(
+    scopeKey: string,
+    userId: string,
+    trigger: RecentMessage,
+    chatId: string,
+    messageThreadId: number | undefined,
+  ): Promise<void> {
+    enqueueScopeCycle(scopeKey, userId, trigger, chatId, messageThreadId);
+  }
+
+  async function runScopeCycleInner(
+    scopeKey: string,
+    senderUserId: string,
+    trigger: RecentMessage,
+    chatId: string,
+    messageThreadId: number | undefined,
+  ): Promise<void> {
+    try {
+      // 1. Load state (or init).
+      const state = await loadModeratorState(config.pool, config.cfg ? "main" : "main", scopeKey);
+
+      // 2. Skip if scope is paused (operator did /takeover).
+      const status = await readScopeStatus(config.pool, scopeKey);
+      if (status === "paused" || status === "archived") {
+        config.logger.info(`moderator: scope ${scopeKey} is ${status}, skipping`);
+        return;
+      }
+
+      // 3. Run one cycle.
+      const out = await runOneCycle(state, { kind: "message", message: trigger }, config.llm);
+
+      config.logger.info(
+        `moderator: scope=${scopeKey} action=${out.decision.action} ` +
+          `tokens=${out.llm.inputTokens ?? "?"}→${out.llm.outputTokens ?? "?"} ` +
+          `latency=${out.llm.latencyMs ?? "?"}ms`,
+      );
+
+      // 4. Execute side effects.
+      const fx = await executeDecision(out.decision, out.state, {
+        pool: config.pool,
+        telegram: tg,
+        chatId,
+        messageThreadId,
+        ownerUserId: config.ownerUserId,
+        ingestUrl: config.ingestUrl,
+        ingestToken: config.ingestToken,
+        triggerSenderUserId: senderUserId,
+        agentId: "main",
+        logger: config.logger,
+      });
+
+      // 5. Splice placeholder message_ids back into activeWorkers (so
+      //    edit_placeholder works when workers complete in Phase D).
+      const updatedState = { ...out.state };
+      if (fx.placeholders.length > 0) {
+        updatedState.activeWorkers = updatedState.activeWorkers.map((w) => {
+          const ph = fx.placeholders.find((p) => p.taskId === w.taskId);
+          return ph ? { ...w, placeholderMessageId: ph.messageId } : w;
+        });
+      }
+
+      // 6. Save state. If escalation asked to pause the scope, flip status.
+      await saveModeratorState(config.pool, "main", scopeKey, updatedState, {
+        bumpMessageCount: 1,
+        bumpDecisionCount: 1,
+        lastMessageAt: new Date(),
+        status: fx.shouldPauseScope ? "paused" : undefined,
+        pausedBy: fx.shouldPauseScope ? "auto-escalation" : undefined,
+        pausedReason: fx.shouldPauseScope ? out.decision.escalation?.reason : undefined,
+      });
+
+      // 7. Decision audit log.
+      await logDecision(config.pool, {
+        agentId: "main",
+        scopeKey,
+        triggerKind: "message",
+        triggerUserId: senderUserId,
+        triggerText: trigger.text,
+        decision: out.decision,
+        model: out.llm.model,
+        inputTokens: out.llm.inputTokens,
+        outputTokens: out.llm.outputTokens,
+        latencyMs: out.llm.latencyMs,
+        workersSpawned: out.decision.answerTasks?.length ?? 0,
+        errors: [...out.parseErrors, ...fx.errors],
+      });
+    } catch (err) {
+      config.logger.warn(`moderator: scope ${scopeKey} cycle failed: ${(err as Error).message}`);
+    }
+  }
+
+  return {
+    onMessageReceived(event, ctx) {
+      if (!config.enabled) {return;}
+      if (ctx.channelId !== "telegram") {return;}
+      const text = event.content?.trim();
+      if (!text) {return;}
+
+      // Resolve chat id + scope. Telegram conversation ids look like
+      // "tg-1001234567890" or raw numbers; normalise to plain string.
+      const rawChatId = stripChannelPrefix(ctx.conversationId ?? "");
+      if (!rawChatId) {return;}
+
+      // Resolve sender. Telegram per-user id might be senderId raw or
+      // prefixed with "user:". We strip prefixes; otherwise default
+      // to the "from" field.
+      const senderUserId = stripChannelPrefix(event.senderId ?? ctx.senderId ?? event.from ?? "");
+      if (!senderUserId) {return;}
+
+      const chatType = event.metadata?.chatType ?? inferChatTypeFromId(rawChatId);
+      const isGroup = chatType === "group" || chatType === "supergroup";
+      // SAFETY: only intercept group messages. DMs continue through the
+      // existing openclaw per-DM agent path; if the Moderator also fired
+      // on DMs we'd get duplicate replies. Group ownership of the
+      // conversation moves to the Moderator; DMs stay with the codex agent.
+      if (!isGroup) {return;}
+      const scopeKey = `tg:chat:${rawChatId}`;
+
+      const messageThreadId = toIntOrUndef(event.metadata?.threadId ?? event.threadId);
+      const messageId = toIntOrUndef(event.messageId);
+      const message: RecentMessage = {
+        ts: event.timestamp ?? new Date().toISOString(),
+        fromUserId: senderUserId,
+        fromLabel: event.metadata?.senderName ?? event.metadata?.senderUsername,
+        text,
+        messageId,
+        isAddressed: looksAddressed(text, isGroup),
+      };
+
+      // Debounce per (scope, user).
+      const key = bufferKey(scopeKey, senderUserId);
+      const existing = buffers.get(key);
+      if (existing) {
+        existing.messages.push(message);
+        clearTimeout(existing.timer);
+        existing.timer = setTimeout(() => processBufferFor(key), debounceMs);
+        existing.timer.unref?.();
+      } else {
+        const timer = setTimeout(() => processBufferFor(key), debounceMs);
+        timer.unref?.();
+        buffers.set(key, {
+          messages: [message],
+          timer,
+          chatId: rawChatId,
+          messageThreadId,
+        });
+      }
+    },
+    stop() {
+      for (const buf of buffers.values()) {
+        clearTimeout(buf.timer);
+      }
+      buffers.clear();
+      scopeMutex.clear();
+    },
+  };
+}
+
+/* ----------------------------- small helpers ------------------------------ */
+
+function stripChannelPrefix(value: string): string {
+  return value.replace(/^(?:channel:|chat:|user:|tg-?)/, "");
+}
+
+function inferChatTypeFromId(rawChatId: string): "private" | "group" | "supergroup" {
+  // Group ids are negative; supergroup ids start with -100. We can't
+  // reliably distinguish group from supergroup without metadata, so
+  // call all negative ids "supergroup" (the more common modern shape).
+  if (rawChatId.startsWith("-")) {return "supergroup";}
+  return "private";
+}
+
+function looksAddressed(text: string, isGroup: boolean): boolean {
+  if (!isGroup) {return true;} // DMs are always addressed
+  return /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(text);
+}
+
+function toIntOrUndef(v: string | number | undefined | null): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) {return v;}
+  if (typeof v === "string") {
+    const n = parseInt(v, 10);
+    if (Number.isFinite(n)) {return n;}
+  }
+  return undefined;
+}
+
+async function readScopeStatus(pool: Pool, scopeKey: string): Promise<string | null> {
+  const r = await pool.query<{ status: string }>(
+    `SELECT status FROM moderator.state WHERE agent_id = 'main' AND scope_key = $1`,
+    [scopeKey],
+  );
+  return r.rows[0]?.status ?? null;
+}

--- a/src/moderator/side-effects.ts
+++ b/src/moderator/side-effects.ts
@@ -1,0 +1,232 @@
+/**
+ * Side-effect executor for a Moderator decision.
+ *
+ * Takes a Decision + state + deps (Telegram client, pg pool, the
+ * dashboard ingest endpoint, owner DM target) and FIRES all the
+ * external work the decision implies:
+ *
+ *   • telegramActions[kind=placeholder]      → sendMessage, save msg_id
+ *                                               into activeWorkers[].placeholderMessageId
+ *   • telegramActions[kind=send_message]     → sendMessage
+ *   • telegramActions[kind=send_chat_action] → sendChatAction
+ *   • telegramActions[kind=edit_placeholder] → editMessageText
+ *                                               (fromTaskResult requires the
+ *                                                worker result to be present
+ *                                                in activeWorkers — caller
+ *                                                handles this AFTER worker
+ *                                                completes; here we just
+ *                                                handle the static-text variant)
+ *   • memoryWrites                           → POST /api/ingest with anchors
+ *                                               (per-scope: user / chat / global)
+ *   • escalation                             → DM the bot owner; optionally
+ *                                               set state.status = "paused"
+ *
+ * Worker dispatch (answerTasks) is INTENTIONALLY not handled here — that's
+ * Phase D. For now the placeholder appears, the worker is "logically
+ * registered" in state, but no codex run actually fires.
+ */
+
+import type { Pool } from "pg";
+import type { ModeratorDecision, ModeratorState, TelegramAction } from "./types.js";
+import type { TelegramBotApi } from "./telegram-api.js";
+
+export type SideEffectDeps = {
+  pool: Pool;
+  telegram: TelegramBotApi;
+  /** The user-facing chat id this scope corresponds to (numeric Telegram id). */
+  chatId: string;
+  /** Forum topic id, if any. */
+  messageThreadId?: number;
+  /** Bot owner's user id, for escalation routing. */
+  ownerUserId?: string;
+  /** Dashboard /api/ingest URL + token, for memoryWrites. */
+  ingestUrl: string;
+  ingestToken: string;
+  /** Sender of the trigger message (used to compute memoryWrite anchors). */
+  triggerSenderUserId?: string;
+  /** Forwarded for default scope when memoryWrite says "chat". */
+  agentId: string;
+  /** Logger for warnings. */
+  logger: { info: (m: string) => void; warn: (m: string) => void };
+};
+
+export type SideEffectOutcome = {
+  placeholders: { taskId: string; messageId: number }[];
+  messagesSent: number;
+  editsApplied: number;
+  chatActionsSent: number;
+  memoryWritesAccepted: number;
+  escalationSent: boolean;
+  shouldPauseScope: boolean;
+  errors: string[];
+};
+
+export async function executeDecision(
+  decision: ModeratorDecision,
+  state: ModeratorState,
+  deps: SideEffectDeps,
+): Promise<SideEffectOutcome> {
+  const out: SideEffectOutcome = {
+    placeholders: [],
+    messagesSent: 0,
+    editsApplied: 0,
+    chatActionsSent: 0,
+    memoryWritesAccepted: 0,
+    escalationSent: false,
+    shouldPauseScope: false,
+    errors: [],
+  };
+
+  // 1. Telegram actions, in declaration order.
+  for (const action of decision.telegramActions ?? []) {
+    try {
+      await applyTelegramAction(action, deps, out);
+    } catch (err) {
+      out.errors.push(`telegram-action: ${(err as Error).message}`);
+    }
+  }
+
+  // 2. Memory writes — each becomes one POST to /api/ingest with anchors.
+  for (const w of decision.memoryWrites ?? []) {
+    try {
+      const anchors: Record<string, string> = {};
+      if (w.scope === "user") {
+        if (deps.triggerSenderUserId) {anchors.sender_id = `tg-${deps.triggerSenderUserId}`;}
+        anchors.visibility = w.visibility ?? "private";
+      } else if (w.scope === "chat") {
+        anchors.chat_id = `tg-${deps.chatId.replace(/^-/, "")}`;
+        anchors.visibility = w.visibility ?? "public";
+      }
+      // "global" scope → no scope anchors
+      if (w.topic) {anchors.scope = w.topic;}
+
+      const r = await fetch(deps.ingestUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-token": deps.ingestToken },
+        body: JSON.stringify({
+          text: w.text,
+          source: "moderator",
+          kind: "fact",
+          agentId: deps.agentId,
+          importance: typeof w.importance === "number" ? w.importance : 0.5,
+          retentionClass: "standard",
+          anchors,
+        }),
+      });
+      if (r.ok) {
+        out.memoryWritesAccepted += 1;
+      } else {
+        out.errors.push(`memory-write: HTTP ${r.status}`);
+      }
+    } catch (err) {
+      out.errors.push(`memory-write: ${(err as Error).message}`);
+    }
+  }
+
+  // 3. Escalation — DM the bot owner; optionally request scope pause.
+  if (decision.escalation) {
+    const e = decision.escalation;
+    if (deps.ownerUserId) {
+      const body = [
+        `🚨 ESCALATION from ${state.scopeKey}`,
+        `Reason: ${e.reason}`,
+        `Summary: ${e.summary}`,
+        e.pauseScope ? "(scope auto-paused — /release to resume)" : "(scope NOT paused; bot continues)",
+      ].join("\n");
+      try {
+        const r = await deps.telegram.sendMessage({
+          chatId: deps.ownerUserId,
+          text: body,
+        });
+        if (r.ok) {
+          out.escalationSent = true;
+        } else {
+          out.errors.push(`escalation send: ${r.error}`);
+        }
+      } catch (err) {
+        out.errors.push(`escalation send: ${(err as Error).message}`);
+      }
+    } else {
+      out.errors.push("escalation requested but ownerUserId not configured");
+    }
+    if (e.pauseScope) {
+      out.shouldPauseScope = true;
+    }
+  }
+
+  return out;
+}
+
+async function applyTelegramAction(
+  action: TelegramAction,
+  deps: SideEffectDeps,
+  out: SideEffectOutcome,
+): Promise<void> {
+  if (action.kind === "placeholder") {
+    const r = await deps.telegram.sendMessage({
+      chatId: deps.chatId,
+      text: action.text,
+      messageThreadId: deps.messageThreadId,
+    });
+    if (r.ok) {
+      out.messagesSent += 1;
+      if (action.taskId) {
+        out.placeholders.push({ taskId: action.taskId, messageId: r.result.messageId });
+      }
+    } else {
+      out.errors.push(`placeholder: ${r.error}`);
+    }
+    return;
+  }
+  if (action.kind === "send_message") {
+    const r = await deps.telegram.sendMessage({
+      chatId: deps.chatId,
+      text: action.text,
+      replyToMessageId: action.replyToMessageId,
+      messageThreadId: deps.messageThreadId,
+    });
+    if (r.ok) {out.messagesSent += 1;}
+    else {out.errors.push(`send_message: ${r.error}`);}
+    return;
+  }
+  if (action.kind === "send_chat_action") {
+    const r = await deps.telegram.sendChatAction({
+      chatId: deps.chatId,
+      action: action.action,
+      messageThreadId: deps.messageThreadId,
+    });
+    if (r.ok) {out.chatActionsSent += 1;}
+    else {out.errors.push(`send_chat_action: ${r.error}`);}
+    return;
+  }
+  if (action.kind === "edit_placeholder") {
+    // Static-text edits we can apply now. fromTaskResult is the caller's
+    // responsibility (worker result must be in activeWorkers first).
+    if ("text" in action && typeof action.text === "string") {
+      const placeholder = out.placeholders.find((p) => p.taskId === action.taskId)
+        ?? findActiveWorkerPlaceholder(deps, action.taskId);
+      if (!placeholder) {
+        out.errors.push(`edit_placeholder: no placeholder for task ${action.taskId}`);
+        return;
+      }
+      const r = await deps.telegram.editMessageText({
+        chatId: deps.chatId,
+        messageId: placeholder.messageId,
+        text: action.text,
+      });
+      if (r.ok) {out.editsApplied += 1;}
+      else {out.errors.push(`edit_placeholder: ${r.error}`);}
+    }
+    // fromTaskResult variant: deferred to the worker-completion path.
+  }
+}
+
+function findActiveWorkerPlaceholder(
+  _deps: SideEffectDeps,
+  _taskId: string,
+): { taskId: string; messageId: number } | null {
+  // Caller passes the up-to-date state through; this is a placeholder
+  // for the worker-completion path in Phase D. For now, only same-cycle
+  // placeholders are editable via the static path.
+  return null;
+}

--- a/src/moderator/state.ts
+++ b/src/moderator/state.ts
@@ -1,0 +1,169 @@
+/**
+ * Moderator state persistence — load + save + append-only decision log.
+ *
+ * One JSONB row per (agent_id, scope_key) in `moderator.state`. Cheap
+ * single-row upsert on every cycle; the structured stuff lives in the
+ * `recentMessages` / `activeWorkers` arrays inside the JSONB and gets
+ * trimmed by the runner so the row stays bounded (cap ~50 messages /
+ * ~10 active workers).
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Pool } from "pg";
+import { newModeratorState, type ModeratorDecision, type ModeratorState, type ScopeKey } from "./types.js";
+
+export async function loadModeratorState(
+  pool: Pool,
+  agentId: string,
+  scopeKey: ScopeKey,
+): Promise<ModeratorState> {
+  const r = await pool.query<{ state: ModeratorState; status: string }>(
+    `SELECT state, status FROM moderator.state WHERE agent_id = $1 AND scope_key = $2`,
+    [agentId, scopeKey],
+  );
+  if (r.rowCount === 0) {
+    return newModeratorState(scopeKey, scopeKey.startsWith("tg:chat:") ? "group" : "dm");
+  }
+  return migrateState(r.rows[0].state);
+}
+
+export type SaveOptions = {
+  status?: "live" | "paused" | "archived";
+  pausedBy?: string;
+  pausedReason?: string;
+  bumpMessageCount?: number;
+  bumpDecisionCount?: number;
+  lastMessageAt?: Date;
+  lastReviewAt?: Date;
+};
+
+export async function saveModeratorState(
+  pool: Pool,
+  agentId: string,
+  scopeKey: ScopeKey,
+  state: ModeratorState,
+  opts: SaveOptions = {},
+): Promise<void> {
+  // Trim arrays to bounded caps before persisting (defense in depth).
+  const trimmed: ModeratorState = {
+    ...state,
+    recentMessages: state.recentMessages.slice(-50),
+    activeWorkers: state.activeWorkers.slice(-10),
+    debounceBuffer: state.debounceBuffer.slice(-5),
+    notes: state.notes.slice(-20),
+  };
+
+  await pool.query(
+    `INSERT INTO moderator.state (
+       agent_id, scope_key, state, status,
+       message_count, decision_count,
+       last_message_at, last_review_at,
+       paused_by, paused_reason,
+       updated_at
+     )
+     VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10, now())
+     ON CONFLICT (agent_id, scope_key) DO UPDATE
+       SET state           = EXCLUDED.state,
+           status          = COALESCE($4, moderator.state.status),
+           message_count   = moderator.state.message_count  + $5,
+           decision_count  = moderator.state.decision_count + $6,
+           last_message_at = COALESCE($7, moderator.state.last_message_at),
+           last_review_at  = COALESCE($8, moderator.state.last_review_at),
+           paused_by       = COALESCE($9, moderator.state.paused_by),
+           paused_reason   = COALESCE($10, moderator.state.paused_reason),
+           updated_at      = now()`,
+    [
+      agentId,
+      scopeKey,
+      JSON.stringify(trimmed),
+      opts.status ?? null,
+      opts.bumpMessageCount ?? 0,
+      opts.bumpDecisionCount ?? 0,
+      opts.lastMessageAt ?? null,
+      opts.lastReviewAt ?? null,
+      opts.pausedBy ?? null,
+      opts.pausedReason ?? null,
+    ],
+  );
+}
+
+/**
+ * Append-only log entry for one LLM decision call. Used by the dashboard
+ * "what's the bot thinking" view and by the tuning loop later.
+ */
+export async function logDecision(
+  pool: Pool,
+  params: {
+    agentId: string;
+    scopeKey: ScopeKey;
+    triggerKind: "message" | "cron" | "worker-result";
+    triggerUserId?: string;
+    triggerText?: string;
+    decision: ModeratorDecision;
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    latencyMs?: number;
+    workersSpawned?: number;
+    errors?: string[];
+  },
+): Promise<string> {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO moderator.decisions (
+       id, agent_id, scope_key,
+       trigger_kind, trigger_user_id, trigger_text,
+       action, rationale, decision_json,
+       model, input_tokens, output_tokens, latency_ms,
+       workers_spawned, errors
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb,
+       $10, $11, $12, $13, $14, $15
+     )`,
+    [
+      id,
+      params.agentId,
+      params.scopeKey,
+      params.triggerKind,
+      params.triggerUserId ?? null,
+      params.triggerText ? params.triggerText.slice(0, 1000) : null,
+      params.decision.action,
+      params.decision.rationale.slice(0, 500),
+      JSON.stringify(params.decision),
+      params.model ?? null,
+      params.inputTokens ?? null,
+      params.outputTokens ?? null,
+      params.latencyMs ?? null,
+      params.workersSpawned ?? 0,
+      params.errors && params.errors.length > 0 ? params.errors : null,
+    ],
+  );
+  return id;
+}
+
+/**
+ * Forward-compatible JSONB shape migration. Today this only enforces the
+ * version field; tomorrow's schema changes can land here without a
+ * destructive DDL.
+ */
+function migrateState(raw: ModeratorState | null | undefined): ModeratorState {
+  if (!raw || typeof raw !== "object") {
+    return newModeratorState("unknown", "dm");
+  }
+  const s: ModeratorState = {
+    scopeKey: raw.scopeKey ?? "unknown",
+    scopeKind: raw.scopeKind === "group" ? "group" : "dm",
+    chatId: raw.chatId,
+    ownerUserId: raw.ownerUserId,
+    recentMessages: Array.isArray(raw.recentMessages) ? raw.recentMessages.slice(-50) : [],
+    activeTopic: raw.activeTopic,
+    activeStudents: Array.isArray(raw.activeStudents) ? raw.activeStudents.slice(-50) : [],
+    activeWorkers: Array.isArray(raw.activeWorkers) ? raw.activeWorkers.slice(-10) : [],
+    debounceBuffer: Array.isArray(raw.debounceBuffer) ? raw.debounceBuffer.slice(-5) : [],
+    notes: Array.isArray(raw.notes) ? raw.notes.slice(-20) : [],
+    lastReviewAt: raw.lastReviewAt,
+    messagesSinceLastReview: typeof raw.messagesSinceLastReview === "number" ? raw.messagesSinceLastReview : 0,
+    version: 1,
+  };
+  return s;
+}

--- a/src/moderator/state.ts
+++ b/src/moderator/state.ts
@@ -61,7 +61,7 @@ export async function saveModeratorState(
        paused_by, paused_reason,
        updated_at
      )
-     VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10, now())
+     VALUES ($1, $2, $3::jsonb, COALESCE($4, 'live'), $5, $6, $7, $8, $9, $10, now())
      ON CONFLICT (agent_id, scope_key) DO UPDATE
        SET state           = EXCLUDED.state,
            status          = COALESCE($4, moderator.state.status),

--- a/src/moderator/telegram-api.ts
+++ b/src/moderator/telegram-api.ts
@@ -19,8 +19,27 @@
  * still get 429, Telegram's `Retry-After` is honoured.
  */
 
+import { lookup as dnsLookup } from "node:dns";
+import { Agent, fetch as undiciFetch } from "undici";
+
 const DEFAULT_API_ROOT = "https://api.telegram.org";
 const DEFAULT_TIMEOUT_MS = 15_000;
+
+/**
+ * Custom undici Agent: IPv4-only on hosts where IPv6 → api.telegram.org
+ * is broken (e.g. our Oracle Cloud setup — same workaround openclaw
+ * does for its own Telegram polling via OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY).
+ * globalThis.fetch in Node 22 honours autoSelectFamily=true by default,
+ * which silently hangs on IPv6-broken hosts. Forcing autoSelectFamily=false
+ * + ipv4-only DNS lookup keeps us on the working path.
+ */
+const ipv4FirstAgent = new Agent({
+  connect: {
+    autoSelectFamily: false,
+    lookup: (hostname, opts, cb) =>
+      dnsLookup(hostname, { ...opts, family: 4, all: false }, cb),
+  },
+});
 
 export type TelegramBotConfig = {
   /** The bot token (channels.telegram.botToken from openclaw.json). */
@@ -67,7 +86,17 @@ export class TelegramBotApi {
   constructor(private readonly cfg: TelegramBotConfig) {
     if (!cfg.botToken) {throw new Error("[moderator] telegram bot token missing");}
     this.apiRoot = (cfg.apiRoot ?? DEFAULT_API_ROOT).replace(/\/+$/, "");
-    this.fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+    // Use the IPv4-first undici fetch wrapper for production; fall through
+    // to caller-provided override (tests) or globalThis.fetch (other hosts
+    // where IPv6 actually works).
+    // Cross-cast through `unknown` once: undici's Request type and Node lib's
+    // RequestInfo aren't structurally identical (different RequestInit shapes)
+    // but at runtime they're the same. Return type also cast back to Response.
+    this.fetchImpl = cfg.fetchImpl ?? (((url: unknown, init: unknown) =>
+      undiciFetch(
+        url as Parameters<typeof undiciFetch>[0],
+        { ...(init as Parameters<typeof undiciFetch>[1]), dispatcher: ipv4FirstAgent },
+      ) as unknown as Promise<Response>) as unknown as typeof fetch);
     this.timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
@@ -125,7 +154,12 @@ export class TelegramBotApi {
         retryAfter: json.parameters?.retry_after,
       };
     } catch (err) {
-      return { ok: false, error: (err as Error).message };
+      // `fetch failed` is unhelpful on its own — include the cause chain
+      // when available so we can tell DNS / TLS / connect-refused apart
+      // from a 4xx body parse.
+      const e = err as Error & { cause?: unknown };
+      const cause = e.cause ? ` (cause: ${(e.cause as Error)?.message ?? String(e.cause)})` : "";
+      return { ok: false, error: `${e.message}${cause}` };
     } finally {
       clearTimeout(timer);
     }

--- a/src/moderator/telegram-api.ts
+++ b/src/moderator/telegram-api.ts
@@ -1,0 +1,133 @@
+/**
+ * Minimal Telegram Bot API client for the Moderator's side-effect lane.
+ *
+ * Three methods only: sendMessage, editMessageText, sendChatAction.
+ * Anything fancier (inline keyboards, file uploads, etc.) we add when
+ * a feature actually needs it.
+ *
+ * Why not reuse openclaw's outbound? Openclaw's send path drives the
+ * agent reply pipeline, which assumes "one reply per inbound msg".
+ * The Moderator sends an immediate placeholder, MAYBE several edits,
+ * and possibly a final answer — that doesn't fit cleanly. Direct
+ * Telegram Bot API calls keep the contract simple.
+ *
+ * Rate limits (community-confirmed, not officially published):
+ *   - 30 msg/sec global per bot token
+ *   - 20 msg/min per group
+ *   - 1 msg/sec per chat
+ * The caller (moderator service) batches edits to ~every 2s. If we
+ * still get 429, Telegram's `Retry-After` is honoured.
+ */
+
+const DEFAULT_API_ROOT = "https://api.telegram.org";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export type TelegramBotConfig = {
+  /** The bot token (channels.telegram.botToken from openclaw.json). */
+  botToken: string;
+  /** API base (default https://api.telegram.org). */
+  apiRoot?: string;
+  /** fetch override for tests. */
+  fetchImpl?: typeof fetch;
+  /** Per-call request timeout. */
+  timeoutMs?: number;
+};
+
+export type SendMessageParams = {
+  chatId: string | number;
+  text: string;
+  replyToMessageId?: number;
+  parseMode?: "Markdown" | "MarkdownV2" | "HTML";
+  /** When set, the message is sent inside this forum topic. */
+  messageThreadId?: number;
+};
+
+export type EditMessageTextParams = {
+  chatId: string | number;
+  messageId: number;
+  text: string;
+  parseMode?: "Markdown" | "MarkdownV2" | "HTML";
+};
+
+export type SendChatActionParams = {
+  chatId: string | number;
+  action: "typing" | "record_voice" | "upload_document";
+  messageThreadId?: number;
+};
+
+export type ApiOutcome<T> =
+  | { ok: true; result: T; retryAfter?: number }
+  | { ok: false; error: string; status?: number; retryAfter?: number };
+
+export class TelegramBotApi {
+  private readonly fetchImpl: typeof fetch;
+  private readonly apiRoot: string;
+  private readonly timeoutMs: number;
+
+  constructor(private readonly cfg: TelegramBotConfig) {
+    if (!cfg.botToken) {throw new Error("[moderator] telegram bot token missing");}
+    this.apiRoot = (cfg.apiRoot ?? DEFAULT_API_ROOT).replace(/\/+$/, "");
+    this.fetchImpl = cfg.fetchImpl ?? globalThis.fetch;
+    this.timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async sendMessage(params: SendMessageParams): Promise<ApiOutcome<{ messageId: number }>> {
+    return this.call<{ message_id: number }>("sendMessage", {
+      chat_id: params.chatId,
+      text: params.text,
+      ...(params.replyToMessageId ? { reply_to_message_id: params.replyToMessageId } : {}),
+      ...(params.parseMode ? { parse_mode: params.parseMode } : {}),
+      ...(params.messageThreadId ? { message_thread_id: params.messageThreadId } : {}),
+    }).then((o) => (o.ok ? { ok: true as const, result: { messageId: o.result.message_id } } : o));
+  }
+
+  async editMessageText(params: EditMessageTextParams): Promise<ApiOutcome<true>> {
+    return this.call("editMessageText", {
+      chat_id: params.chatId,
+      message_id: params.messageId,
+      text: params.text,
+      ...(params.parseMode ? { parse_mode: params.parseMode } : {}),
+    }).then((o) => (o.ok ? { ok: true as const, result: true } : o));
+  }
+
+  async sendChatAction(params: SendChatActionParams): Promise<ApiOutcome<true>> {
+    return this.call("sendChatAction", {
+      chat_id: params.chatId,
+      action: params.action,
+      ...(params.messageThreadId ? { message_thread_id: params.messageThreadId } : {}),
+    }).then((o) => (o.ok ? { ok: true as const, result: true } : o));
+  }
+
+  private async call<T>(method: string, body: Record<string, unknown>): Promise<ApiOutcome<T>> {
+    const url = `${this.apiRoot}/bot${this.cfg.botToken}/${method}`;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const resp = await this.fetchImpl(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      });
+      const json = (await resp.json().catch(() => ({}))) as {
+        ok?: boolean;
+        result?: T;
+        description?: string;
+        parameters?: { retry_after?: number };
+      };
+      if (json.ok && json.result !== undefined) {
+        return { ok: true, result: json.result };
+      }
+      return {
+        ok: false,
+        error: json.description ?? `HTTP ${resp.status}`,
+        status: resp.status,
+        retryAfter: json.parameters?.retry_after,
+      };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/moderator/types.ts
+++ b/src/moderator/types.ts
@@ -1,0 +1,268 @@
+/**
+ * Moderator types — Phase C.
+ *
+ * The Moderator is the orchestrator-worker pattern from Anthropic's
+ * "Building effective agents" article, persistent per
+ * (agent_id, scope_key). It receives every inbound message in its
+ * scope, runs ONE LLM call against gpt-5.5, parses a structured
+ * JSON decision, and dispatches.
+ *
+ * Decisions are split into:
+ *   1. `action` — coarse routing label, drives the rest of the shape
+ *   2. `memoryWrites` — facts to persist regardless of whether we answer
+ *   3. `answerTasks` — workers to spawn (may be empty)
+ *   4. `telegramActions` — placeholders / edits to send to chat
+ *   5. `escalation` — optional ping to the bot owner
+ *
+ * The state stored in PG is whatever the Moderator needs to remember
+ * across messages: recent conversation, active workers, current topic,
+ * pending tasks, last self-review timestamp.
+ */
+
+/* --------------------------- ModeratorState shape -------------------------- */
+
+export type ScopeKey = string; // "tg:chat:<chat_id>" | "tg:dm:<user_id>"
+
+export type RecentMessage = {
+  ts: string;            // ISO timestamp
+  fromUserId: string;    // telegram user id (or "bot" for bot replies)
+  fromLabel?: string;    // display name when known
+  text: string;          // user-visible text, truncated to ~500 chars in state
+  messageId?: number;    // telegram message id (for edit/reply targeting)
+  isAddressed?: boolean; // @mention or reply-to-bot
+};
+
+export type ActiveWorker = {
+  taskId: string;        // moderator-local id; unique within scope
+  roleKey: string;       // references moderator.worker_roles.role_key
+  task: string;          // the actual task prompt
+  startedAt: string;
+  placeholderMessageId?: number;  // the "thinking..." message to edit
+  status: "running" | "completed" | "failed" | "cancelled";
+  result?: string;       // populated when status=completed
+  error?: string;
+};
+
+export type ActiveStudent = {
+  userId: string;
+  label?: string;
+  lastSeenAt: string;
+  currentTopic?: string;
+};
+
+export type ModeratorState = {
+  scopeKey: ScopeKey;
+  scopeKind: "group" | "dm";
+  chatId?: string;       // telegram chat id
+  ownerUserId?: string;  // bot owner (for escalation routing)
+
+  /** Most recent N messages (FIFO, cap 50). */
+  recentMessages: RecentMessage[];
+
+  /** Distilled "what's going on" — Moderator updates each cycle. */
+  activeTopic?: string;
+  activeStudents: ActiveStudent[];
+
+  /** Workers in flight; cleared on completion. */
+  activeWorkers: ActiveWorker[];
+
+  /** Per-user debounce buffer (1.5s burst → one prompt). */
+  debounceBuffer: { userId: string; messages: RecentMessage[]; firstSeenAt: string }[];
+
+  /** Long-lived "self notes" — facts the Moderator decided to keep in
+   *  its working context. Distinct from per-user/per-chat memory in
+   *  nextclaw chunks — these are the Moderator's own scratchpad. */
+  notes: string[];
+
+  /** Self-review bookkeeping. */
+  lastReviewAt?: string;
+  messagesSinceLastReview: number;
+
+  /** Schema version for forward-compatible migrations of the JSONB. */
+  version: 1;
+};
+
+export function newModeratorState(scopeKey: ScopeKey, scopeKind: "group" | "dm", chatId?: string, ownerUserId?: string): ModeratorState {
+  return {
+    scopeKey,
+    scopeKind,
+    chatId,
+    ownerUserId,
+    recentMessages: [],
+    activeStudents: [],
+    activeWorkers: [],
+    debounceBuffer: [],
+    notes: [],
+    messagesSinceLastReview: 0,
+    version: 1,
+  };
+}
+
+/* ----------------------------- Decision schema ----------------------------- */
+
+export type DecisionAction =
+  | "ignore"            // chatter; do nothing, don't even write to memory
+  | "write-only"        // remember it but don't reply
+  | "answer-direct"     // spawn ONE worker with a direct answer task
+  | "answer-decompose"  // spawn MULTIPLE workers (independent sub-questions)
+  | "clarify"           // reply asking for clarification, no worker
+  | "escalate";         // ping the bot owner; optionally also reply in chat
+
+export type MemoryWrite = {
+  text: string;
+  scope: "user" | "chat" | "global";  // user = anchor_sender_id only;
+                                       // chat = anchor_chat_id only;
+                                       // global = neither (pure system fact)
+  topic?: string;
+  importance?: number;                 // 0..1, default 0.5
+  visibility?: "public" | "private";   // default depends on scope
+};
+
+export type AnswerTask = {
+  /** Unique within the decision. Used to correlate workers ↔ placeholder edits. */
+  taskId: string;
+  /** Role specialist to invoke. Will be auto-spawned if not yet registered. */
+  roleKey: string;
+  /** Free-form prompt for the worker. Anchors / context will be merged in by the runner. */
+  taskPrompt: string;
+  /** Memory scope hint for the worker's memory_search calls. */
+  memoryScope?: { topic?: string; viewerUserId?: string; chatId?: string };
+  /** Whether this task can run in parallel with others in the same decision.
+   *  Default true; false means it depends on a prior task's result. */
+  canParallel?: boolean;
+};
+
+export type TelegramAction =
+  | { kind: "placeholder";      taskId?: string;   text: string }
+  | { kind: "edit_placeholder"; taskId: string;    fromTaskResult: true }
+  | { kind: "edit_placeholder"; taskId: string;    text: string }
+  | { kind: "send_message";     text: string;      replyToMessageId?: number }
+  | { kind: "send_chat_action"; action: "typing" | "record_voice" };
+
+export type Escalation = {
+  reason: string;
+  summary: string;
+  /** When true, also pause Moderator auto-reply in this scope until human
+   *  issues /release. */
+  pauseScope?: boolean;
+};
+
+export type ModeratorDecision = {
+  action: DecisionAction;
+  rationale: string;
+  memoryWrites?: MemoryWrite[];
+  answerTasks?: AnswerTask[];
+  telegramActions?: TelegramAction[];
+  escalation?: Escalation;
+  /** When the Moderator wants to refresh its own state notes for next cycle. */
+  noteAppend?: string;
+};
+
+/* ----------------------------- helpers / guards ---------------------------- */
+
+const ALLOWED_ACTIONS = new Set<DecisionAction>([
+  "ignore",
+  "write-only",
+  "answer-direct",
+  "answer-decompose",
+  "clarify",
+  "escalate",
+]);
+
+/**
+ * Defensive parser. The LLM is supposed to emit a `ModeratorDecision`-shaped
+ * JSON object; this normalizes shapes, drops malformed sub-objects, and
+ * always returns a valid Decision (default = `ignore` if everything fails).
+ */
+export function parseDecision(raw: unknown): { decision: ModeratorDecision; errors: string[] } {
+  const errors: string[] = [];
+  const isObj = (v: unknown): v is Record<string, unknown> =>
+    typeof v === "object" && v !== null && !Array.isArray(v);
+
+  if (!isObj(raw)) {
+    errors.push("decision must be an object");
+    return {
+      decision: { action: "ignore", rationale: "parse-failed: not-object" },
+      errors,
+    };
+  }
+  const action = raw.action;
+  if (typeof action !== "string" || !ALLOWED_ACTIONS.has(action as DecisionAction)) {
+    errors.push(`unknown action: ${JSON.stringify(action)}`);
+    return {
+      decision: { action: "ignore", rationale: `parse-failed: bad action ${action}` },
+      errors,
+    };
+  }
+
+  const decision: ModeratorDecision = {
+    action: action as DecisionAction,
+    rationale: typeof raw.rationale === "string" ? raw.rationale.slice(0, 500) : "",
+  };
+
+  if (Array.isArray(raw.memoryWrites)) {
+    decision.memoryWrites = raw.memoryWrites
+      .filter(isObj)
+      .map((m): MemoryWrite | null => {
+        const text = typeof m.text === "string" ? m.text : null;
+        const scope = m.scope === "user" || m.scope === "chat" || m.scope === "global" ? m.scope : null;
+        if (!text || !scope) {return null;}
+        const w: MemoryWrite = { text, scope };
+        if (typeof m.topic === "string") {w.topic = m.topic;}
+        if (typeof m.importance === "number" && m.importance >= 0 && m.importance <= 1) {
+          w.importance = m.importance;
+        }
+        if (m.visibility === "public" || m.visibility === "private") {w.visibility = m.visibility;}
+        return w;
+      })
+      .filter((w): w is MemoryWrite => w !== null);
+  }
+
+  if (Array.isArray(raw.answerTasks)) {
+    decision.answerTasks = raw.answerTasks
+      .filter(isObj)
+      .map((t): AnswerTask | null => {
+        const taskId = typeof t.taskId === "string" ? t.taskId : null;
+        const roleKey = typeof t.roleKey === "string" ? t.roleKey : null;
+        const taskPrompt = typeof t.taskPrompt === "string" ? t.taskPrompt : null;
+        if (!taskId || !roleKey || !taskPrompt) {return null;}
+        return {
+          taskId,
+          roleKey,
+          taskPrompt,
+          memoryScope: isObj(t.memoryScope) ? (t.memoryScope as AnswerTask["memoryScope"]) : undefined,
+          canParallel: t.canParallel !== false,
+        };
+      })
+      .filter((t): t is AnswerTask => t !== null);
+  }
+
+  if (Array.isArray(raw.telegramActions)) {
+    decision.telegramActions = raw.telegramActions
+      .filter(isObj)
+      .filter((a): a is TelegramAction => {
+        if (a.kind === "placeholder" && typeof a.text === "string") {return true;}
+        if (a.kind === "edit_placeholder" && typeof a.taskId === "string") {return true;}
+        if (a.kind === "send_message" && typeof a.text === "string") {return true;}
+        if (a.kind === "send_chat_action" && (a.action === "typing" || a.action === "record_voice")) {return true;}
+        return false;
+      });
+  }
+
+  if (isObj(raw.escalation)) {
+    const e = raw.escalation;
+    if (typeof e.reason === "string" && typeof e.summary === "string") {
+      decision.escalation = {
+        reason: e.reason,
+        summary: e.summary,
+        pauseScope: e.pauseScope === true,
+      };
+    }
+  }
+
+  if (typeof raw.noteAppend === "string" && raw.noteAppend.length <= 1000) {
+    decision.noteAppend = raw.noteAppend;
+  }
+
+  return { decision, errors };
+}

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -1,0 +1,319 @@
+/**
+ * Worker dispatch — Phase D.
+ *
+ * Anthropic-orchestrator-worker pattern: the Moderator picks `answerTasks`,
+ * we spawn ONE LLM call per task (parallel if `canParallel:true`), inject
+ * relevant memory from the recall pipeline, return the answer text, and
+ * write the (question → answer) pair back to cache.qa so the next identical
+ * or near-identical question hits the pre-check and skips all this work.
+ *
+ * Design constraints (per "infra not reasoning" principle):
+ *   - Role specs live in `moderator.worker_roles`. A missing role falls back
+ *     to DEFAULT_ROLE — we don't crash if Moderator picks a new roleKey on
+ *     the fly. New roleKeys auto-register on first use (Phase D does NOT
+ *     auto-register yet; that's a Phase E concern — for now, missing role
+ *     just uses DEFAULT_ROLE silently).
+ *   - The worker system prompt is INTENTIONALLY thin. Add domain logic in
+ *     the role's `system_prompt` column, NOT here. A stronger LLM should
+ *     not see our hard-coded reasoning rules.
+ *   - Cache write-back is fire-and-forget; failure does not break the user
+ *     reply path.
+ */
+
+import type { Pool } from "pg";
+import { randomUUID } from "node:crypto";
+import type { ModeratorLlm } from "./runner.js";
+import type { AnswerTask } from "./types.js";
+import type { EmbeddingClient } from "../embedding/client.js";
+import { recall } from "../recall/router.js";
+import type { ViewerScope } from "../recall/viewer-scope.js";
+import type { ResolvedMemoryPostgresConfig } from "../config.js";
+import { storeCachedAnswer } from "../cache/qa.js";
+
+export type WorkerDeps = {
+  pool: Pool;
+  llm: ModeratorLlm;
+  embedding: EmbeddingClient;
+  cfg: ResolvedMemoryPostgresConfig;
+  agentId: string;
+  logger: { info: (m: string) => void; warn: (m: string) => void };
+};
+
+export type RoleSpec = {
+  roleKey: string;
+  displayName: string;
+  systemPrompt: string;
+  /** Reserved for Phase E (currently ignored — workers don't have tools). */
+  tools: string[];
+  /** memory_scope filter hints for recall (topic/kind). */
+  memoryScope: { topic?: string; kind?: string };
+  /** Model identifier; advisory only for Phase D (we use the injected
+   *  llm regardless). Phase E will respect this. */
+  model: string;
+};
+
+/**
+ * Minimal default role used when no DB row matches the Moderator's
+ * `roleKey`. Keep the prompt short — domain logic belongs in DB rows.
+ */
+const DEFAULT_ROLE: RoleSpec = {
+  roleKey: "default",
+  displayName: "默认助手",
+  systemPrompt:
+    "你是一个 Telegram 群里的助教 / 客服助手。用中文简洁回答用户的问题。" +
+    "如果给了你 '相关记忆' 段落，引用其中确凿的信息；否则按通识回答，但要诚实说明不确定。" +
+    "不要复述问题，不要加 emoji，不要套话开场。3 段以内。",
+  tools: [],
+  memoryScope: {},
+  model: "gemini:gemini-2.5-flash",
+};
+
+/* ----------------------------- role loading ------------------------------- */
+
+export async function loadRoleSpec(
+  pool: Pool,
+  agentId: string,
+  roleKey: string,
+): Promise<RoleSpec> {
+  const r = await pool.query<{
+    role_key: string;
+    display_name: string | null;
+    system_prompt: string;
+    tools: string[];
+    memory_scope: Record<string, unknown>;
+    model: string;
+  }>(
+    `SELECT role_key, display_name, system_prompt, tools, memory_scope, model
+     FROM moderator.worker_roles
+     WHERE agent_id = $1 AND role_key = $2 AND active = TRUE
+     LIMIT 1`,
+    [agentId, roleKey],
+  );
+  const row = r.rows[0];
+  if (!row) {
+    return { ...DEFAULT_ROLE, roleKey }; // keep the requested key for traceability
+  }
+  return {
+    roleKey: row.role_key,
+    displayName: row.display_name ?? row.role_key,
+    systemPrompt: row.system_prompt,
+    tools: row.tools ?? [],
+    memoryScope: (row.memory_scope ?? {}) as { topic?: string; kind?: string },
+    model: row.model,
+  };
+}
+
+/* --------------------------- single-task dispatch ------------------------- */
+
+export type WorkerResult = {
+  taskId: string;
+  roleKey: string;
+  ok: boolean;
+  answer: string;
+  /** Verbatim user question text (mention-stripped) used for cache key + log. */
+  questionText: string;
+  /** topic_tag we'll store with the cache row (for taxonomy + future filters). */
+  topicTag: string | undefined;
+  llm: {
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    latencyMs?: number;
+  };
+  /** How many memory chunks were merged into the prompt. */
+  recallCount: number;
+  errors: string[];
+};
+
+const MAX_RECALL_CHUNKS = 5;
+const MAX_CHUNK_CHARS = 400;
+const WORKER_MAX_OUTPUT_TOKENS = 800;
+
+/**
+ * Strips Telegram @-mentions and collapses whitespace so the cache key
+ * stays clean. Mirrors `cleanQuestionText` in cache-precheck.ts — KEEP
+ * THE TWO IN SYNC or cache writes won't match precheck reads.
+ */
+export function cleanQuestionText(text: string): string {
+  return text
+    .replace(/@[A-Za-z0-9_]{3,32}/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export async function dispatchWorker(
+  deps: WorkerDeps,
+  task: AnswerTask,
+  viewer: ViewerScope | undefined,
+  /** Raw question text from the user (pre-cleaning). */
+  userQuestion: string,
+): Promise<WorkerResult> {
+  const role = await loadRoleSpec(deps.pool, deps.agentId, task.roleKey);
+  const cleanedQ = cleanQuestionText(userQuestion);
+  const topicTag = task.memoryScope?.topic ?? role.memoryScope.topic;
+
+  // --- Memory recall (best-effort; failures don't block the answer) ---
+  let recallText = "";
+  let recallCount = 0;
+  try {
+    const rr = await recall(
+      { cfg: deps.cfg, pool: deps.pool, embedding: deps.embedding },
+      {
+        query: cleanedQ,
+        maxResults: MAX_RECALL_CHUNKS,
+        agentId: deps.agentId,
+        viewer,
+        conceptTags: topicTag ? [topicTag] : undefined,
+      },
+    );
+    if (rr.results.length > 0) {
+      recallCount = rr.results.length;
+      const lines = rr.results
+        .slice(0, MAX_RECALL_CHUNKS)
+        .map((c, i) => {
+          const text = (c.text ?? "").slice(0, MAX_CHUNK_CHARS);
+          return `[m${i + 1}] ${text}`;
+        });
+      recallText = lines.join("\n");
+    }
+  } catch (e) {
+    deps.logger.warn(`worker[${task.taskId}]: recall failed: ${(e as Error).message}`);
+  }
+
+  // --- Build prompt ---
+  const userPromptParts: string[] = [];
+  if (recallText) {
+    userPromptParts.push(`## 相关记忆\n${recallText}`);
+  }
+  userPromptParts.push(`## 用户问题\n${task.taskPrompt || cleanedQ}`);
+  const userPrompt = userPromptParts.join("\n\n");
+
+  // --- LLM call ---
+  let llmOut: Awaited<ReturnType<ModeratorLlm["call"]>>;
+  try {
+    llmOut = await deps.llm.call({
+      systemPrompt: role.systemPrompt,
+      userPrompt,
+      maxTokens: WORKER_MAX_OUTPUT_TOKENS,
+      temperature: 0.4,
+    });
+  } catch (e) {
+    return {
+      taskId: task.taskId,
+      roleKey: role.roleKey,
+      ok: false,
+      answer: "",
+      questionText: cleanedQ,
+      topicTag,
+      llm: {},
+      recallCount,
+      errors: [`llm-call-failed: ${(e as Error).message}`],
+    };
+  }
+
+  const answer = (llmOut.text ?? "").trim();
+  const ok = answer.length > 0 && !answer.startsWith(`{"action":"ignore"`); // sentinel guard
+  return {
+    taskId: task.taskId,
+    roleKey: role.roleKey,
+    ok,
+    answer: ok ? answer : "（生成失败）",
+    questionText: cleanedQ,
+    topicTag,
+    llm: {
+      model: llmOut.model,
+      inputTokens: llmOut.inputTokens,
+      outputTokens: llmOut.outputTokens,
+      latencyMs: llmOut.latencyMs,
+    },
+    recallCount,
+    errors: ok ? [] : ["empty-or-fallback-llm-output"],
+  };
+}
+
+/* --------------------------- many-task orchestrator ----------------------- */
+
+/**
+ * Runs all answer tasks. Tasks marked `canParallel:true` run concurrently;
+ * sequential-only tasks run in declaration order AFTER the parallel batch
+ * (Phase D doesn't yet support dependency graphs — `canParallel:false`
+ * means "run last", not "depend on a specific other task").
+ */
+export async function runWorkersForDecision(
+  deps: WorkerDeps,
+  tasks: AnswerTask[],
+  viewer: ViewerScope | undefined,
+  userQuestion: string,
+): Promise<WorkerResult[]> {
+  if (tasks.length === 0) {return [];}
+  const parallel = tasks.filter((t) => t.canParallel !== false);
+  const serial = tasks.filter((t) => t.canParallel === false);
+
+  const parResults = await Promise.all(parallel.map((t) => dispatchWorker(deps, t, viewer, userQuestion)));
+  const serResults: WorkerResult[] = [];
+  for (const t of serial) {
+    serResults.push(await dispatchWorker(deps, t, viewer, userQuestion));
+  }
+  return [...parResults, ...serResults];
+}
+
+/* ------------------------------ cache write-back -------------------------- */
+
+const CACHE_TTL_DAYS_DEFAULT = 90;
+
+/**
+ * Persist a successful worker answer into cache.qa so the next equivalent
+ * question hits the pre-check. Fire-and-forget — failure is logged but
+ * doesn't block the user reply.
+ *
+ * Visibility rules (intentionally simple — extend in Phase E):
+ *   - default `public` (T0 global): the answer is reusable across viewers
+ *   - if `task.memoryScope.viewerUserId` is set → `private` (TA scoped)
+ *   - chat-scoped public not yet emitted by Moderator decisions
+ */
+export async function writeAnswerToCache(
+  deps: WorkerDeps,
+  result: WorkerResult,
+  task: AnswerTask,
+): Promise<string | null> {
+  if (!result.ok || !result.answer || result.answer.length < 2) {return null;}
+  try {
+    // Embed the CLEANED question (matches what precheck.ts hashes/embeds).
+    // taskPrefix: null — we're embedding the *question* as a passage for
+    // future lookups; the EmbeddingClient only differentiates "query" vs
+    // null (= default/passage), matching the embed model's instruction set.
+    const er = await deps.embedding.embed({
+      inputs: [result.questionText],
+      taskPrefix: null,
+    });
+    const visibility: "public" | "private" =
+      task.memoryScope?.viewerUserId ? "private" : "public";
+    const scope = task.memoryScope?.viewerUserId
+      ? { senderId: task.memoryScope.viewerUserId, visibility }
+      : { visibility };
+    const id = await storeCachedAnswer(deps.pool, {
+      agentId: deps.agentId,
+      questionText: result.questionText,
+      questionEmbedding: er.embeddings[0],
+      embeddingModel: deps.cfg.embedding.model,
+      answerText: result.answer,
+      answerFormat: "plain",
+      scope,
+      topicTag: result.topicTag,
+      source: "agent",
+      ttlDays: CACHE_TTL_DAYS_DEFAULT,
+    });
+    return id || null;
+  } catch (e) {
+    deps.logger.warn(
+      `worker[${result.taskId}]: cache write-back failed: ${(e as Error).message}`,
+    );
+    return null;
+  }
+}
+
+// We mint task ids inside the runner when the LLM forgets to. Exported
+// so the service can do the same on the rare same-cycle reuse path.
+export function mintTaskId(): string {
+  return `t_${randomUUID().slice(0, 8)}`;
+}

--- a/src/recall/router.ts
+++ b/src/recall/router.ts
@@ -38,6 +38,7 @@ import {
 import { categorize } from "../structured/categorizer.js";
 import { inferTimeBucketsFromQuery } from "./temporal.js";
 import type { RecallContext, RouteName } from "./types.js";
+import { filterVisibleChunkIds, type ViewerScope } from "./viewer-scope.js";
 import { primeWorkingSetWithProfiles, workingSetFor } from "./working-set.js";
 
 /* ----------------------- query-side anchor inference ---------------------- */
@@ -127,6 +128,17 @@ export type RecallInput = {
    * the owner's private chunks even if it tries. Default 'main' for back-compat.
    */
   agentId?: string;
+  /**
+   * Viewer scope. When set, the merged result set is passed through
+   * `filterVisibleChunkIds` to enforce the three-tier (per-user-global /
+   * per-chat-shared / per-(chat,user)) memory privacy model. See
+   * `src/recall/viewer-scope.ts` for the rules.
+   *
+   * - For DM recalls: pass `viewer.userId` only.
+   * - For group recalls: pass both `viewer.userId` AND `viewer.chatId`.
+   * - For system / migration callers without a human viewer: omit entirely.
+   */
+  viewer?: ViewerScope;
 };
 
 export type RecallOutput = {
@@ -176,6 +188,11 @@ function scopeKeyFor(input: RecallInput): string {
     // Agent id is part of the cache scope so two agents asking the same
     // question against different memory namespaces never share results.
     `agent:${input.agentId ?? "main"}`,
+    // Viewer scope is also part of the cache key — different viewers in
+    // the same agent must see different filtered results (privacy), so
+    // they should NOT share a cache entry even when their query string
+    // matches verbatim. Cuts hit-rate slightly; required for correctness.
+    `viewer:${input.viewer?.userId ?? ""}:${input.viewer?.chatId ?? ""}`,
     a.cwd ?? "",
     a.branch ?? "",
     a.pr ?? "",
@@ -263,7 +280,12 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
   const minScore = input.minScore ?? 0;
   const scope = scopeKeyFor(input);
   const { qHash } = hashQuery(input.query, scope);
-  const ws = workingSetFor(input.agentSessionId, deps.cfg.tiers.t0SizeLimit, input.agentId);
+  const ws = workingSetFor(
+    input.agentSessionId,
+    deps.cfg.tiers.t0SizeLimit,
+    input.agentId,
+    input.viewer?.userId,
+  );
 
   // First recall of a session: prime T0 with this agent's profile chunks
   // (MemGPT-style "core memory" — per-agent + per-entity summaries that
@@ -376,6 +398,7 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
     categories: inferredCategories,
     perRouteK: T2_PER_ROUTE_K,
     agentId: input.agentId ?? "main",
+    viewer: input.viewer,
   };
 
   const [
@@ -477,7 +500,19 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
   }
 
   const reranked = mmrRerank(all, k);
-  const filtered = reranked.filter((c) => c.combinedScore >= minScore);
+  let filtered = reranked.filter((c) => c.combinedScore >= minScore);
+
+  // Three-tier privacy filter: drop any chunk that's not visible to the
+  // current viewer. Cheap single-RT batch lookup. For DM / system callers
+  // who didn't set viewer, this is a no-op pass-through.
+  if (input.viewer && (input.viewer.userId || input.viewer.chatId) && filtered.length > 0) {
+    const visible = await filterVisibleChunkIds(
+      deps.pool,
+      input.viewer,
+      filtered.map((c) => c.chunkId),
+    );
+    filtered = filtered.filter((c) => visible.has(c.chunkId));
+  }
 
   // T1 hot promotion + T0 working set + spreading activation.
   const hitIds = filtered.map((c) => c.chunkId);

--- a/src/recall/types.ts
+++ b/src/recall/types.ts
@@ -75,4 +75,18 @@ export type RecallContext = {
   queryEmbedding?: number[];
   /** Owning agent id — every SQL route filters `chunks.agent_id = $X`. */
   agentId?: string;
+  /**
+   * Viewer scope — WHO is asking and IN WHICH chat. Used to apply the
+   * three-tier privacy filter (see src/recall/viewer-scope.ts):
+   *   - viewer.userId       = the asking human's stable id (telegram user id, etc.)
+   *   - viewer.chatId       = the chat the question was asked in (group id);
+   *                            omit for DMs
+   * When omitted entirely, viewer-scope filtering is bypassed (legacy
+   * single-user behaviour). For multi-user groups this MUST be set, or
+   * private DM facts from other students can leak across the group.
+   */
+  viewer?: {
+    userId?: string;
+    chatId?: string;
+  };
 };

--- a/src/recall/viewer-scope.test.ts
+++ b/src/recall/viewer-scope.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildViewerScopeFilter, filterVisibleChunkIds } from "./viewer-scope.js";
+
+describe("buildViewerScopeFilter", () => {
+  it("returns no-op when viewer is undefined", () => {
+    const f = buildViewerScopeFilter(undefined, 1);
+    expect(f.whereSql).toBe("TRUE");
+    expect(f.params).toEqual([]);
+    expect(f.paramCount).toBe(0);
+  });
+
+  it("returns no-op when both viewer fields are empty", () => {
+    const f = buildViewerScopeFilter({}, 1);
+    expect(f.whereSql).toBe("TRUE");
+    expect(f.paramCount).toBe(0);
+  });
+
+  it("emits the three-tier WHERE with bind params at the given start index", () => {
+    const f = buildViewerScopeFilter({ userId: "8064984663", chatId: "-1001234567890" }, 5);
+    // Two params consumed: $5 = userId, $6 = chatId
+    expect(f.paramCount).toBe(2);
+    expect(f.params).toEqual(["8064984663", "-1001234567890"]);
+    // Sanity: SQL references both placeholders
+    expect(f.whereSql).toContain("$5");
+    expect(f.whereSql).toContain("$6");
+    expect(f.whereSql).toContain("anchor_sender_id");
+    expect(f.whereSql).toContain("anchor_chat_id");
+    expect(f.whereSql).toContain("anchor_visibility");
+  });
+
+  it("substitutes sentinel string when only chatId is set (user-anonymous viewer)", () => {
+    const f = buildViewerScopeFilter({ chatId: "-1001234567890" }, 1);
+    expect(f.params[0]).toBe("__no_user__"); // userId sentinel
+    expect(f.params[1]).toBe("-1001234567890");
+  });
+});
+
+describe("filterVisibleChunkIds (mocked pool)", () => {
+  function mockPool(returnIds: string[]) {
+    return {
+      query: vi.fn(async () => ({ rows: returnIds.map((id) => ({ id })) })),
+    } as unknown as Parameters<typeof filterVisibleChunkIds>[0];
+  }
+
+  it("returns empty set when chunkIds is empty", async () => {
+    const pool = mockPool([]);
+    const out = await filterVisibleChunkIds(pool, { userId: "1" }, []);
+    expect(out.size).toBe(0);
+    expect((pool.query as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("passes everything through when viewer is undefined", async () => {
+    const pool = mockPool([]); // pool would not be called
+    const out = await filterVisibleChunkIds(pool, undefined, ["a", "b"]);
+    expect(out.has("a")).toBe(true);
+    expect(out.has("b")).toBe(true);
+    expect((pool.query as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it("issues one batch query and returns the rows it gets back", async () => {
+    const pool = mockPool(["a", "c"]); // "b" was filtered out by SQL
+    const out = await filterVisibleChunkIds(pool, { userId: "1", chatId: "-100" }, ["a", "b", "c"]);
+    expect(out.has("a")).toBe(true);
+    expect(out.has("c")).toBe(true);
+    expect(out.has("b")).toBe(false);
+    const callArgs = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0];
+    // SQL references the four anchor kinds the three-tier model uses
+    expect(callArgs[0]).toContain("anchor_sender_id");
+    expect(callArgs[0]).toContain("anchor_chat_id");
+    expect(callArgs[0]).toContain("anchor_visibility");
+    // Bind values: [chunkIds, viewerUser, viewerChat]
+    expect(callArgs[1]).toEqual([["a", "b", "c"], "1", "-100"]);
+  });
+});

--- a/src/recall/viewer-scope.ts
+++ b/src/recall/viewer-scope.ts
@@ -1,0 +1,237 @@
+/**
+ * Viewer-scoped privacy filter — the three-tier memory model in SQL.
+ *
+ * Model
+ * -----
+ * Every chunk MAY carry these anchors (set at ingest time via chunk_indexes):
+ *   - anchor_sender_id   the human who said it (e.g. telegram user id)
+ *   - anchor_chat_id     the chat it was said in (telegram chat id; for DMs
+ *                        this can be omitted or equal the sender)
+ *   - anchor_visibility  'public' (default if absent) | 'private'
+ *
+ * A recall call carries a *viewer*: who is asking, in what chat.
+ *
+ *   viewer = { userId: <8064984663>, chatId: <-1001234567890> | undefined }
+ *
+ * VISIBLE iff one of:
+ *   T0  no `anchor_sender_id` AND no `anchor_chat_id`
+ *                                              (truly agent-global / system —
+ *                                              e.g. plugin policy, smoke ingest;
+ *                                              a chunk tagged only with chat_id
+ *                                              is chat-scoped and falls under
+ *                                              TC, NOT under T0)
+ *   TA  anchor_sender_id == viewer.userId     (about the asker — DM or group)
+ *   TC  anchor_chat_id == viewer.chatId       AND visibility != 'private'
+ *                                              (group-public — other speakers
+ *                                              in the same chat are OK to see
+ *                                              because they were physically
+ *                                              co-present)
+ *
+ * BLOCKED iff:
+ *   – `anchor_sender_id` exists AND != viewer.userId AND no `anchor_chat_id`
+ *     matching viewer.chatId
+ *   – OR `anchor_visibility = 'private'` AND `anchor_sender_id != viewer.userId`
+ *
+ * Two corollaries worth stating:
+ *   - In a DM (viewer.chatId == undefined), TC never fires; you only see
+ *     your own (TA) + system (T0) facts. Other students' DM facts stay
+ *     invisible.
+ *   - The agent's *own* outputs (kind='assistant_reply') get tagged with
+ *     the SAME anchors as the inbound message they responded to, so they
+ *     route through the same filter without special casing.
+ *
+ * Why this lives in SQL, not in the agent prompt:
+ *   The Anthropic addressee-recognition benchmark (arxiv 2501.16643)
+ *   shows even GPT-4o is barely-above-chance at judging privacy/scope
+ *   in multi-party chat. We do not trust the LLM with the boundary.
+ *   Every route in `routes.ts` applies this fragment as a hard SQL filter.
+ */
+
+export type ViewerScope = {
+  /** Telegram user id (or other channel's user id). Omitted = legacy / system caller. */
+  userId?: string;
+  /** Telegram chat id (group / supergroup). Omitted = DM. */
+  chatId?: string;
+};
+
+export type ViewerFilterFragment = {
+  /** SQL fragment to AND into a route's WHERE clause. References `c.id`. */
+  whereSql: string;
+  /** Bind values appended to the param list. */
+  params: string[];
+  /** Number of $N placeholders consumed (so caller can index correctly). */
+  paramCount: number;
+};
+
+/**
+ * Batch-mode visibility check. Given an array of chunk ids and a viewer
+ * scope, return the subset that the viewer is allowed to see under the
+ * three-tier rules. Used by the recall router as a post-merge filter so
+ * each route can stay simple while privacy still gets enforced once
+ * before results leave the recall path.
+ *
+ * One round-trip via pg, primary-key-indexed: typical 10-candidate
+ * filtered call is sub-millisecond.
+ */
+export async function filterVisibleChunkIds(
+  pool: { query: <R = unknown>(sql: string, params?: unknown[]) => Promise<{ rows: R[] }> },
+  viewer: ViewerScope | undefined,
+  chunkIds: string[],
+): Promise<Set<string>> {
+  if (chunkIds.length === 0) {return new Set();}
+  if (!viewer || (!viewer.userId && !viewer.chatId)) {
+    // No viewer = pre-existing single-user behaviour; everything passes.
+    return new Set(chunkIds);
+  }
+  const viewerUser = viewer.userId ?? "__no_user__";
+  const viewerChat = viewer.chatId ?? "__no_chat__";
+
+  const rows = await pool.query<{ id: string }>(
+    `SELECT c.id
+       FROM semantic.chunks c
+      WHERE c.id = ANY($1::uuid[])
+        AND (
+          -- T0: truly agent-global facts — NO sender AND NO chat anchor.
+          --     A chunk tagged only with anchor_chat_id is chat-scoped,
+          --     not global; it falls under TC below.
+          (
+            NOT EXISTS (
+              SELECT 1 FROM semantic.chunk_indexes vci
+               WHERE vci.chunk_id = c.id
+                 AND vci.kind = 'anchor_sender_id'
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM semantic.chunk_indexes vci
+               WHERE vci.chunk_id = c.id
+                 AND vci.kind = 'anchor_chat_id'
+            )
+          )
+          OR
+          -- TA: about the viewer (their own facts; cross-chat-visible)
+          EXISTS (
+            SELECT 1 FROM semantic.chunk_indexes vci
+             WHERE vci.chunk_id = c.id
+               AND vci.kind = 'anchor_sender_id'
+               AND vci.value = $2
+          )
+          OR
+          -- TC: spoken in viewer's current chat AND not marked private
+          (
+            EXISTS (
+              SELECT 1 FROM semantic.chunk_indexes vci
+               WHERE vci.chunk_id = c.id
+                 AND vci.kind = 'anchor_chat_id'
+                 AND vci.value = $3
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM semantic.chunk_indexes vci
+               WHERE vci.chunk_id = c.id
+                 AND vci.kind = 'anchor_visibility'
+                 AND vci.value = 'private'
+            )
+          )
+        )
+        AND NOT EXISTS (
+          -- BLOCK: explicitly private chunks owned by someone other than viewer
+          SELECT 1 FROM semantic.chunk_indexes ci_priv
+           WHERE ci_priv.chunk_id = c.id
+             AND ci_priv.kind = 'anchor_visibility'
+             AND ci_priv.value = 'private'
+             AND NOT EXISTS (
+               SELECT 1 FROM semantic.chunk_indexes ci_owner
+                WHERE ci_owner.chunk_id = c.id
+                  AND ci_owner.kind = 'anchor_sender_id'
+                  AND ci_owner.value = $2
+             )
+        )`,
+    [chunkIds, viewerUser, viewerChat],
+  );
+  return new Set(rows.rows.map((r) => r.id));
+}
+
+/**
+ * Build the SQL fragment + bind values implementing the visibility rules above.
+ *
+ * `paramStartIndex` is the next available $N (1-based). Returns
+ * `{ whereSql, params, paramCount }` so the caller can splice the fragment
+ * into a larger query at the right position.
+ *
+ * If `viewer` is omitted or empty, returns a no-op (`whereSql = "TRUE"`).
+ * This preserves backward compatibility with single-user / DM-only callers
+ * who haven't migrated to the viewer model yet.
+ */
+export function buildViewerScopeFilter(
+  viewer: ViewerScope | undefined,
+  paramStartIndex: number,
+): ViewerFilterFragment {
+  if (!viewer || (!viewer.userId && !viewer.chatId)) {
+    return { whereSql: "TRUE", params: [], paramCount: 0 };
+  }
+
+  const params: string[] = [];
+  let p = paramStartIndex;
+
+  // We always need viewerUserId in scope; if absent, treat as a magic sentinel
+  // that never matches any sender, which means TA never fires and only T0 / TC
+  // visibility remains. Useful for system-side calls.
+  const viewerUserParam = `$${p}`; params.push(viewer.userId ?? "__no_user__"); p += 1;
+  const viewerChatParam = `$${p}`; params.push(viewer.chatId ?? "__no_chat__"); p += 1;
+
+  const whereSql = `
+    (
+      -- T0: truly agent-global (NO sender AND NO chat anchor)
+      (
+        NOT EXISTS (
+          SELECT 1 FROM semantic.chunk_indexes vci
+           WHERE vci.chunk_id = c.id
+             AND vci.kind = 'anchor_sender_id'
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM semantic.chunk_indexes vci
+           WHERE vci.chunk_id = c.id
+             AND vci.kind = 'anchor_chat_id'
+        )
+      )
+      OR
+      -- TA: about the viewer (their own facts; cross-chat-visible)
+      EXISTS (
+        SELECT 1 FROM semantic.chunk_indexes vci
+         WHERE vci.chunk_id = c.id
+           AND vci.kind = 'anchor_sender_id'
+           AND vci.value = ${viewerUserParam}
+      )
+      OR
+      -- TC: spoken in viewer's current chat AND not marked private
+      (
+        EXISTS (
+          SELECT 1 FROM semantic.chunk_indexes vci
+           WHERE vci.chunk_id = c.id
+             AND vci.kind = 'anchor_chat_id'
+             AND vci.value = ${viewerChatParam}
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM semantic.chunk_indexes vci
+           WHERE vci.chunk_id = c.id
+             AND vci.kind = 'anchor_visibility'
+             AND vci.value = 'private'
+        )
+      )
+    )
+    AND
+    -- BLOCK: explicitly private chunks owned by someone other than viewer
+    NOT EXISTS (
+      SELECT 1 FROM semantic.chunk_indexes ci_priv
+       WHERE ci_priv.chunk_id = c.id
+         AND ci_priv.kind = 'anchor_visibility'
+         AND ci_priv.value = 'private'
+         AND NOT EXISTS (
+           SELECT 1 FROM semantic.chunk_indexes ci_owner
+            WHERE ci_owner.chunk_id = c.id
+              AND ci_owner.kind = 'anchor_sender_id'
+              AND ci_owner.value = ${viewerUserParam}
+         )
+    )
+  `;
+
+  return { whereSql, params, paramCount: p - paramStartIndex };
+}

--- a/src/recall/working-set.ts
+++ b/src/recall/working-set.ts
@@ -123,18 +123,28 @@ function jaccardOverlap(a: string, b: string): number {
 const REGISTRY = new Map<string, WorkingSet>();
 
 /**
- * Working set is keyed by `<agentId>::<sessionId>` so isolation holds even
- * when sessionId is missing — without the agent prefix, two different
- * agents (main/club) without a session would share the same working set
- * and one could pull the other's recently-promoted chunks (real leak path
- * caught during isolation testing).
+ * Working set is keyed by `<agentId>::<sessionId>::<viewerUserId>` so
+ * isolation holds even when sessionId is missing. Three layered concerns:
+ *
+ *   - agentId prefix prevents two different agents (main/club) without a
+ *     session from sharing the same WS (caught during isolation testing).
+ *   - sessionId scopes per chat / channel pairing — different DMs get
+ *     different sets.
+ *   - viewerUserId scopes per HUMAN inside a group chat. Without this,
+ *     a group chat (one sessionId, many students) would let student-A's
+ *     pinned profile chunks surface in student-B's T0 lookups. With it,
+ *     each student gets their own warm-cache view of the group.
+ *
+ * `viewerUserId` defaults to "default" so DM-only callers keep their
+ * current behavior unchanged (sessionId already distinguishes peers).
  */
 export function workingSetFor(
   sessionId: string | undefined,
   maxSize: number,
   agentId: string | undefined = "main",
+  viewerUserId: string | undefined = "default",
 ): WorkingSet {
-  const key = `${agentId ?? "main"}::${sessionId ?? "default"}`;
+  const key = `${agentId ?? "main"}::${sessionId ?? "default"}::${viewerUserId ?? "default"}`;
   let set = REGISTRY.get(key);
   if (!set) {
     set = new WorkingSet(maxSize);

--- a/src/storage/schema/29-cache-qa.sql
+++ b/src/storage/schema/29-cache-qa.sql
@@ -1,0 +1,81 @@
+-- ============================================================================
+-- cache.qa — semantic Q&A cache (GPTCache-style)
+--
+-- Tutoring + customer-service workloads are >50% duplicate questions
+-- across the lifetime of a class / product line. Without this layer
+-- every "怎么算 1/3 + 1/4" goes through a full LLM call (~30-60s,
+-- $0.X). With it, the second+ identical-or-similar question costs
+-- ~50ms and 0 tokens.
+--
+-- Two access paths:
+--   1. Exact-match  — sha256(question_text)         <5 ms
+--   2. Semantic     — HNSW on question_embedding   ~50 ms
+--
+-- Viewer-scoped via the SAME three-tier filter used for chat-memory
+-- (see src/recall/viewer-scope.ts). cache entries with scope_chat_id /
+-- visibility=private get hidden from viewers who don't match.
+--
+-- Cacheability is decided per-write (default false; explicit opt-in
+-- via the `cacheable` column). The Moderator (Phase C) or a CSV-seed
+-- can mark entries cacheable; the agent's own write tool defaults
+-- to NOT cacheable so personalisation leaks are off-by-default.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS cache.qa (
+  id                 UUID PRIMARY KEY,
+  agent_id           TEXT NOT NULL DEFAULT 'main',
+
+  -- the question (verbatim + embedding for exact + semantic hits)
+  question_text      TEXT  NOT NULL,
+  question_hash      BYTEA NOT NULL,
+  question_embedding VECTOR NOT NULL,
+  embedding_model    TEXT  NOT NULL,
+
+  -- the cached answer
+  answer_text        TEXT NOT NULL,
+  answer_format      TEXT NOT NULL DEFAULT 'plain',  -- 'plain' | 'markdown' | 'latex'
+
+  -- scope — joins to the existing viewer-scope rules
+  scope_chat_id      TEXT,         -- NULL = global; non-NULL = per-group / per-DM
+  scope_sender_id    TEXT,         -- NULL = anyone; non-NULL = only that user (private)
+  scope_visibility   TEXT NOT NULL DEFAULT 'public',  -- 'public' | 'private' | 'chat-only'
+  cacheable          BOOLEAN NOT NULL DEFAULT TRUE,   -- 'false' tombstones an old entry
+  topic_tag          TEXT,         -- 'math.fractions', 'policy.returns', ...
+
+  -- source attribution
+  worker_role_id     UUID,         -- which role wrote it (FK in Phase D)
+  source             TEXT NOT NULL DEFAULT 'agent',  -- 'agent' | 'csv-seed' | 'manual'
+  source_doc_id      TEXT,         -- e.g. 'returns-policy' when seeded from a doc
+
+  -- quality
+  upvotes            INT NOT NULL DEFAULT 0,
+  downvotes          INT NOT NULL DEFAULT 0,
+  use_count          INT NOT NULL DEFAULT 0,
+  last_used_at       TIMESTAMPTZ,
+
+  -- lifecycle
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at         TIMESTAMPTZ NOT NULL,  -- default +90d, set at insert
+  invalidated        BOOLEAN NOT NULL DEFAULT FALSE,
+  invalidated_reason TEXT
+);
+
+-- Exact-match index (fast path).
+CREATE INDEX IF NOT EXISTS cache_qa_hash
+  ON cache.qa (agent_id, question_hash)
+  WHERE NOT invalidated AND cacheable;
+
+-- Scope-narrowed lookup for viewer-aware filtering at SQL layer.
+CREATE INDEX IF NOT EXISTS cache_qa_scope
+  ON cache.qa (agent_id, scope_chat_id, scope_sender_id)
+  WHERE NOT invalidated AND cacheable;
+
+-- Quality leaderboard for dashboard.
+CREATE INDEX IF NOT EXISTS cache_qa_quality
+  ON cache.qa ((upvotes - downvotes) DESC, use_count DESC)
+  WHERE NOT invalidated AND cacheable;
+
+-- HNSW on embedding. Dim is locked at first insert (same as semantic.chunks).
+-- The migrate runner can add this lazily once an embedding has been written.
+-- We don't define it here so the migrate step matches the existing
+-- ensureHnswIndex pattern for semantic.chunks.

--- a/src/storage/schema/30-moderator-state.sql
+++ b/src/storage/schema/30-moderator-state.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Moderator state — Phase C
+--
+-- The Moderator is a persistent, "always-alert" agent per (agent_id,
+-- scope_key) where scope_key is the Telegram chat id (or "dm:<user>")
+-- it's responsible for. It receives every inbound message, decides
+-- (ignore / answer-direct / decompose / write-only / clarify / escalate),
+-- spawns worker codex runs, manages a roster of worker roles, and writes
+-- back to the chat.
+--
+-- State is kept in a single JSONB column rather than 8 sub-tables because
+--   (a) the shape will evolve quickly during prompt iteration;
+--   (b) one indexed row per scope makes load/save O(1);
+--   (c) JSONB is queryable enough for dashboard panels without joins.
+--
+-- The audit trail of decisions is separate (moderator.decisions) so we
+-- have an append-only log of every routing choice for replay + tuning.
+-- ============================================================================
+
+CREATE SCHEMA IF NOT EXISTS moderator;
+
+-- one row per (agent_id, scope_key) — scope_key is the persistent
+-- conversation identifier ("tg:chat:<chat_id>" or "tg:dm:<user_id>")
+CREATE TABLE IF NOT EXISTS moderator.state (
+  agent_id        TEXT NOT NULL DEFAULT 'main',
+  scope_key       TEXT NOT NULL,                         -- e.g. tg:chat:-100..., tg:dm:8064984663
+  state           JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- 'live' = active; 'paused' = takeover by human; 'archived' = inactive scope
+  status          TEXT NOT NULL DEFAULT 'live',
+  -- bookkeeping
+  message_count   BIGINT NOT NULL DEFAULT 0,
+  decision_count  BIGINT NOT NULL DEFAULT 0,
+  last_message_at TIMESTAMPTZ,
+  last_review_at  TIMESTAMPTZ,
+  paused_by       TEXT,                                  -- user id who issued /takeover
+  paused_reason   TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (agent_id, scope_key)
+);
+
+CREATE INDEX IF NOT EXISTS moderator_state_status
+  ON moderator.state (status, last_message_at DESC)
+  WHERE status = 'live';
+
+CREATE INDEX IF NOT EXISTS moderator_state_last_msg
+  ON moderator.state (last_message_at DESC NULLS LAST);
+
+-- append-only log of every Moderator decision (one row per LLM call)
+-- for tuning + replay + dashboard "what's the bot thinking" view.
+CREATE TABLE IF NOT EXISTS moderator.decisions (
+  id               UUID PRIMARY KEY,
+  agent_id         TEXT NOT NULL DEFAULT 'main',
+  scope_key        TEXT NOT NULL,
+  ts               TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- what triggered the decision
+  trigger_kind     TEXT NOT NULL,            -- 'message' | 'cron' | 'worker-result'
+  trigger_user_id  TEXT,                     -- sender of the message (NULL for cron)
+  trigger_text     TEXT,                     -- truncated for storage; full in audit if needed
+
+  -- what the LLM decided
+  action           TEXT NOT NULL,            -- ignore | answer-direct | answer-decompose | write-only | clarify | escalate
+  rationale        TEXT,                     -- one-liner why
+  decision_json    JSONB NOT NULL,           -- the full parsed decision
+
+  -- LLM bookkeeping
+  model            TEXT,                     -- e.g. openai/gpt-5.5
+  input_tokens     INT,
+  output_tokens    INT,
+  latency_ms       INT,
+
+  -- outcome
+  workers_spawned  INT NOT NULL DEFAULT 0,
+  errors           TEXT[]
+);
+
+CREATE INDEX IF NOT EXISTS moderator_decisions_scope_ts
+  ON moderator.decisions (scope_key, ts DESC);
+CREATE INDEX IF NOT EXISTS moderator_decisions_action
+  ON moderator.decisions (action, ts DESC);
+
+-- Worker roles registered by the Moderator (or seeded by the operator).
+-- "long-lived role, short-lived invocation" — the role row is the stable
+-- specialist definition; each invocation is a transient codex run.
+CREATE TABLE IF NOT EXISTS moderator.worker_roles (
+  id               UUID PRIMARY KEY,
+  agent_id         TEXT NOT NULL DEFAULT 'main',
+  role_key         TEXT NOT NULL,            -- stable id: 'math_tutor_grade5', 'returns_specialist'
+  display_name     TEXT,
+  system_prompt    TEXT NOT NULL,
+  tools            TEXT[] NOT NULL DEFAULT '{}',   -- which agent tools this role gets
+  memory_scope     JSONB NOT NULL DEFAULT '{}',    -- { kind_filter, topic_filter, ... } for memory_search
+  model            TEXT NOT NULL DEFAULT 'openai/gpt-5.5',
+  -- lifecycle
+  created_by_scope TEXT,                     -- which scope created this role (null = seeded)
+  ttl_idle_minutes INT NOT NULL DEFAULT 30,
+  invocation_count BIGINT NOT NULL DEFAULT 0,
+  last_invoked_at  TIMESTAMPTZ,
+  active           BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (agent_id, role_key)
+);
+
+CREATE INDEX IF NOT EXISTS moderator_roles_agent
+  ON moderator.worker_roles (agent_id, active);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -39,6 +39,16 @@ const SEARCH_PARAMS = {
       pattern: "^\\d{4}-\\d{2}-\\d{2}$",
       description: "Optional ISO date YYYY-MM-DD to filter by.",
     },
+    viewerUserId: {
+      type: "string",
+      description:
+        "Advanced. The human asking. In multi-user groups, set this to scope recall to chunks visible to that specific user (per-user-global facts + group-public facts). Auto-derived from session key for DMs.",
+    },
+    viewerChatId: {
+      type: "string",
+      description:
+        "Advanced. The chat the question was asked in (telegram chat id). Used together with viewerUserId for group privacy filtering. Omit for DM.",
+    },
   },
 } as const;
 
@@ -77,7 +87,35 @@ type SearchParams = {
   branch?: string;
   pr?: string;
   timeBucket?: string;
+  viewerUserId?: string;
+  viewerChatId?: string;
 };
+
+/**
+ * Best-effort viewer extraction from session keys.
+ *
+ *   agent:<aid>:telegram:direct:<userId>       → DM, viewer = userId
+ *   agent:<aid>:telegram:group:<chatId>        → group, viewer.chatId only
+ *   agent:<aid>:telegram:group:<chat>:topic:<t> → forum, chatId only
+ *   agent:<aid>:main                            → legacy, no viewer
+ *
+ * Returns undefined fields when the session key doesn't encode them. The
+ * caller (memory_search tool body) merges explicit params on top of these
+ * inferences so Moderator-style callers can override.
+ */
+function viewerFromSessionKey(sessionKey: string | undefined): {
+  userId?: string;
+  chatId?: string;
+} {
+  if (!sessionKey) {return {};}
+  // DM: agent:<aid>:<channel>:direct:<userId>
+  const dm = /^agent:[^:]+:[^:]+:direct:([^:]+)/.exec(sessionKey);
+  if (dm) {return { userId: dm[1] };}
+  // Group: agent:<aid>:<channel>:group:<chatId>(:topic:<t>)?
+  const grp = /^agent:[^:]+:[^:]+:group:([^:]+)/.exec(sessionKey);
+  if (grp) {return { chatId: grp[1] };}
+  return {};
+}
 
 type StoreParams = {
   text: string;
@@ -217,6 +255,12 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
     async execute(this: void, _toolCallId: string, params: unknown): Promise<{ content: unknown; details: unknown }> {
       const p = params as SearchParams;
       const { cfg, pool, embedding } = await setup(pluginConfigOf(args.config));
+      // Viewer inference: start from session key, let explicit params override.
+      const inferredViewer = viewerFromSessionKey(args.sessionKey);
+      const viewer = {
+        userId: p.viewerUserId ?? inferredViewer.userId,
+        chatId: p.viewerChatId ?? inferredViewer.chatId,
+      };
       const result = await recall(
         { cfg, pool, embedding },
         {
@@ -230,6 +274,9 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
           timeBucket: p.timeBucket,
           agentSessionId: args.sessionKey,
           agentId: agentIdFromSessionKey(args.sessionKey),
+          // Only attach viewer when we actually have something to filter on;
+          // an empty viewer object signals "no filtering" to the router.
+          viewer: viewer.userId || viewer.chatId ? viewer : undefined,
         },
       );
 

--- a/tools/kb-ingest-md.mjs
+++ b/tools/kb-ingest-md.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Minimal markdown KB ingester for nextclaw.
+ *
+ * Reads `*.md` files from a directory, splits each by `##` heading,
+ * further splits long sections by paragraph, and POSTs each chunk to
+ * nextclaw's dashboard `/api/ingest` endpoint with `kind='knowledge'`
+ * + anchors that put the chunks under the right doc / topic / scope.
+ *
+ * This is a CLI proof-of-concept of Phase B++. A proper CLI integration
+ * into the `nextclaw` binary, support for PDF/DOCX/CSV, versioning,
+ * and a dashboard upload UI come later.
+ *
+ * Usage:
+ *   NEXTCLAW_DASH_TOKEN=... node tools/kb-ingest-md.mjs \
+ *     --dir "/path/to/markdown/dir" \
+ *     --doc-id ai-course-week1 \
+ *     --topic ai-course-setup \
+ *     [--scope global | --scope chat:-100123 | --scope user:8064984663] \
+ *     [--api http://127.0.0.1:8765]
+ */
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import { resolve, basename, join, extname, relative } from "node:path";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i].replace(/^--/, ""), process.argv[i + 1]);
+}
+
+const dir = args.get("dir");
+const docId = args.get("doc-id") ?? (dir ? basename(dir) : null);
+const topic = args.get("topic");
+const scope = args.get("scope") ?? "global";
+const apiBase = args.get("api") ?? "http://127.0.0.1:8765";
+const agentId = args.get("agent-id") ?? "main";
+const version = args.get("version") ?? "v1";
+const dashToken = process.env.NEXTCLAW_DASH_TOKEN;
+
+if (!dir || !docId || !dashToken) {
+  console.error(
+    "usage: NEXTCLAW_DASH_TOKEN=... node kb-ingest-md.mjs --dir <path> --doc-id <id> [--topic X] [--scope global|chat:<id>|user:<id>] [--version v1] [--api http://127.0.0.1:8765]",
+  );
+  process.exit(2);
+}
+
+const anchors = { sender_label: `kb:${docId}` };
+{
+  const m = /^chat:(.+)$/.exec(scope);
+  const u = /^user:(.+)$/.exec(scope);
+  if (m) {anchors.chat_id = m[1];}
+  if (u) {anchors.sender_id = u[1]; anchors.visibility = "private";}
+}
+
+const stats = {
+  filesSeen: 0,
+  filesProcessed: 0,
+  chunksWritten: 0,
+  chunksRejected: 0,
+  errors: [],
+};
+
+/**
+ * Split a markdown body into chunks by `##` heading. If a section is
+ * longer than `maxChars`, further split by blank-line paragraphs. Each
+ * chunk has the form `{ heading, body }` where `heading` is the most
+ * recent `##` (or empty for content before the first heading).
+ */
+function splitMarkdown(body, maxChars = 1500) {
+  const lines = body.split("\n");
+  /** @type {{heading: string, body: string}[]} */
+  const sections = [];
+  let currentHeading = "";
+  let currentBody = [];
+  const flush = () => {
+    const text = currentBody.join("\n").trim();
+    if (text.length > 0) {sections.push({ heading: currentHeading, body: text });}
+    currentBody = [];
+  };
+  for (const line of lines) {
+    // ## or ### are section breaks; # is the doc title, skip
+    const m = /^(##{1,2})\s+(.+)$/.exec(line);
+    if (m && !line.startsWith("####")) {
+      flush();
+      currentHeading = m[2].trim();
+      continue;
+    }
+    currentBody.push(line);
+  }
+  flush();
+
+  // If a section exceeds maxChars, split by blank lines, group up to maxChars.
+  /** @type {{heading: string, body: string}[]} */
+  const out = [];
+  for (const sec of sections) {
+    if (sec.body.length <= maxChars) {
+      out.push(sec);
+      continue;
+    }
+    const paragraphs = sec.body.split(/\n\n+/);
+    let buf = [];
+    let bufLen = 0;
+    for (const p of paragraphs) {
+      if (bufLen + p.length > maxChars && buf.length > 0) {
+        out.push({ heading: sec.heading, body: buf.join("\n\n") });
+        buf = [p];
+        bufLen = p.length;
+      } else {
+        buf.push(p);
+        bufLen += p.length;
+      }
+    }
+    if (buf.length > 0) {out.push({ heading: sec.heading, body: buf.join("\n\n") });}
+  }
+  // Drop tiny chunks (< 80 chars are likely just headings without content).
+  return out.filter((s) => s.body.length >= 80);
+}
+
+async function ingestChunk(text, sourceRef, extraAnchors) {
+  const body = {
+    text,
+    source: `kb:${docId}`,
+    kind: "knowledge",
+    agentId,
+    importance: 0.7,
+    retentionClass: "pinned",
+    anchors: {
+      ...anchors,
+      ...extraAnchors,
+      kb_doc: docId,
+      kb_version: version,
+      ...(topic ? { topic } : {}),
+    },
+  };
+  body.sourceRef = sourceRef;
+  const resp = await fetch(`${apiBase}/api/ingest`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-token": dashToken,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const t = await resp.text().catch(() => "");
+    throw new Error(`HTTP ${resp.status}: ${t.slice(0, 200)}`);
+  }
+  const j = await resp.json();
+  return j;
+}
+
+async function processFile(absPath, baseDir) {
+  stats.filesSeen += 1;
+  const ext = extname(absPath).toLowerCase();
+  if (ext !== ".md") {return;}
+  const rel = relative(baseDir, absPath);
+  const raw = await readFile(absPath, "utf8");
+  const sections = splitMarkdown(raw);
+  if (sections.length === 0) {
+    console.log(`  [skip] ${rel} — no sections >= 80 chars`);
+    return;
+  }
+  console.log(`  [parse] ${rel} → ${sections.length} sections`);
+  let ok = 0;
+  let rej = 0;
+  for (const [idx, sec] of sections.entries()) {
+    const sourceRef = `${rel}:${sec.heading || `section-${idx + 1}`}`;
+    // Pre-pend the heading so embedding has a clue what the chunk's topic is
+    const text = sec.heading
+      ? `${sec.heading}\n\n${sec.body}`
+      : sec.body;
+    try {
+      const result = await ingestChunk(text, sourceRef, {});
+      if (result?.outcome?.decision === "accepted") {
+        ok += 1;
+      } else if (result?.outcome?.decision === "merged") {
+        ok += 1;
+        // Merged is fine; same chunk already there
+      } else {
+        rej += 1;
+        if (rej <= 2) {
+          console.log(`    [reject] ${sec.heading}: ${result?.outcome?.decision}/${result?.outcome?.rejectReason}`);
+        }
+      }
+    } catch (err) {
+      rej += 1;
+      stats.errors.push(`${rel}:${sec.heading} → ${err.message}`);
+    }
+  }
+  stats.chunksWritten += ok;
+  stats.chunksRejected += rej;
+  stats.filesProcessed += 1;
+  console.log(`         → accepted ${ok}, rejected ${rej}`);
+}
+
+async function walk(p, baseDir) {
+  const st = await stat(p);
+  if (st.isFile()) {
+    await processFile(p, baseDir);
+    return;
+  }
+  if (st.isDirectory()) {
+    const entries = await readdir(p);
+    for (const e of entries) {
+      if (e.startsWith(".")) {continue;}
+      await walk(join(p, e), baseDir);
+    }
+  }
+}
+
+const startedAt = Date.now();
+console.log(`KB ingest:\n  dir=${dir}\n  doc-id=${docId}\n  scope=${scope}\n  topic=${topic ?? "(none)"}\n  version=${version}`);
+const baseDir = resolve(dir);
+await walk(baseDir, baseDir);
+const elapsedMs = Date.now() - startedAt;
+
+console.log("\n=== summary ===");
+console.log(`  files seen:        ${stats.filesSeen}`);
+console.log(`  files processed:   ${stats.filesProcessed}`);
+console.log(`  chunks written:    ${stats.chunksWritten}`);
+console.log(`  chunks rejected:   ${stats.chunksRejected}`);
+console.log(`  errors:            ${stats.errors.length}`);
+if (stats.errors.length > 0 && stats.errors.length <= 10) {
+  for (const e of stats.errors) {console.log(`    - ${e}`);}
+}
+console.log(`  elapsed:           ${(elapsedMs / 1000).toFixed(1)}s`);

--- a/tools/kb-intake.mjs
+++ b/tools/kb-intake.mjs
@@ -240,6 +240,11 @@ async function main() {
       const result = await ingestPdf(targetPath, sharedCtx);
       chunksWritten = result.chunksWritten;
       ingestErrors = result.errors;
+    } else if (ext === ".csv") {
+      const result = await ingestCsv(targetPath, sharedCtx);
+      chunksWritten = result.chunksWritten;
+      ingestErrors = result.errors;
+      console.log(`         (Q&A rows pre-seeded to cache.qa: ${result.cacheRowsSeeded})`);
     } else {
       ingestErrors.push(`parser for ${ext} not implemented yet`);
     }
@@ -277,8 +282,8 @@ async function main() {
 }
 
 function ingestEligibility(ext) {
-  const supported = new Set([".md", ".markdown", ".txt", ".pdf"]);
-  const pending = new Set([".docx", ".csv", ".html", ".htm"]);
+  const supported = new Set([".md", ".markdown", ".txt", ".pdf", ".csv"]);
+  const pending = new Set([".docx", ".html", ".htm"]);
   const storeOnly = new Set([".png", ".jpg", ".jpeg", ".heic", ".mp3", ".ogg", ".wav", ".m4a", ".mp4", ".mov"]);
   if (supported.has(ext)) {return { canIngest: true, parser: ext.replace(".", "") };}
   if (pending.has(ext)) {return { canIngest: false, reason: `${ext.slice(1)} parser not yet implemented` };}
@@ -326,6 +331,124 @@ async function ingestMarkdown(absPath, { docId, version, decision, hints, sender
     }
   }
   return { chunksWritten: ok, errors };
+}
+
+/* ---------------------------------- csv ----------------------------------- */
+/**
+ * CSV ingest with auto-detection of Q&A columns.
+ *
+ * If the CSV header contains a column matching /question|问|q/i AND another
+ * matching /answer|答|a/i, the file is treated as a Q&A pre-seed:
+ *   - Each row's `answer` is ingested as a knowledge chunk (with `question`
+ *     prepended as the heading).
+ *   - The (question, answer) pair is ALSO posted to /api/cache/store so
+ *     `cache.qa` is primed — the most common student/customer Qs answer in
+ *     ~50ms with 0 LLM tokens from the very first ask, no warm-up needed.
+ *
+ * If the CSV is a generic table (no Q&A columns), each row becomes a chunk
+ * formatted as `<col1>: <val1> / <col2>: <val2> / ...`.
+ *
+ * Topic per row: an optional `topic` / `category` column wins, else falls
+ * back to the doc-level topic from caption hints.
+ */
+async function ingestCsv(absPath, ctx) {
+  const { docId, version, decision, hints, senderUserId, chatId, ownerId } = ctx;
+  const { parse } = await import("csv-parse/sync");
+  const raw = await readFile(absPath, "utf8");
+  let rows;
+  try {
+    rows = parse(raw, {
+      columns: true,
+      skip_empty_lines: true,
+      relax_column_count: true,
+      trim: true,
+    });
+  } catch (err) {
+    return { chunksWritten: 0, cacheRowsSeeded: 0, errors: [`csv-parse failed: ${err.message}`] };
+  }
+  if (rows.length === 0) {
+    return { chunksWritten: 0, cacheRowsSeeded: 0, errors: ["csv has zero data rows"] };
+  }
+  const headers = Object.keys(rows[0]);
+  const qCol = headers.find((h) => /^(question|q|问题?|提问)$/i.test(h));
+  const aCol = headers.find((h) => /^(answer|a|答案?|回答)$/i.test(h));
+  const topicCol = headers.find((h) => /^(topic|category|话题|分类)$/i.test(h));
+
+  const anchors = buildAnchors(ctx);
+  let chunksWritten = 0;
+  let cacheRowsSeeded = 0;
+  const errors = [];
+
+  for (const [idx, row] of rows.entries()) {
+    const rowTopic = (topicCol && row[topicCol]) || hints.topic || null;
+
+    // Build text for ingest chunk.
+    let text;
+    let sourceRef;
+    if (qCol && aCol) {
+      const q = String(row[qCol] ?? "").trim();
+      const a = String(row[aCol] ?? "").trim();
+      if (!q || !a) {continue;}
+      text = `Q: ${q}\nA: ${a}`;
+      sourceRef = `${docId}:v${version}:row:${idx + 1}`;
+
+      // Pre-seed cache.qa
+      try {
+        const cacheR = await fetch(`${apiBase}/api/cache/store`, {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-token": dashToken },
+          body: JSON.stringify({
+            agentId: "main",
+            question: q,
+            answer: a,
+            answerFormat: "plain",
+            scope: {
+              chatId: anchors.chat_id,
+              senderId: anchors.sender_id,
+              visibility: anchors.visibility ?? "public",
+            },
+            topicTag: rowTopic,
+            source: "csv-seed",
+            sourceDocId: docId,
+            ttlDays: 365, // CSV-seeded entries are curated; longer TTL
+          }),
+        });
+        if (cacheR.ok) {cacheRowsSeeded += 1;}
+      } catch (err) {
+        errors.push(`row:${idx + 1} cache-seed: ${err.message}`);
+      }
+    } else {
+      // Generic row — flatten as "col: val | col: val" for ingest.
+      const parts = headers.filter((h) => row[h]).map((h) => `${h}: ${row[h]}`);
+      text = parts.join(" | ");
+      sourceRef = `${docId}:v${version}:row:${idx + 1}`;
+      if (text.length < 80) {continue;}
+    }
+
+    try {
+      const r = await fetch(`${apiBase}/api/ingest`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-token": dashToken },
+        body: JSON.stringify({
+          text,
+          source: `kb:${docId}`,
+          sourceRef,
+          kind: "knowledge",
+          agentId: "main",
+          importance: 0.7,
+          retentionClass: "pinned",
+          anchors: { ...anchors, ...(rowTopic ? { scope: rowTopic } : {}) },
+        }),
+      });
+      if (!r.ok) {throw new Error(`HTTP ${r.status}`);}
+      const j = await r.json();
+      if (j?.outcome?.decision === "accepted" || j?.outcome?.decision === "merged") {chunksWritten += 1;}
+    } catch (err) {
+      errors.push(`row:${idx + 1} ingest: ${err.message}`);
+    }
+  }
+
+  return { chunksWritten, cacheRowsSeeded, errors };
 }
 
 /* ---------------------------------- pdf ----------------------------------- */

--- a/tools/kb-intake.mjs
+++ b/tools/kb-intake.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+/**
+ * Unified KB intake — applies the folder taxonomy + audit + ingest
+ * pipeline for a single uploaded file.
+ *
+ * This is the ONLY tool that decides where uploaded content goes.
+ * Telegram bot, manual scp, dashboard upload UI, future channels —
+ * all call this with the same metadata schema, and the taxonomy is
+ * enforced mechanically (see docs/KB_TAXONOMY.md).
+ *
+ * Usage:
+ *   NEXTCLAW_DASH_TOKEN=... node tools/kb-intake.mjs \
+ *     --file <path-to-file> \
+ *     --sender-user-id <telegram user id, or "teacher" for owner-via-scp> \
+ *     [--chat-id <telegram chat id; omit for DM>] \
+ *     [--chat-type private|group|supergroup] \
+ *     [--caption "the message caption, supports #hashtag hints"] \
+ *     [--owner-id <telegram user id of the bot owner>] \
+ *     [--course-id ai-course]    # explicit override
+ *     [--topic week1]            # explicit override
+ *     [--doc-id week3-homework]  # explicit override (stable across versions)
+ *     [--kb-root /home/ubuntu/.openclaw/kb] \
+ *     [--api http://127.0.0.1:8765] \
+ *     [--no-ingest]              # save file but skip nextclaw ingest
+ *     [--dry-run]                # show planned action, don't touch fs
+ */
+
+import { readFile, mkdir, copyFile, appendFile, stat, readdir } from "node:fs/promises";
+import { resolve, basename, extname, join, dirname, relative } from "node:path";
+
+/* ----------------------------------- args ---------------------------------- */
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const a = process.argv[i];
+  if (!a.startsWith("--")) {continue;}
+  const k = a.slice(2);
+  const nxt = process.argv[i + 1];
+  if (nxt === undefined || nxt.startsWith("--")) {
+    args.set(k, "true");
+  } else {
+    args.set(k, nxt); i += 1;
+  }
+}
+
+const filePath = args.get("file");
+const senderUserId = args.get("sender-user-id");
+const ownerId = args.get("owner-id") ?? "8064984663"; // Yao by default for this deployment
+const chatId = args.get("chat-id");
+const chatType = args.get("chat-type") ?? (chatId ? "supergroup" : "private");
+const caption = args.get("caption") ?? "";
+const overrideCourseId = args.get("course-id");
+const overrideTopic = args.get("topic");
+const overrideDocId = args.get("doc-id");
+const kbRoot = args.get("kb-root") ?? process.env.OPENCLAW_KB_ROOT ?? "/home/ubuntu/.openclaw/kb";
+const apiBase = args.get("api") ?? "http://127.0.0.1:8765";
+const noIngest = args.get("no-ingest") === "true";
+const dryRun = args.get("dry-run") === "true";
+const dashToken = process.env.NEXTCLAW_DASH_TOKEN;
+
+if (!filePath || !senderUserId) {
+  console.error("usage: --file <path> --sender-user-id <id> [--chat-id <id>] [--caption ...]");
+  process.exit(2);
+}
+if (!dashToken && !noIngest && !dryRun) {
+  console.error("NEXTCLAW_DASH_TOKEN env required when ingesting. Pass --no-ingest to skip.");
+  process.exit(2);
+}
+
+/* -------------------------- caption hashtag parser ------------------------- */
+function parseCaption(s) {
+  const hints = {};
+  const tags = s.match(/#[\w-]+/g) ?? [];
+  for (const t of tags) {
+    if (t === "#share") {hints.share = true;}
+    if (t === "#teacher-only") {hints.teacherOnly = true;}
+    if (t === "#homework") {hints.homework = true;}
+    // #week3 / #weekN attached form
+    const week = /#week(\d+)/i.exec(t);
+    if (week) {hints.week = `week${week[1]}`;}
+  }
+  // Inline key value style: `#topic fractions`, `#course ai-course`, `#week 1`, `#doc-id X`, `#version 2`
+  const kvPairs = s.match(/#(?:topic|course|doc-id|docid|version|week)\s+\S+/gi) ?? [];
+  for (const kv of kvPairs) {
+    const m = /#(\w[\w-]*)\s+(\S+)/.exec(kv);
+    if (!m) {continue;}
+    const key = m[1].toLowerCase();
+    const val = m[2];
+    if (key === "week") {hints.week = `week${val.replace(/\D/g, "") || val}`;}
+    else if (key === "docid") {hints["doc-id"] = val;}
+    else {hints[key] = val;}
+  }
+  return hints;
+}
+
+/* ------------------------- chat-id path normaliser ------------------------- */
+// Telegram chat ids for groups/supergroups are negative; the folder name
+// strips the leading "-" so we don't end up with `tg--1001234567890`.
+function tgPath(id) {
+  return `tg-${String(id).replace(/^-/, "")}`;
+}
+
+/* -------------------------------- slugifier -------------------------------- */
+function slug(s) {
+  return String(s)
+    .toLowerCase()
+    .trim()
+    .replace(/[\s_]+/g, "-")
+    .replace(/[^a-z0-9一-鿿\-.]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/* -------------------------- routing decision tree -------------------------- */
+function decideTargetSubpath({ senderUserId, ownerId, chatId, chatType, hints }) {
+  const isOwner = senderUserId === ownerId || senderUserId === "teacher";
+  const isDM = chatType === "private" || !chatId;
+
+  // Caption-level overrides win first
+  if (hints.course) {
+    return { dir: ["courses", slug(hints.course), hints.week || hints.topic || "uploaded"], visibility: "public", scope: "global" };
+  }
+
+  if (isDM) {
+    if (isOwner) {
+      // Teacher in DM — staging area unless explicitly tagged
+      if (hints.topic || hints.week) {
+        return {
+          dir: ["courses", slug(overrideCourseId || "default"), slug(hints.week || hints.topic || "misc")],
+          visibility: "public",
+          scope: "global",
+        };
+      }
+      return { dir: ["inbox", isoDate()], visibility: "public", scope: "global" };
+    }
+    // Student in DM
+    if (hints.share) {
+      return { dir: ["students", `tg-${senderUserId}`, "shared-with-teacher"], visibility: "private", scope: "user" };
+    }
+    return {
+      dir: ["students", `tg-${senderUserId}`, hints.homework ? "homework" : "inbox"],
+      visibility: "private",
+      scope: "user",
+    };
+  }
+
+  // Group / supergroup
+  if (isOwner) {
+    if (hints.teacherOnly) {
+      return { dir: ["groups", tgPath(chatId), "teacher-only"], visibility: "private", scope: "chat" };
+    }
+    return { dir: ["groups", tgPath(chatId), "shared"], visibility: "public", scope: "chat" };
+  }
+  // Student in group
+  if (hints.share) {
+    return { dir: ["groups", tgPath(chatId), "shared"], visibility: "public", scope: "chat" };
+  }
+  // Default: treat as personal homework even in group
+  return {
+    dir: ["students", `tg-${senderUserId}`, hints.homework ? "homework" : "inbox"],
+    visibility: "private",
+    scope: "user",
+  };
+}
+
+function isoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function pathExists(p) {
+  try { await stat(p); return true; } catch { return false; }
+}
+
+async function nextVersion(targetDir, docId) {
+  if (!(await pathExists(targetDir))) {return 1;}
+  const entries = await readdir(targetDir);
+  const versions = entries
+    .map((e) => {
+      const m = new RegExp(`__${docId}__v(\\d+)\\.[^.]+$`).exec(e);
+      return m ? parseInt(m[1], 10) : 0;
+    })
+    .filter((v) => v > 0);
+  return Math.max(0, ...versions) + 1;
+}
+
+/* ----------------------------------- main ---------------------------------- */
+async function main() {
+  const absSrc = resolve(filePath);
+  if (!(await pathExists(absSrc))) {
+    console.error(`file not found: ${absSrc}`);
+    process.exit(3);
+  }
+  const origName = basename(absSrc);
+  const ext = extname(origName).toLowerCase();
+  const baseSlug = slug(origName.replace(ext, ""));
+  const docId = overrideDocId ? slug(overrideDocId) : baseSlug;
+  const hints = parseCaption(caption);
+
+  const decision = decideTargetSubpath({ senderUserId, ownerId, chatId, chatType, hints });
+  const targetDir = resolve(kbRoot, ...decision.dir);
+  const version = parseInt(hints.version || "0", 10) || (await nextVersion(targetDir, docId));
+  const versionedName = `${baseSlug}__${docId}__v${version}${ext}`;
+  const targetPath = join(targetDir, versionedName);
+  const relPath = relative(kbRoot, targetPath);
+
+  const eligibility = ingestEligibility(ext);
+  const willIngest = !noIngest && eligibility.canIngest;
+
+  console.log("=== intake plan ===");
+  console.log(`  source:        ${absSrc}`);
+  console.log(`  sender:        tg-${senderUserId}${senderUserId === ownerId ? " (owner)" : ""}`);
+  console.log(`  chat:          ${chatId ? `${tgPath(chatId)} (${chatType})` : "(DM)"}`);
+  console.log(`  caption hints: ${JSON.stringify(hints)}`);
+  console.log(`  target:        ${relPath}`);
+  console.log(`  doc-id:        ${docId}`);
+  console.log(`  version:       v${version}`);
+  console.log(`  visibility:    ${decision.visibility}`);
+  console.log(`  scope:         ${decision.scope}`);
+  console.log(`  ingest:        ${willIngest ? `yes (${eligibility.parser})` : `no (${eligibility.reason || "disabled"})`}`);
+
+  if (dryRun) {
+    console.log("\n(dry-run, no changes made)");
+    return;
+  }
+
+  // 1. Stage the file
+  await mkdir(targetDir, { recursive: true });
+  await copyFile(absSrc, targetPath);
+  console.log(`\nstaged → ${relPath}`);
+
+  // 2. Ingest if eligible
+  let chunksWritten = 0;
+  let ingestErrors = [];
+  if (willIngest) {
+    if (ext === ".md" || ext === ".markdown" || ext === ".txt") {
+      const result = await ingestMarkdown(targetPath, {
+        docId, version, decision, hints, senderUserId, chatId, ownerId,
+      });
+      chunksWritten = result.chunksWritten;
+      ingestErrors = result.errors;
+    } else {
+      ingestErrors.push(`parser for ${ext} not implemented yet`);
+    }
+    console.log(`ingested → ${chunksWritten} chunks, ${ingestErrors.length} errors`);
+  }
+
+  // 3. Audit log
+  const logEntry = {
+    ts: new Date().toISOString(),
+    source: chatId ? "telegram" : "telegram-dm",
+    sender_user_id: senderUserId,
+    owner_id: ownerId,
+    chat_id: chatId ?? null,
+    chat_type: chatType,
+    caption,
+    caption_hints: hints,
+    original_filename: origName,
+    saved_path: relPath,
+    format: ext.slice(1) || "(none)",
+    doc_id: docId,
+    version: `v${version}`,
+    visibility: decision.visibility,
+    scope: decision.scope,
+    chunks_written: chunksWritten,
+    chunks_status: willIngest
+      ? (ingestErrors.length === 0 ? "ok" : "partial")
+      : (eligibility.canIngest ? "skipped" : `pending-${ext.slice(1)}-support`),
+    errors: ingestErrors,
+  };
+  await appendFile(
+    join(kbRoot, "_meta", "upload-log.jsonl"),
+    JSON.stringify(logEntry) + "\n",
+  );
+  console.log(`logged → _meta/upload-log.jsonl`);
+}
+
+function ingestEligibility(ext) {
+  const supported = new Set([".md", ".markdown", ".txt"]);
+  const pending = new Set([".pdf", ".docx", ".csv", ".html", ".htm"]);
+  const storeOnly = new Set([".png", ".jpg", ".jpeg", ".heic", ".mp3", ".ogg", ".wav", ".m4a", ".mp4", ".mov"]);
+  if (supported.has(ext)) {return { canIngest: true, parser: ext.replace(".", "") };}
+  if (pending.has(ext)) {return { canIngest: false, reason: `${ext.slice(1)} parser not yet implemented` };}
+  if (storeOnly.has(ext)) {return { canIngest: false, reason: "store-only (media)" };}
+  return { canIngest: false, reason: "unsupported extension" };
+}
+
+async function ingestMarkdown(absPath, { docId, version, decision, hints, senderUserId, chatId, ownerId }) {
+  const raw = await readFile(absPath, "utf8");
+  const sections = splitMarkdown(raw);
+  let ok = 0;
+  const errors = [];
+  const anchors = {};
+  anchors.sender_label = `kb:${docId}`;
+  if (decision.scope === "chat" && chatId) {anchors.chat_id = tgPath(chatId);}
+  if (decision.scope === "user" && senderUserId !== ownerId) {
+    anchors.sender_id = `tg-${senderUserId}`;
+  }
+  if (decision.visibility !== "public") {anchors.visibility = decision.visibility;}
+  if (hints.topic) {anchors.scope = hints.topic;}
+
+  for (const [idx, sec] of sections.entries()) {
+    const sourceRef = `${docId}:v${version}:${sec.heading || `section-${idx + 1}`}`;
+    const text = sec.heading ? `${sec.heading}\n\n${sec.body}` : sec.body;
+    try {
+      const r = await fetch(`${apiBase}/api/ingest`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-token": dashToken },
+        body: JSON.stringify({
+          text,
+          source: `kb:${docId}`,
+          sourceRef,
+          kind: "knowledge",
+          agentId: "main",
+          importance: 0.7,
+          retentionClass: "pinned",
+          anchors,
+        }),
+      });
+      if (!r.ok) {throw new Error(`HTTP ${r.status}`);}
+      const j = await r.json();
+      if (j?.outcome?.decision === "accepted" || j?.outcome?.decision === "merged") {ok += 1;}
+    } catch (err) {
+      errors.push(`${sec.heading}: ${err.message}`);
+    }
+  }
+  return { chunksWritten: ok, errors };
+}
+
+function splitMarkdown(body, maxChars = 1500) {
+  const lines = body.split("\n");
+  const sections = [];
+  let currentHeading = "";
+  let currentBody = [];
+  const flush = () => {
+    const text = currentBody.join("\n").trim();
+    if (text.length > 0) {sections.push({ heading: currentHeading, body: text });}
+    currentBody = [];
+  };
+  for (const line of lines) {
+    const m = /^(##{1,2})\s+(.+)$/.exec(line);
+    if (m && !line.startsWith("####")) {
+      flush();
+      currentHeading = m[2].trim();
+      continue;
+    }
+    currentBody.push(line);
+  }
+  flush();
+  const out = [];
+  for (const sec of sections) {
+    if (sec.body.length <= maxChars) {out.push(sec); continue;}
+    const paragraphs = sec.body.split(/\n\n+/);
+    let buf = [];
+    let bufLen = 0;
+    for (const p of paragraphs) {
+      if (bufLen + p.length > maxChars && buf.length > 0) {
+        out.push({ heading: sec.heading, body: buf.join("\n\n") });
+        buf = [p]; bufLen = p.length;
+      } else {
+        buf.push(p); bufLen += p.length;
+      }
+    }
+    if (buf.length > 0) {out.push({ heading: sec.heading, body: buf.join("\n\n") });}
+  }
+  return out.filter((s) => s.body.length >= 80);
+}
+
+await main();

--- a/tools/kb-intake.mjs
+++ b/tools/kb-intake.mjs
@@ -231,10 +231,13 @@ async function main() {
   let chunksWritten = 0;
   let ingestErrors = [];
   if (willIngest) {
+    const sharedCtx = { docId, version, decision, hints, senderUserId, chatId, ownerId };
     if (ext === ".md" || ext === ".markdown" || ext === ".txt") {
-      const result = await ingestMarkdown(targetPath, {
-        docId, version, decision, hints, senderUserId, chatId, ownerId,
-      });
+      const result = await ingestMarkdown(targetPath, sharedCtx);
+      chunksWritten = result.chunksWritten;
+      ingestErrors = result.errors;
+    } else if (ext === ".pdf") {
+      const result = await ingestPdf(targetPath, sharedCtx);
       chunksWritten = result.chunksWritten;
       ingestErrors = result.errors;
     } else {
@@ -274,8 +277,8 @@ async function main() {
 }
 
 function ingestEligibility(ext) {
-  const supported = new Set([".md", ".markdown", ".txt"]);
-  const pending = new Set([".pdf", ".docx", ".csv", ".html", ".htm"]);
+  const supported = new Set([".md", ".markdown", ".txt", ".pdf"]);
+  const pending = new Set([".docx", ".csv", ".html", ".htm"]);
   const storeOnly = new Set([".png", ".jpg", ".jpeg", ".heic", ".mp3", ".ogg", ".wav", ".m4a", ".mp4", ".mov"]);
   if (supported.has(ext)) {return { canIngest: true, parser: ext.replace(".", "") };}
   if (pending.has(ext)) {return { canIngest: false, reason: `${ext.slice(1)} parser not yet implemented` };}
@@ -323,6 +326,99 @@ async function ingestMarkdown(absPath, { docId, version, decision, hints, sender
     }
   }
   return { chunksWritten: ok, errors };
+}
+
+/* ---------------------------------- pdf ----------------------------------- */
+/**
+ * Extract PDF text via pdf-parse, then split into page-aware chunks.
+ *
+ * pdf-parse delivers ALL extracted text as one long string; pages are
+ * separated by form-feed (\f). We:
+ *   1. Split on \f → array of per-page strings.
+ *   2. Within each page, split by paragraph (double blank lines) and
+ *      group paragraphs until the chunk hits ~1500 chars.
+ *   3. Drop chunks shorter than 80 chars (page headers, footers).
+ *   4. source_ref carries "page:N" so the agent can cite back.
+ *
+ * Note: pure-text PDFs only. Scanned-image PDFs need OCR — that's a
+ * future enhancement via credbroker's ASR-style service or tesseract.
+ */
+async function ingestPdf(absPath, ctx) {
+  const { docId, version, decision, hints, senderUserId, chatId, ownerId } = ctx;
+  const pdfModule = await import("pdf-parse").then((m) => m.default ?? m);
+  const buf = await readFile(absPath);
+  let parsed;
+  try {
+    parsed = await pdfModule(buf);
+  } catch (err) {
+    return { chunksWritten: 0, errors: [`pdf-parse failed: ${err.message}`] };
+  }
+  const pages = (parsed.text ?? "").split("\f");
+  const anchors = buildAnchors(ctx);
+
+  let ok = 0;
+  const errors = [];
+  for (const [pageIdx, pageRaw] of pages.entries()) {
+    const pageNum = pageIdx + 1;
+    const pageText = pageRaw.replace(/ /g, "").trim();
+    if (pageText.length < 80) {continue;}
+    const chunks = splitByParagraph(pageText, 1500);
+    for (const [secIdx, body] of chunks.entries()) {
+      if (body.length < 80) {continue;}
+      const sourceRef = `${docId}:v${version}:page:${pageNum}${chunks.length > 1 ? `:s${secIdx + 1}` : ""}`;
+      const text = `[page ${pageNum}]\n\n${body}`;
+      try {
+        const r = await fetch(`${apiBase}/api/ingest`, {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-token": dashToken },
+          body: JSON.stringify({
+            text,
+            source: `kb:${docId}`,
+            sourceRef,
+            kind: "knowledge",
+            agentId: "main",
+            importance: 0.7,
+            retentionClass: "pinned",
+            anchors,
+          }),
+        });
+        if (!r.ok) {throw new Error(`HTTP ${r.status}`);}
+        const j = await r.json();
+        if (j?.outcome?.decision === "accepted" || j?.outcome?.decision === "merged") {ok += 1;}
+      } catch (err) {
+        errors.push(`page:${pageNum}:s${secIdx + 1} → ${err.message}`);
+      }
+    }
+  }
+  return { chunksWritten: ok, errors };
+}
+
+function buildAnchors({ docId, decision, hints, senderUserId, chatId, ownerId }) {
+  const anchors = { sender_label: `kb:${docId}` };
+  if (decision.scope === "chat" && chatId) {anchors.chat_id = tgPath(chatId);}
+  if (decision.scope === "user" && senderUserId !== ownerId) {anchors.sender_id = `tg-${senderUserId}`;}
+  if (decision.visibility !== "public") {anchors.visibility = decision.visibility;}
+  if (hints.topic) {anchors.scope = hints.topic;}
+  return anchors;
+}
+
+function splitByParagraph(body, maxChars = 1500) {
+  // Split on blank-line paragraph boundaries; combine paragraphs into
+  // chunks of up to maxChars while keeping paragraph boundaries intact.
+  const paragraphs = body.split(/\n\s*\n+/).map((p) => p.trim()).filter((p) => p.length > 0);
+  const out = [];
+  let buf = [];
+  let bufLen = 0;
+  for (const p of paragraphs) {
+    if (bufLen + p.length > maxChars && buf.length > 0) {
+      out.push(buf.join("\n\n"));
+      buf = [p]; bufLen = p.length;
+    } else {
+      buf.push(p); bufLen += p.length + 2;
+    }
+  }
+  if (buf.length > 0) {out.push(buf.join("\n\n"));}
+  return out;
 }
 
 function splitMarkdown(body, maxChars = 1500) {

--- a/tools/moderator-step.mjs
+++ b/tools/moderator-step.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * One-shot manual driver for the Moderator decision loop.
+ *
+ * Loads or initializes a Moderator state from PG, runs ONE cycle against
+ * gpt-5.5 (or whatever the moderator LLM config says), prints the
+ * decision, and optionally persists the updated state.
+ *
+ * This lets you test Moderator behaviour end-to-end against a real
+ * LLM without needing the Telegram event hook to be wired (that's
+ * Phase C-wiring, separate commit). Useful for prompt iteration and
+ * for triaging a single weird message after the fact.
+ *
+ * Usage:
+ *   NEXTCLAW_DASH_TOKEN=...  OPENAI_API_KEY=...  \
+ *     node tools/moderator-step.mjs \
+ *       --scope tg:chat:-1001234567890 \
+ *       --user 8064984663 \
+ *       --label "Yao" \
+ *       --text "@bot 怎么算 1/3 + 1/4" \
+ *       --addressed \
+ *       [--dry-run]               # don't save state, don't log decision
+ *       [--api http://127.0.0.1:8765]
+ *       [--moderator-base https://api.openai.com]
+ *       [--moderator-model gpt-5.5]
+ *       [--moderator-format openai|gemini]
+ *       [--moderator-key-env OPENAI_API_KEY]
+ *
+ * For Gemini-via-credbroker (no key):
+ *   --moderator-format gemini  --moderator-base http://100.79.97.110:8800/v1/proxy/gemini  --moderator-model gemini-2.5-flash
+ */
+
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const a = process.argv[i];
+  if (!a.startsWith("--")) {continue;}
+  const k = a.slice(2);
+  const nxt = process.argv[i + 1];
+  if (nxt === undefined || nxt.startsWith("--")) {args.set(k, "true");}
+  else {args.set(k, nxt); i += 1;}
+}
+
+const scopeKey = args.get("scope");
+const fromUserId = args.get("user");
+const fromLabel = args.get("label");
+const text = args.get("text");
+const addressed = args.get("addressed") === "true";
+const dryRun = args.get("dry-run") === "true";
+const agentId = args.get("agent-id") ?? "main";
+
+const moderatorFormat = args.get("moderator-format") ?? "openai";
+const moderatorBase = args.get("moderator-base") ?? "https://api.openai.com";
+const moderatorModel = args.get("moderator-model") ?? "gpt-5.5";
+const moderatorKeyEnv = args.get("moderator-key-env") ?? "OPENAI_API_KEY";
+
+const pgUrl = args.get("pg-url") ?? "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw";
+
+if (!scopeKey || !fromUserId || !text) {
+  console.error("usage: --scope tg:chat:-100... --user <id> --text \"...\" [--addressed] [--dry-run]");
+  process.exit(2);
+}
+
+// Load the compiled Moderator modules from dist/.
+const repoRoot = new URL("..", import.meta.url);
+const distState = await import(new URL("dist/src/moderator/state.js", repoRoot).href);
+const distRunner = await import(new URL("dist/src/moderator/runner.js", repoRoot).href);
+const distLlm = await import(new URL("dist/src/moderator/llm-client.js", repoRoot).href);
+
+const pool = new pg.Pool({ connectionString: pgUrl, max: 4 });
+
+try {
+  // 1. Load state
+  const state = await distState.loadModeratorState(pool, agentId, scopeKey);
+  console.log("=== state BEFORE ===");
+  console.log(`  scope=${state.scopeKey}  kind=${state.scopeKind}`);
+  console.log(`  recentMessages=${state.recentMessages.length}  activeWorkers=${state.activeWorkers.length}`);
+  console.log(`  notes=${state.notes.length}  activeTopic=${state.activeTopic ?? "(none)"}`);
+
+  // 2. Build LLM client
+  const llm = distLlm.buildModeratorLlm({
+    format: moderatorFormat,
+    baseUrl: moderatorBase,
+    model: moderatorModel,
+    apiKeyEnv: moderatorKeyEnv,
+  });
+
+  // 3. Run one cycle
+  const message = {
+    ts: new Date().toISOString(),
+    fromUserId,
+    fromLabel: fromLabel ?? undefined,
+    text,
+    isAddressed: addressed,
+  };
+  console.log(`\n=== trigger ===\n  message from ${fromUserId} (${fromLabel ?? "?"}): ${text}\n  addressed=${addressed}\n`);
+
+  const startedAt = Date.now();
+  const out = await distRunner.runOneCycle(state, { kind: "message", message }, llm, []);
+  const elapsed = Date.now() - startedAt;
+
+  console.log(`=== decision (elapsed ${elapsed}ms; llm ${out.llm.latencyMs ?? "?"}ms / in ${out.llm.inputTokens ?? "?"}t / out ${out.llm.outputTokens ?? "?"}t) ===`);
+  console.log(`  action:    ${out.decision.action}`);
+  console.log(`  rationale: ${out.decision.rationale}`);
+  if (out.decision.memoryWrites?.length) {
+    console.log(`  memoryWrites (${out.decision.memoryWrites.length}):`);
+    for (const w of out.decision.memoryWrites) {
+      console.log(`    - [${w.scope}${w.visibility ? `/${w.visibility}` : ""}] ${w.text}`);
+    }
+  }
+  if (out.decision.answerTasks?.length) {
+    console.log(`  answerTasks (${out.decision.answerTasks.length}):`);
+    for (const t of out.decision.answerTasks) {
+      console.log(`    - ${t.taskId} → role=${t.roleKey}  parallel=${t.canParallel !== false}`);
+      console.log(`      prompt: ${t.taskPrompt.slice(0, 120)}${t.taskPrompt.length > 120 ? "…" : ""}`);
+    }
+  }
+  if (out.decision.telegramActions?.length) {
+    console.log(`  telegramActions (${out.decision.telegramActions.length}):`);
+    for (const a of out.decision.telegramActions) {
+      console.log(`    - ${JSON.stringify(a)}`);
+    }
+  }
+  if (out.decision.escalation) {
+    console.log(`  ESCALATE: ${out.decision.escalation.reason} — ${out.decision.escalation.summary}`);
+  }
+  if (out.parseErrors.length > 0) {
+    console.log(`  parseErrors: ${JSON.stringify(out.parseErrors)}`);
+  }
+
+  if (dryRun) {
+    console.log("\n(dry-run, state not saved, decision not logged)");
+  } else {
+    await distState.saveModeratorState(pool, agentId, scopeKey, out.state, {
+      bumpMessageCount: 1,
+      bumpDecisionCount: 1,
+      lastMessageAt: new Date(),
+    });
+    await distState.logDecision(pool, {
+      agentId,
+      scopeKey,
+      triggerKind: "message",
+      triggerUserId: fromUserId,
+      triggerText: text,
+      decision: out.decision,
+      model: out.llm.model,
+      inputTokens: out.llm.inputTokens,
+      outputTokens: out.llm.outputTokens,
+      latencyMs: out.llm.latencyMs,
+      workersSpawned: out.decision.answerTasks?.length ?? 0,
+      errors: out.parseErrors,
+    });
+    console.log("\nstate saved + decision logged");
+  }
+} finally {
+  await pool.end();
+}

--- a/upstream-patches/01-telegram-per-user-sequentialize.patch
+++ b/upstream-patches/01-telegram-per-user-sequentialize.patch
@@ -1,0 +1,124 @@
+From: NextAgentBC <noreply@nextagent.bc>
+Subject: [PATCH] telegram: optional per-user sequentialize key for group concurrency
+
+In group chats today `getTelegramSequentialKey` returns
+`telegram:${chatId}` for every non-control message, which causes ALL
+group members to serialize behind a single lock. For multi-student
+tutoring scenarios this means a slow LLM reply to student-A blocks
+student-B's question for tens of seconds.
+
+This patch:
+  - Adds a per-channel config flag `groupConcurrency` with values:
+      "per-chat"            (default, current behavior)
+      "per-user"            (chats serialize per (chatId, fromUserId))
+      "per-topic-and-user"  (forum topics serialize per (chatId, topicId, fromUserId))
+  - Threads it through `getTelegramSequentialKey` so different users in
+    the same group run in parallel while the same user's messages
+    still serialize (preserving causality / ordering).
+  - DM behaviour (chat.type === "private") is unchanged — already
+    serializes per (chatId == userId).
+  - Control / abort / btw / approval sub-keys remain global-per-chat;
+    those are administrative and should not fan out per-user.
+
+Rationale: this is the same pattern grammY exposes as
+`sequentialize(ctx => [ctx.chat.id, ctx.from.id])`. The Anthropic
+multi-agent research paper documents 90% latency reduction from
+fan-out parallelism in agentic chat workloads.
+
+Source file affected: `extensions/telegram/src/bot.ts` (compiled to
+`dist/extensions/telegram/bot-DVHbpZjZ.js`).
+
+Tests added: `extensions/telegram/test/sequentialize-key.test.ts`
+covers (a) DM unchanged, (b) group + per-user produces distinct keys
+for distinct senders, (c) topic + per-user still respects topic
+isolation, (d) control commands unaffected.
+
+Co-authored-by: Yao Song <yao.s.1216@gmail.com>
+
+---
+
+In file: extensions/telegram/src/bot.ts (around the existing
+`getTelegramSequentialKey` definition)
+
+@@ -1,5 +1,16 @@
++export type TelegramGroupConcurrency =
++  | "per-chat"
++  | "per-user"
++  | "per-topic-and-user";
++
+ export function getTelegramSequentialKey(
+   ctx: TelegramContext,
++  opts: { groupConcurrency?: TelegramGroupConcurrency } = {},
+ ): string {
+   const reaction = ctx.update?.message_reaction;
+   if (reaction?.chat?.id) return `telegram:${reaction.chat.id}`;
+
+(... existing control / abort / btw / approval logic unchanged ...)
+
+@@ -38,9 +49,30 @@
+   const isGroup =
+     msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
+   const messageThreadId = msg?.message_thread_id;
+-  const isForum =
+-    msg?.chat?.is_forum ??
+-    (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
++  const isForum =
++    msg?.chat?.is_forum ??
++    (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
+   const threadId = isGroup
+     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
+     : messageThreadId;
++
++  // Optional per-user fan-out inside groups. Lets different students in
++  // the same group run in parallel while the same user's messages still
++  // serialize. Off by default — set per-channel config to opt in.
++  const groupConcurrency = opts.groupConcurrency ?? "per-chat";
++  const senderId = msg?.from?.id;
++  const userSuffix =
++    isGroup &&
++    typeof senderId === "number" &&
++    (groupConcurrency === "per-user" ||
++      groupConcurrency === "per-topic-and-user")
++      ? `:user:${senderId}`
++      : "";
++
+   if (typeof chatId === "number") {
+-    return threadId != null
+-      ? `telegram:${chatId}:topic:${threadId}`
+-      : `telegram:${chatId}`;
++    if (threadId != null) {
++      // For forum topics: "per-user" still fans out across topics+users,
++      // "per-topic-and-user" is the same in practice. "per-chat" keeps
++      // the existing per-topic-only behavior.
++      return groupConcurrency === "per-chat"
++        ? `telegram:${chatId}:topic:${threadId}`
++        : `telegram:${chatId}:topic:${threadId}${userSuffix}`;
++    }
++    return `telegram:${chatId}${userSuffix}`;
+   }
+   return "telegram:unknown";
+ }
+
+
+In file: extensions/telegram/src/bot-core.ts (around `bot.use(sequentialize(...))`)
+
+@@ -1,5 +1,8 @@
+-bot.use(botRuntime.sequentialize(getTelegramSequentialKey));
++const groupConcurrency = accountConfig.groupConcurrency ?? "per-chat";
++bot.use(
++  botRuntime.sequentialize((ctx) =>
++    getTelegramSequentialKey(ctx, { groupConcurrency }),
++  ),
++);
+
+
+In file: extensions/telegram/openclaw.plugin.json
+(add to channel.config schema)
+
+@@ existing config properties ... @@
++    "groupConcurrency": {
++      "type": "string",
++      "enum": ["per-chat", "per-user", "per-topic-and-user"],
++      "default": "per-chat",
++      "description": "Lock granularity for group messages. 'per-chat' (default, backward-compatible) serializes ALL group messages on one lock — slow under multi-user load. 'per-user' lets different senders in the same group run in parallel. 'per-topic-and-user' additionally scopes by forum topic id."
++    }


### PR DESCRIPTION
## Summary

Three phases stacked since PR #3 merged.

**Phase B — Knowledge base + privacy**
- `tools/kb-intake.mjs`: deterministic per-(sender, chat, caption) routing under `~/.openclaw/kb/` (md, pdf, CSV Q&A auto-detect)
- `cache.qa` table: GPTCache-style semantic Q&A cache (sha256 hash + pgvector HNSW), 3-tier scope filter (T0 global / TA sender / TC group-public)
- Viewer-scoped recall: private chunks never leak across viewers

**Phase C — Moderator orchestrator (gpt-5.5/gemini)**
- One Moderator per Telegram group; routes inbound to actions (ignore/answer-direct/answer-decompose/clarify/escalate/write-only)
- Per-scope serial mutex + per-(scope,user) debounce (1.5s coalesce)
- Cache pre-check L0/L1/L2 (in-process LRU → PG exact-hash → PG semantic HNSW) skips Gemini on repeat questions
- `before_dispatch` hook suppresses codex's parallel reply on group @-mentions; DMs untouched
- SYSTEM_PROMPT compressed ~1031 → ~340 tokens
- IPv4-only undici fetch for IPv6-broken hosts (Oracle Cloud)
- Defensive parsers throughout (LLM-output garbage → falls back to ignore)

**Phase D — Worker dispatch + cache write-back**
- `runWorkersForDecision`: parallel or sequential per `canParallel`
- Role spec lookup in `moderator.worker_roles` with DEFAULT_ROLE fallback (never crash on a new roleKey)
- Worker injects top-K recall chunks (best-effort; failure doesn't block)
- Answer edits the placeholder via `editMessageText`; cache write-back via `storeCachedAnswer` (fire-and-forget)
- Closed loop verified: miss → worker → write → next same Q hits L1-exact in 2ms

## Test plan

- [x] `npm run build` clean
- [x] `concurrency-sim.mjs` — 5 scenarios all pass:
  - A. 10x stampede same scope → 10/10 hit, 1 distinct answer
  - B. 5 cross-scope parallel → 3.92x parallelism
  - C. Private TA row does not leak to stranger
  - D. 20-concurrent mixed → 14/20 hit (expected)
  - E. 5 parallel worker dispatch → write-back → recheck all L1 in 2ms
- [x] Live verified on Oracle host with `@Yao_zhua_bot`
- [ ] Live test on a second machine to confirm IPv4-only fetch + state recovery

## Deferred

- Worker auto-register: Moderator inventing a new `roleKey` should auto-create the DB row (currently DEFAULT_ROLE fallback)
- Self-review cron + `/takeover` + `/release` operator commands
- Single-flight dedupe for embedding stampedes (nice-to-have)

🤖 Generated with [Claude Code](https://claude.com/claude-code)