### PR TITLE
Worker auto-register: model-coined specialists persist (leverage hook)

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -16,7 +16,7 @@ import { randomUUID } from "node:crypto";
 import { buildEmbeddingClientFromConfig } from "./dist/src/embedding/client.js";
 import { buildModeratorLlm } from "./dist/src/moderator/llm-client.js";
 import { tryCachePrecheck, clearL0Cache, l0Stats } from "./dist/src/moderator/cache-precheck.js";
-import { dispatchWorker, writeAnswerToCache } from "./dist/src/moderator/workers.js";
+import { dispatchWorker, writeAnswerToCache, loadRoleSpec, upsertWorkerRole } from "./dist/src/moderator/workers.js";
 import { storeCachedAnswer } from "./dist/src/cache/qa.js";
 
 const PG_URL = "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw";
@@ -168,7 +168,7 @@ async function scenarioE_workerRoundtrip() {
 
   const t0 = Date.now();
   const results = await Promise.all(
-    tasks.map((t) => dispatchWorker(wkDeps, t, { userId: "u-test", chatId: "-1003789981008" }, t.taskPrompt)),
+    tasks.map((t) => dispatchWorker(wkDeps, t, { userId: "u-test", chatId: "-1003789981008" }, t.taskPrompt, SCOPE)),
   );
   const dispatchWall = Date.now() - t0;
   console.log(`  5 parallel dispatches: wall=${dispatchWall}ms, individual latencies=${results.map((r) => r.llm.latencyMs).join("/")}ms`);
@@ -197,6 +197,50 @@ async function scenarioE_workerRoundtrip() {
   }
 }
 
+async function scenarioF_roleAutoRegister() {
+  console.log("\n=== F. Role auto-register — Moderator-coined role persists across calls ===");
+  const uid = randomUUID().slice(0, 6);
+  const roleKey = `sim_specialist_${uid}`;
+  const spec = {
+    systemPrompt: `你是一个 [${uid}] 测试 specialist：用 8 个字以内回答任何问题，结尾加 [${uid}] 标签。`,
+    displayName: `Sim Specialist ${uid}`,
+    memoryScope: { topic: "sim.role-register" },
+  };
+
+  // 1. Initial state: role does not exist → loadRoleSpec returns DEFAULT_ROLE
+  const before = await loadRoleSpec(pool, AGENT, roleKey);
+  console.log(`  before insert: roleKey=${before.roleKey} displayName='${before.displayName}' isDefault=${before.systemPrompt === (await loadRoleSpec(pool, AGENT, "__nonexistent__")).systemPrompt}`);
+
+  // 2. RACE: 5 parallel upsert attempts for the SAME brand-new key.
+  //    ON CONFLICT DO NOTHING → exactly one should report `created=true`.
+  const created = await Promise.all(
+    Array.from({ length: 5 }, () => upsertWorkerRole(pool, AGENT, roleKey, spec, SCOPE)),
+  );
+  const successes = created.filter(Boolean).length;
+  console.log(`  5 parallel upserts: created=${successes}/5 (expect exactly 1)`);
+
+  // 3. Subsequent loadRoleSpec must return the Moderator-designed spec, NOT default.
+  const after = await loadRoleSpec(pool, AGENT, roleKey);
+  const usesNewSpec = after.systemPrompt === spec.systemPrompt;
+  console.log(`  after upsert: roleKey=${after.roleKey} displayName='${after.displayName}'`);
+  console.log(`  systemPrompt matches spec: ${usesNewSpec ? "✓" : "✗ — DEFAULT_ROLE was returned"}`);
+
+  // 4. Second upsert with a DIFFERENT prompt under the same key → must be ignored (first-write-wins).
+  const overwriteAttempted = await upsertWorkerRole(
+    pool,
+    AGENT,
+    roleKey,
+    { ...spec, systemPrompt: "覆盖测试 — 不该出现", displayName: "should not stick" },
+    SCOPE,
+  );
+  const final = await loadRoleSpec(pool, AGENT, roleKey);
+  console.log(`  second upsert returned created=${overwriteAttempted} (expect false)`);
+  console.log(`  systemPrompt still original: ${final.systemPrompt === spec.systemPrompt ? "✓ first-write-wins" : "✗ overwritten"}`);
+
+  // Cleanup.
+  await pool.query("DELETE FROM moderator.worker_roles WHERE agent_id=$1 AND role_key=$2", [AGENT, roleKey]);
+}
+
 async function main() {
   console.log("Concurrency simulation — Moderator cache + worker pipeline");
   console.log("==========================================================");
@@ -206,6 +250,7 @@ async function main() {
     await scenarioC_viewerIsolation();
     await scenarioD_mixed();
     await scenarioE_workerRoundtrip();
+    await scenarioF_roleAutoRegister();
   } finally {
     await pool.end();
   }

--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -52,7 +52,7 @@ Output schema:
   "action": <one of above>,
   "rationale": "<one sentence>",
   "memoryWrites": [{"text":"...","scope":"user"|"chat"|"global","topic":"...","importance":0..1,"visibility":"public"|"private"}],
-  "answerTasks": [{"taskId":"t1","roleKey":"<spec id>","taskPrompt":"...","memoryScope":{"topic":"..."},"canParallel":true}],
+  "answerTasks": [{"taskId":"t1","roleKey":"<spec id>","taskPrompt":"...","memoryScope":{"topic":"..."},"canParallel":true,"newRoleSpec":{"systemPrompt":"<only if roleKey is brand new — design the specialist's voice & focus; will be persisted>","displayName":"..."}}],
   "telegramActions": [{"kind":"placeholder","taskId":"t1","text":"⏳ ..."},{"kind":"edit_placeholder","taskId":"t1","fromTaskResult":true}],
   "escalation": {"reason":"...","summary":"...","pauseScope":false},
   "noteAppend": "<optional one-liner>"

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -263,7 +263,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           logger: config.logger,
         };
         const viewer = { userId: senderUserId, chatId };
-        const results = await runWorkersForDecision(wkDeps, tasks, viewer, trigger.text);
+        const results = await runWorkersForDecision(wkDeps, tasks, viewer, trigger.text, scopeKey);
         for (const r of results) {
           // Find the placeholder message_id for this task: first try
           // fx.placeholders (this cycle), fall back to activeWorkers

--- a/src/moderator/types.ts
+++ b/src/moderator/types.ts
@@ -130,6 +130,24 @@ export type AnswerTask = {
   /** Whether this task can run in parallel with others in the same decision.
    *  Default true; false means it depends on a prior task's result. */
   canParallel?: boolean;
+  /**
+   * Optional inline specialist spec. When set AND `roleKey` is not yet
+   * registered in `moderator.worker_roles`, the Moderator auto-creates
+   * the row before dispatching. Subsequent decisions reusing the same
+   * `roleKey` get the persisted spec — so the Moderator's choice of
+   * specialist designs accumulates over time, instead of every novel
+   * `roleKey` collapsing back to DEFAULT_ROLE.
+   *
+   * This is the "leverage" hook: stronger Moderator → better specialist
+   * designs → richer permanent registry.
+   *
+   * Operator-seeded rows always win; agent-created rows are first-write-wins.
+   */
+  newRoleSpec?: {
+    systemPrompt: string;
+    displayName?: string;
+    memoryScope?: { topic?: string; kind?: string };
+  };
 };
 
 export type TelegramAction =
@@ -226,13 +244,32 @@ export function parseDecision(raw: unknown): { decision: ModeratorDecision; erro
         const roleKey = typeof t.roleKey === "string" ? t.roleKey : null;
         const taskPrompt = typeof t.taskPrompt === "string" ? t.taskPrompt : null;
         if (!taskId || !roleKey || !taskPrompt) {return null;}
-        return {
+        const out: AnswerTask = {
           taskId,
           roleKey,
           taskPrompt,
           memoryScope: isObj(t.memoryScope) ? (t.memoryScope as AnswerTask["memoryScope"]) : undefined,
           canParallel: t.canParallel !== false,
         };
+        // Optional inline role spec — model declares a new specialist on the fly.
+        // We only accept a usable systemPrompt; everything else is shaped down.
+        if (isObj(t.newRoleSpec)) {
+          const ns = t.newRoleSpec;
+          const sp = typeof ns.systemPrompt === "string" ? ns.systemPrompt.trim() : "";
+          if (sp.length >= 20 && sp.length <= 4000) {
+            out.newRoleSpec = {
+              systemPrompt: sp,
+              displayName: typeof ns.displayName === "string" ? ns.displayName.slice(0, 80) : undefined,
+              memoryScope: isObj(ns.memoryScope)
+                ? {
+                    topic: typeof ns.memoryScope.topic === "string" ? ns.memoryScope.topic : undefined,
+                    kind: typeof ns.memoryScope.kind === "string" ? ns.memoryScope.kind : undefined,
+                  }
+                : undefined,
+            };
+          }
+        }
+        return out;
       })
       .filter((t): t is AnswerTask => t !== null);
   }

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -68,6 +68,63 @@ const DEFAULT_ROLE: RoleSpec = {
   model: "gemini:gemini-2.5-flash",
 };
 
+/* --------------------------- role auto-register --------------------------- */
+
+/**
+ * Cap on agent-created roles per agent_id. Hard guard against a runaway
+ * Moderator polluting the registry with garbage roleKeys. Operator-seeded
+ * rows (created_by_scope IS NULL) don't count toward the limit.
+ */
+const MAX_AGENT_CREATED_ROLES = 200;
+
+/**
+ * Insert a new worker role if it doesn't already exist. Operator-seeded
+ * rows (with no `created_by_scope`) always win — if a row exists for
+ * this (agent_id, role_key), we DO NOT overwrite. Returns true if a row
+ * was actually inserted.
+ *
+ * Why first-write-wins for agent rows: the Moderator's first design for
+ * a roleKey is the canonical one. If a later decision proposes a
+ * different prompt for the SAME key, that's a sign the model is
+ * confused — better to use the original than churn the registry.
+ */
+export async function upsertWorkerRole(
+  pool: Pool,
+  agentId: string,
+  roleKey: string,
+  spec: NonNullable<import("./types.js").AnswerTask["newRoleSpec"]>,
+  createdByScope: string,
+): Promise<boolean> {
+  // Soft cap — refuse silently if the agent has too many roles already.
+  const cnt = await pool.query<{ n: string }>(
+    `SELECT COUNT(*)::text AS n FROM moderator.worker_roles
+     WHERE agent_id = $1 AND created_by_scope IS NOT NULL`,
+    [agentId],
+  );
+  if (Number.parseInt(cnt.rows[0]?.n ?? "0", 10) >= MAX_AGENT_CREATED_ROLES) {
+    return false;
+  }
+  const r = await pool.query(
+    `INSERT INTO moderator.worker_roles
+       (id, agent_id, role_key, display_name, system_prompt, tools,
+        memory_scope, model, created_by_scope)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, '{}'::text[],
+             $5::jsonb, $6, $7)
+     ON CONFLICT (agent_id, role_key) DO NOTHING
+     RETURNING id`,
+    [
+      agentId,
+      roleKey,
+      spec.displayName ?? roleKey,
+      spec.systemPrompt,
+      JSON.stringify(spec.memoryScope ?? {}),
+      DEFAULT_ROLE.model, // model preference inherits default; can be tuned per-row later
+      createdByScope,
+    ],
+  );
+  return (r.rowCount ?? 0) > 0;
+}
+
 /* ----------------------------- role loading ------------------------------- */
 
 export async function loadRoleSpec(
@@ -147,7 +204,34 @@ export async function dispatchWorker(
   viewer: ViewerScope | undefined,
   /** Raw question text from the user (pre-cleaning). */
   userQuestion: string,
+  /** Scope key the Moderator is acting in, e.g. `tg:chat:-100...`. Used to
+   *  attribute newly-registered roles so we can audit which scope coined them. */
+  scopeKey: string,
 ): Promise<WorkerResult> {
+  // If the Moderator declared a new specialist inline, persist it BEFORE
+  // loading the role spec. First-write-wins via ON CONFLICT DO NOTHING,
+  // so a race between two parallel tasks for the same brand-new key is
+  // safe — both insert attempts coalesce, both subsequent loads see the
+  // same row. Failure to upsert (e.g. cap reached) just falls back to
+  // DEFAULT_ROLE, mirroring the pre-leverage behavior.
+  if (task.newRoleSpec) {
+    try {
+      const created = await upsertWorkerRole(
+        deps.pool,
+        deps.agentId,
+        task.roleKey,
+        task.newRoleSpec,
+        scopeKey,
+      );
+      if (created) {
+        deps.logger.info(
+          `worker[${task.taskId}]: registered new role '${task.roleKey}' (${task.newRoleSpec.systemPrompt.length} chars)`,
+        );
+      }
+    } catch (e) {
+      deps.logger.warn(`worker[${task.taskId}]: role upsert failed: ${(e as Error).message}`);
+    }
+  }
   const role = await loadRoleSpec(deps.pool, deps.agentId, task.roleKey);
   const cleanedQ = cleanQuestionText(userQuestion);
   const topicTag = task.memoryScope?.topic ?? role.memoryScope.topic;
@@ -244,15 +328,18 @@ export async function runWorkersForDecision(
   tasks: AnswerTask[],
   viewer: ViewerScope | undefined,
   userQuestion: string,
+  scopeKey: string,
 ): Promise<WorkerResult[]> {
   if (tasks.length === 0) {return [];}
   const parallel = tasks.filter((t) => t.canParallel !== false);
   const serial = tasks.filter((t) => t.canParallel === false);
 
-  const parResults = await Promise.all(parallel.map((t) => dispatchWorker(deps, t, viewer, userQuestion)));
+  const parResults = await Promise.all(
+    parallel.map((t) => dispatchWorker(deps, t, viewer, userQuestion, scopeKey)),
+  );
   const serResults: WorkerResult[] = [];
   for (const t of serial) {
-    serResults.push(await dispatchWorker(deps, t, viewer, userQuestion));
+    serResults.push(await dispatchWorker(deps, t, viewer, userQuestion, scopeKey));
   }
   return [...parResults, ...serResults];
 }


### PR DESCRIPTION
## Why

Project principle: as the underlying LLM gets stronger, our infra should be a **lever** that amplifies it — not duplicate work that gets subsumed.

Currently, every brand-new `roleKey` the Moderator picks collapses back to `DEFAULT_ROLE` because nothing materialized the specialist. Stronger Moderator → same generic prompt every time → no compounding.

This PR closes that loop: when the Moderator declares a new specialist inline via `answerTasks[i].newRoleSpec`, we persist the spec to `moderator.worker_roles` before dispatching. Future decisions reusing that `roleKey` load the Moderator's design from DB instead of falling back. Every smart routing decision becomes permanent infrastructure.

## What

- `AnswerTask.newRoleSpec? = { systemPrompt, displayName?, memoryScope? }` — optional inline spec
- `parseDecision` shapes it down defensively (length-bounded, type-checked)
- `decisions.ts` SYSTEM_PROMPT gains ONE line documenting the field — weaker models can ignore it, no regression
- `workers.ts`: `upsertWorkerRole(...)` with `ON CONFLICT DO NOTHING` (first-write-wins) + `MAX_AGENT_CREATED_ROLES=200` cap to block runaway

## Test plan

- [x] `npm run build` clean
- [x] concurrency-sim scenario F:
  1. loadRoleSpec on novel key → DEFAULT_ROLE
  2. 5 parallel upserts of same brand-new key → exactly 1 created (race-safe)
  3. loadRoleSpec now returns Moderator's design
  4. Second upsert with different prompt → rejected; original preserved
- [x] Gateway restart clean
- [ ] Live test in `@Yao_zhua_bot` group: ask question requiring a fresh specialist → check `moderator.worker_roles` for new row → ask similar question → verify it picked up persisted spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)