### PR TITLE
Worker tool runtime + memory_search (model gets a new limb)

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -17,6 +17,7 @@ import { buildEmbeddingClientFromConfig } from "./dist/src/embedding/client.js";
 import { buildModeratorLlm } from "./dist/src/moderator/llm-client.js";
 import { tryCachePrecheck, clearL0Cache, l0Stats } from "./dist/src/moderator/cache-precheck.js";
 import { dispatchWorker, writeAnswerToCache, loadRoleSpec, upsertWorkerRole } from "./dist/src/moderator/workers.js";
+import { buildWorkerLlmFromConfig } from "./dist/src/moderator/worker-llm.js";
 import { storeCachedAnswer } from "./dist/src/cache/qa.js";
 
 const PG_URL = "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw";
@@ -142,7 +143,7 @@ async function scenarioD_mixed() {
 async function scenarioE_workerRoundtrip() {
   console.log("\n=== E. Phase D round-trip — 5 parallel worker dispatches → write-back → cache ===");
   clearL0Cache();
-  const llm = buildModeratorLlm({
+  const workerLlm = buildWorkerLlmFromConfig({
     format: "gemini",
     baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini",
     model: "gemini-2.5-flash",
@@ -153,7 +154,7 @@ async function scenarioE_workerRoundtrip() {
     embedding: { model: "qwen3-embedding:0.6b" },
   };
   const logger = { info: () => {}, warn: () => {} }; // quiet
-  const wkDeps = { pool, llm, embedding, cfg, agentId: AGENT, logger };
+  const wkDeps = { pool, workerLlm, embedding, cfg, agentId: AGENT, logger };
 
   // 5 *different* novel questions (UUID suffix), so each must call the LLM,
   // then write back. After write-back, a second precheck for each must hit.
@@ -241,6 +242,69 @@ async function scenarioF_roleAutoRegister() {
   await pool.query("DELETE FROM moderator.worker_roles WHERE agent_id=$1 AND role_key=$2", [AGENT, roleKey]);
 }
 
+async function scenarioG_workerTools() {
+  console.log("\n=== G. Worker tool calls — model invokes memory_search mid-answer ===");
+  const workerLlm = buildWorkerLlmFromConfig({
+    format: "gemini",
+    baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini",
+    model: "gemini-2.5-flash",
+  });
+  const cfg = {
+    pluginId: "memory-postgres",
+    storage: { schema: "public", chunksTable: "chunks", chunkIndexesTable: "chunk_indexes" },
+    embedding: { model: "qwen3-embedding:0.6b" },
+  };
+  const logger = { info: (m) => console.log("    log:", m), warn: () => {} };
+  const wkDeps = { pool, workerLlm, embedding, cfg, agentId: AGENT, logger };
+
+  // Register a role that has the memory_search tool.
+  const uid = randomUUID().slice(0, 6);
+  const roleKey = `sim_searcher_${uid}`;
+  await upsertWorkerRole(
+    pool,
+    AGENT,
+    roleKey,
+    {
+      systemPrompt:
+        "你是一个助教，要回答用户问题前 **必须先调用 memory_search 工具** 查找历史记忆。" +
+        "如果搜到相关内容，用它回答；如果没搜到，明说你查过没找到。回答简洁，不超过 3 句。",
+      displayName: `Sim Searcher ${uid}`,
+      tools: ["memory_search"],
+    },
+    SCOPE,
+  );
+
+  // A question that obviously benefits from memory_search.
+  const task = {
+    taskId: `t_searcher_${uid}`,
+    roleKey,
+    taskPrompt: "之前有人问过怎么算 1/3 + 1/4 吗？如果有，告诉我答案。",
+    memoryScope: { topic: "math.fractions" },
+    canParallel: true,
+  };
+
+  const result = await dispatchWorker(
+    wkDeps,
+    task,
+    { userId: "u-sim", chatId: "-1003789981008" },
+    task.taskPrompt,
+    SCOPE,
+  );
+
+  console.log(`  ok: ${result.ok}`);
+  console.log(`  tool calls made: ${result.toolCalls?.length ?? 0}${result.toolCalls ? " (" + result.toolCalls.map((c) => c.name).join(",") + ")" : ""}`);
+  if (result.toolCalls?.length) {
+    console.log(`  first call args: ${JSON.stringify(result.toolCalls[0].args)}`);
+  }
+  console.log(`  answer (first 180 chars): ${JSON.stringify(result.answer.slice(0, 180))}`);
+  console.log(`  tokens=${result.llm.inputTokens}→${result.llm.outputTokens} latency=${result.llm.latencyMs}ms`);
+  const usedTool = (result.toolCalls?.length ?? 0) > 0;
+  console.log(`  → tool wiring works: ${usedTool ? "✓" : "✗ (model chose not to call — try a clearer prompt)"}`);
+
+  // Cleanup the role.
+  await pool.query("DELETE FROM moderator.worker_roles WHERE agent_id=$1 AND role_key=$2", [AGENT, roleKey]);
+}
+
 async function main() {
   console.log("Concurrency simulation — Moderator cache + worker pipeline");
   console.log("==========================================================");
@@ -251,6 +315,7 @@ async function main() {
     await scenarioD_mixed();
     await scenarioE_workerRoundtrip();
     await scenarioF_roleAutoRegister();
+    await scenarioG_workerTools();
   } finally {
     await pool.end();
   }

--- a/index.ts
+++ b/index.ts
@@ -444,9 +444,20 @@ export default definePluginEntry({
                 format: cfg.embedding.format,
                 path: cfg.embedding.path,
               });
+              // Worker LLM: reuses the moderator's model config but routes
+              // through the tool-aware transport (Gemini :generateContent
+              // with tool calls; OpenAI single-shot fallback only).
+              const { buildWorkerLlmFromConfig } = await import("./src/moderator/worker-llm.js");
+              const workerLlm = buildWorkerLlmFromConfig({
+                format: cfg.moderator.model.format,
+                baseUrl: cfg.moderator.model.baseUrl,
+                model: cfg.moderator.model.model,
+                apiKeyEnv: cfg.moderator.model.apiKeyEnv,
+              });
               moderatorHandle = startModeratorService({
                 enabled: true,
                 llm,
+                workerLlm,
                 embedding: embeddingClient,
                 telegramBotToken: botToken,
                 ownerUserId,

--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -52,7 +52,7 @@ Output schema:
   "action": <one of above>,
   "rationale": "<one sentence>",
   "memoryWrites": [{"text":"...","scope":"user"|"chat"|"global","topic":"...","importance":0..1,"visibility":"public"|"private"}],
-  "answerTasks": [{"taskId":"t1","roleKey":"<spec id>","taskPrompt":"...","memoryScope":{"topic":"..."},"canParallel":true,"newRoleSpec":{"systemPrompt":"<only if roleKey is brand new — design the specialist's voice & focus; will be persisted>","displayName":"..."}}],
+  "answerTasks": [{"taskId":"t1","roleKey":"<spec id>","taskPrompt":"...","memoryScope":{"topic":"..."},"canParallel":true,"newRoleSpec":{"systemPrompt":"<only if roleKey is brand new — design the specialist's voice & focus; will be persisted>","displayName":"...","tools":["memory_search"]}}],
   "telegramActions": [{"kind":"placeholder","taskId":"t1","text":"⏳ ..."},{"kind":"edit_placeholder","taskId":"t1","fromTaskResult":true}],
   "escalation": {"reason":"...","summary":"...","pauseScope":false},
   "noteAppend": "<optional one-liner>"

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -33,6 +33,7 @@ import { executeDecision } from "./side-effects.js";
 import { TelegramBotApi } from "./telegram-api.js";
 import type { RecentMessage } from "./types.js";
 import { runWorkersForDecision, writeAnswerToCache } from "./workers.js";
+import type { WorkerLlmClient } from "./worker-llm.js";
 
 export type ModeratorServiceConfig = {
   enabled: boolean;
@@ -41,6 +42,10 @@ export type ModeratorServiceConfig = {
   /** Embedding client — needed for cache.qa L2 semantic lookup before
    *  the Moderator decision. Skips Gemini entirely on cache hits. */
   embedding: EmbeddingClient;
+  /** Tool-aware worker LLM client. Same backend as `llm` (typically) but
+   *  with multi-turn + tool-call support so workers can invoke
+   *  memory_search etc. mid-answer. */
+  workerLlm: WorkerLlmClient;
   /** Telegram bot token, from openclaw `channels.telegram.botToken`. */
   telegramBotToken: string;
   /** Bot owner user id (for escalation), from `commands.ownerAllowFrom[0]`. */
@@ -256,7 +261,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
       if (tasks.length > 0) {
         const wkDeps = {
           pool: config.pool,
-          llm: config.llm,
+          workerLlm: config.workerLlm,
           embedding: config.embedding,
           cfg: config.cfg,
           agentId: "main",

--- a/src/moderator/types.ts
+++ b/src/moderator/types.ts
@@ -147,6 +147,10 @@ export type AnswerTask = {
     systemPrompt: string;
     displayName?: string;
     memoryScope?: { topic?: string; kind?: string };
+    /** Tool names the specialist is allowed to call. The runtime
+     *  whitelists against the registered tool set, so a typo or
+     *  invented name silently becomes []. */
+    tools?: string[];
   };
 };
 
@@ -265,6 +269,9 @@ export function parseDecision(raw: unknown): { decision: ModeratorDecision; erro
                     topic: typeof ns.memoryScope.topic === "string" ? ns.memoryScope.topic : undefined,
                     kind: typeof ns.memoryScope.kind === "string" ? ns.memoryScope.kind : undefined,
                   }
+                : undefined,
+              tools: Array.isArray(ns.tools)
+                ? ns.tools.filter((t: unknown): t is string => typeof t === "string").slice(0, 8)
                 : undefined,
             };
           }

--- a/src/moderator/worker-llm.ts
+++ b/src/moderator/worker-llm.ts
@@ -1,0 +1,303 @@
+/**
+ * Worker-side LLM client with tool-call support.
+ *
+ * Separate from `llm-client.ts` (which wraps the Moderator's single-shot
+ * decision call) because tool-call semantics need a different request
+ * shape and a multi-turn `history` parameter. We keep them decoupled so
+ * Moderator decision calls never accidentally pick up tool defs.
+ *
+ * Backend: Gemini's `:generateContent` API only for the MVP. OpenAI is
+ * TODO — same idea (tools, tool_choice, tool_calls in response, then a
+ * follow-up call with `tool` role messages), but the request shape is
+ * different enough that we don't share code.
+ *
+ * Reuses the IPv4-only fetch from telegram-api.ts is NOT needed here —
+ * gemini hits go via the credbroker on Tailscale, IPv6 path works.
+ */
+
+import type { ToolCall, ToolDefinition, ToolResult } from "./worker-tools.js";
+
+export type WorkerLlmFormat = "gemini" | "openai";
+
+export type WorkerLlmConfig = {
+  format: WorkerLlmFormat;
+  baseUrl: string;
+  model: string;
+  apiKeyEnv?: string;
+};
+
+/**
+ * One "turn" of conversation. The history list lets us send back the
+ * model's prior tool calls + the tool results, then ask for the final
+ * answer.
+ */
+export type WorkerLlmTurn =
+  | { role: "user"; text: string }
+  | { role: "assistant"; text?: string; toolCalls?: ToolCall[] }
+  | { role: "tool"; toolName: string; content: string };
+
+export type WorkerLlmRequest = {
+  systemPrompt: string;
+  /** Conversation so far. For the first call, just `[{role:"user", text:...}]`. */
+  history: WorkerLlmTurn[];
+  /** Tool defs (omit or pass [] to disable tool calling). */
+  tools?: ToolDefinition[];
+  maxOutputTokens?: number;
+  temperature?: number;
+};
+
+export type WorkerLlmResponse =
+  | {
+      ok: true;
+      text: string;
+      toolCalls?: ToolCall[];
+      inputTokens?: number;
+      outputTokens?: number;
+      latencyMs?: number;
+      model?: string;
+    }
+  | { ok: false; error: string; latencyMs?: number };
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export class WorkerLlmClient {
+  private readonly apiKey?: string;
+  constructor(private readonly cfg: WorkerLlmConfig) {
+    if (cfg.format !== "gemini" && cfg.format !== "openai") {
+      throw new Error(`[worker-llm] format must be gemini|openai, got ${cfg.format}`);
+    }
+    if (cfg.format === "openai") {
+      // Lazy: just throw at call time. Tool support not implemented yet.
+    }
+    this.apiKey = cfg.apiKeyEnv ? process.env[cfg.apiKeyEnv] : undefined;
+  }
+
+  async chat(req: WorkerLlmRequest): Promise<WorkerLlmResponse> {
+    const start = Date.now();
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), DEFAULT_TIMEOUT_MS);
+    try {
+      if (this.cfg.format === "gemini") {
+        return await this.chatGemini(req, ctrl.signal, start);
+      }
+      // OpenAI path: single-shot only (tools TODO). When tools are
+      // requested on this format we just ignore them so the worker can
+      // still answer with text — the model's choice gets logged so the
+      // operator can see this branch fired.
+      return await this.chatOpenAiSingleShot(req, ctrl.signal, start);
+    } catch (e) {
+      return { ok: false, error: (e as Error).message, latencyMs: Date.now() - start };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /* ------------------------------- Gemini ----------------------------------*/
+
+  private async chatGemini(
+    req: WorkerLlmRequest,
+    signal: AbortSignal,
+    start: number,
+  ): Promise<WorkerLlmResponse> {
+    const baseTrimmed = this.cfg.baseUrl.replace(/\/+$/, "");
+    const url = `${baseTrimmed}/v1beta/models/${encodeURIComponent(this.cfg.model)}:generateContent`;
+    const body: Record<string, unknown> = {
+      systemInstruction: { parts: [{ text: req.systemPrompt }] },
+      contents: req.history.map(turnToGeminiContent),
+      generationConfig: {
+        maxOutputTokens: req.maxOutputTokens ?? 800,
+        temperature: req.temperature ?? 0.4,
+      },
+    };
+    if (req.tools && req.tools.length > 0) {
+      body.tools = [
+        {
+          functionDeclarations: req.tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+          })),
+        },
+      ];
+    }
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    const resp = await fetch(
+      this.apiKey ? `${url}?key=${encodeURIComponent(this.apiKey)}` : url,
+      { method: "POST", headers, signal, body: JSON.stringify(body) },
+    );
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => "");
+      return {
+        ok: false,
+        error: `HTTP ${resp.status}: ${txt.slice(0, 300)}`,
+        latencyMs: Date.now() - start,
+      };
+    }
+    const json = (await resp.json()) as {
+      candidates?: Array<{
+        content?: {
+          parts?: Array<{
+            text?: string;
+            functionCall?: { name?: string; args?: Record<string, unknown> };
+          }>;
+        };
+      }>;
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
+    };
+    const parts = json.candidates?.[0]?.content?.parts ?? [];
+    const text = parts.map((p) => p.text ?? "").join("").trim();
+    const toolCalls: ToolCall[] = parts
+      .filter((p) => p.functionCall?.name)
+      .map((p) => ({
+        name: p.functionCall!.name!,
+        args: (p.functionCall!.args ?? {}) as Record<string, unknown>,
+      }));
+    return {
+      ok: true,
+      text,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      inputTokens: json.usageMetadata?.promptTokenCount,
+      outputTokens: json.usageMetadata?.candidatesTokenCount,
+      latencyMs: Date.now() - start,
+      model: this.cfg.model,
+    };
+  }
+
+  /* ------------------------------- OpenAI ----------------------------------*/
+
+  /**
+   * Single-shot OpenAI-compat path. Multi-turn + tool-calling on OpenAI is
+   * deferred (separate request shape) — for now, we flatten the history
+   * into a single user prompt and forward. Anything that needs tools must
+   * be on the gemini transport.
+   */
+  private async chatOpenAiSingleShot(
+    req: WorkerLlmRequest,
+    signal: AbortSignal,
+    start: number,
+  ): Promise<WorkerLlmResponse> {
+    const url = `${this.cfg.baseUrl.replace(/\/+$/, "")}/v1/chat/completions`;
+    const userText = req.history
+      .filter((t) => t.role === "user")
+      .map((t) => (t.role === "user" ? t.text : ""))
+      .join("\n\n");
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (this.apiKey) {headers.authorization = `Bearer ${this.apiKey}`;}
+    const resp = await fetch(url, {
+      method: "POST",
+      headers,
+      signal,
+      body: JSON.stringify({
+        model: this.cfg.model,
+        messages: [
+          { role: "system", content: req.systemPrompt },
+          { role: "user", content: userText },
+        ],
+        max_tokens: req.maxOutputTokens ?? 800,
+        temperature: req.temperature ?? 0.4,
+      }),
+    });
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => "");
+      return { ok: false, error: `HTTP ${resp.status}: ${txt.slice(0, 300)}`, latencyMs: Date.now() - start };
+    }
+    const json = (await resp.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      ok: true,
+      text: (json.choices?.[0]?.message?.content ?? "").trim(),
+      inputTokens: json.usage?.prompt_tokens,
+      outputTokens: json.usage?.completion_tokens,
+      latencyMs: Date.now() - start,
+      model: this.cfg.model,
+    };
+  }
+}
+
+/**
+ * Map our turn shape to Gemini's `contents` entry. The role mapping:
+ *   - user   → role:"user"   parts:[{text}]
+ *   - assistant text → role:"model" parts:[{text}]
+ *   - assistant toolCalls → role:"model" parts:[{functionCall:{...}}]
+ *   - tool result → role:"user" parts:[{functionResponse:{name, response:{result}}}]
+ *
+ * Gemini doesn't have a separate "tool" role — function responses go
+ * back as user-role content with a `functionResponse` part. The model
+ * recognizes them by structure.
+ */
+function turnToGeminiContent(turn: WorkerLlmTurn): {
+  role: "user" | "model";
+  parts: Array<Record<string, unknown>>;
+} {
+  if (turn.role === "user") {
+    return { role: "user", parts: [{ text: turn.text }] };
+  }
+  if (turn.role === "assistant") {
+    const parts: Array<Record<string, unknown>> = [];
+    if (turn.text) {parts.push({ text: turn.text });}
+    if (turn.toolCalls) {
+      for (const tc of turn.toolCalls) {
+        parts.push({ functionCall: { name: tc.name, args: tc.args } });
+      }
+    }
+    return { role: "model", parts: parts.length > 0 ? parts : [{ text: "" }] };
+  }
+  // tool
+  // Try to parse the tool content as JSON for the response field; fall
+  // back to a string wrapper so Gemini's validator doesn't reject it.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(turn.content);
+  } catch {
+    parsed = { result: turn.content };
+  }
+  return {
+    role: "user",
+    parts: [
+      {
+        functionResponse: {
+          name: turn.toolName,
+          response: typeof parsed === "object" && parsed !== null ? parsed : { result: parsed },
+        },
+      },
+    ],
+  };
+}
+
+export function buildWorkerLlmFromConfig(cfg: WorkerLlmConfig): WorkerLlmClient {
+  return new WorkerLlmClient(cfg);
+}
+
+/* --------- thin helper: single-shot text-only (no tools, no history) ------ */
+/**
+ * Convenience wrapper for the non-tool path. Lets dispatchWorker keep
+ * the single-call shape it had pre-tools without rewriting it.
+ */
+export async function chatSingle(
+  client: WorkerLlmClient,
+  systemPrompt: string,
+  userPrompt: string,
+  maxOutputTokens?: number,
+): Promise<WorkerLlmResponse> {
+  return client.chat({
+    systemPrompt,
+    history: [{ role: "user", text: userPrompt }],
+    maxOutputTokens,
+  });
+}
+
+export function exportToolResultsAsHistory(
+  assistantToolCalls: ToolCall[],
+  results: ToolResult[],
+): WorkerLlmTurn[] {
+  return [
+    { role: "assistant", toolCalls: assistantToolCalls },
+    ...results.map<WorkerLlmTurn>((r) => ({
+      role: "tool",
+      toolName: r.name,
+      content: r.content,
+    })),
+  ];
+}

--- a/src/moderator/worker-tools.ts
+++ b/src/moderator/worker-tools.ts
@@ -1,0 +1,170 @@
+/**
+ * Worker tool registry — the "limbs" we hand the LLM.
+ *
+ * Leverage principle (memory: complementary-not-replacement):
+ *   We DON'T decide when to call these — the model does. We only define
+ *   the surface (what tools exist, what they take, what they return) and
+ *   route the calls. A stronger LLM uses tools more cleverly; we get
+ *   smarter answers for free, no code changes here.
+ *
+ * Roles are allowlisted at the role level (`worker_roles.tools`). A role
+ * with `tools=[]` runs single-shot exactly like before — no regression
+ * for older role rows. DEFAULT_ROLE intentionally has zero tools.
+ *
+ * Phase-E candidates (NOT in this MVP):
+ *   - escalate_to_human({reason}) — DM the operator + pause scope
+ *   - schedule_followup({delaySeconds, text}) — cron a future ping
+ *   - kb_lookup({path}) — read a curated KB doc verbatim
+ *   - record_correction({wrongAnswer, correctAnswer}) — explicit memory write
+ */
+
+import type { Pool } from "pg";
+import type { EmbeddingClient } from "../embedding/client.js";
+import type { ResolvedMemoryPostgresConfig } from "../config.js";
+import { recall } from "../recall/router.js";
+import type { ViewerScope } from "../recall/viewer-scope.js";
+
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, { type: string; description?: string }>;
+    required?: string[];
+  };
+};
+
+export type ToolCall = { name: string; args: Record<string, unknown> };
+export type ToolResult = { name: string; content: string };
+
+export type ToolRuntimeDeps = {
+  pool: Pool;
+  embedding: EmbeddingClient;
+  cfg: ResolvedMemoryPostgresConfig;
+  agentId: string;
+  viewer: ViewerScope | undefined;
+};
+
+/* ------------------------------- definitions ------------------------------ */
+
+const MEMORY_SEARCH: ToolDefinition = {
+  name: "memory_search",
+  description:
+    "Search the agent's long-term memory store for relevant chunks. " +
+    "Returns up to N highest-scoring text passages, each with a source label. " +
+    "Use when the user's question references prior conversations, established facts, " +
+    "or domain knowledge that may have been stored. Do NOT use for general world knowledge.",
+  parameters: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Search query in the same language as the user's question. Be specific.",
+      },
+      topic: {
+        type: "string",
+        description: "Optional topic filter (e.g. 'math.fractions', 'policy.returns'). Narrows results.",
+      },
+      max: {
+        type: "number",
+        description: "Max results to return. Default 5, hard cap 10.",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+/** Single source of truth — map[toolName] → ToolDefinition. */
+const REGISTRY: Record<string, ToolDefinition> = {
+  memory_search: MEMORY_SEARCH,
+};
+
+/** Returns tool defs for an allowlist (skips unknown names silently). */
+export function resolveTools(toolNames: string[]): ToolDefinition[] {
+  return toolNames
+    .map((n) => REGISTRY[n])
+    .filter((t): t is ToolDefinition => t !== undefined);
+}
+
+export function listAvailableToolNames(): string[] {
+  return Object.keys(REGISTRY);
+}
+
+/* -------------------------------- executor -------------------------------- */
+
+const MEMORY_SEARCH_MAX = 10;
+const MEMORY_SEARCH_DEFAULT = 5;
+const MAX_CHUNK_CHARS_IN_RESULT = 300;
+
+/**
+ * Execute one tool call. Errors are converted into ToolResult content
+ * (never throw) so the LLM sees them in the next turn and can react.
+ */
+export async function executeTool(
+  deps: ToolRuntimeDeps,
+  call: ToolCall,
+): Promise<ToolResult> {
+  if (call.name === "memory_search") {
+    return execMemorySearch(deps, call.args);
+  }
+  return {
+    name: call.name,
+    content: JSON.stringify({ error: `unknown_tool: ${call.name}` }),
+  };
+}
+
+export async function executeToolsBatch(
+  deps: ToolRuntimeDeps,
+  calls: ToolCall[],
+): Promise<ToolResult[]> {
+  // Parallel — independent calls.
+  return Promise.all(calls.map((c) => executeTool(deps, c)));
+}
+
+async function execMemorySearch(
+  deps: ToolRuntimeDeps,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const query = typeof args.query === "string" ? args.query.trim() : "";
+  if (query.length < 2) {
+    return {
+      name: "memory_search",
+      content: JSON.stringify({ error: "query required (>=2 chars)" }),
+    };
+  }
+  const topic = typeof args.topic === "string" ? args.topic : undefined;
+  const maxRaw = typeof args.max === "number" ? args.max : MEMORY_SEARCH_DEFAULT;
+  const max = Math.min(MEMORY_SEARCH_MAX, Math.max(1, Math.floor(maxRaw)));
+  try {
+    const rr = await recall(
+      { cfg: deps.cfg, pool: deps.pool, embedding: deps.embedding },
+      {
+        query,
+        maxResults: max,
+        agentId: deps.agentId,
+        viewer: deps.viewer,
+        conceptTags: topic ? [topic] : undefined,
+      },
+    );
+    const results = rr.results.map((c, i) => ({
+      idx: i + 1,
+      source: c.source ?? "memory",
+      text: (c.text ?? "").slice(0, MAX_CHUNK_CHARS_IN_RESULT),
+      score: Number(c.combinedScore?.toFixed(3) ?? 0),
+    }));
+    return {
+      name: "memory_search",
+      content: JSON.stringify({
+        query,
+        topic,
+        count: results.length,
+        results,
+      }),
+    };
+  } catch (e) {
+    return {
+      name: "memory_search",
+      content: JSON.stringify({ error: `recall_failed: ${(e as Error).message}` }),
+    };
+  }
+}

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -22,17 +22,19 @@
 
 import type { Pool } from "pg";
 import { randomUUID } from "node:crypto";
-import type { ModeratorLlm } from "./runner.js";
 import type { AnswerTask } from "./types.js";
 import type { EmbeddingClient } from "../embedding/client.js";
 import { recall } from "../recall/router.js";
 import type { ViewerScope } from "../recall/viewer-scope.js";
 import type { ResolvedMemoryPostgresConfig } from "../config.js";
 import { storeCachedAnswer } from "../cache/qa.js";
+import { chatSingle, exportToolResultsAsHistory, type WorkerLlmClient } from "./worker-llm.js";
+import { executeToolsBatch, resolveTools, type ToolCall } from "./worker-tools.js";
 
 export type WorkerDeps = {
   pool: Pool;
-  llm: ModeratorLlm;
+  /** Tool-aware LLM client (uses Gemini's :generateContent endpoint). */
+  workerLlm: WorkerLlmClient;
   embedding: EmbeddingClient;
   cfg: ResolvedMemoryPostgresConfig;
   agentId: string;
@@ -104,12 +106,22 @@ export async function upsertWorkerRole(
   if (Number.parseInt(cnt.rows[0]?.n ?? "0", 10) >= MAX_AGENT_CREATED_ROLES) {
     return false;
   }
+  // Whitelist: only allow tool names that actually exist in the registry.
+  // We never trust the LLM-supplied tool name verbatim — a typo or
+  // hallucinated tool would silently never run, but at least we don't
+  // store garbage in the DB.
+  const { listAvailableToolNames } = await import("./worker-tools.js");
+  const known = new Set(listAvailableToolNames());
+  const requestedTools = Array.isArray(spec.tools)
+    ? spec.tools.filter((t): t is string => typeof t === "string" && known.has(t))
+    : [];
+
   const r = await pool.query(
     `INSERT INTO moderator.worker_roles
        (id, agent_id, role_key, display_name, system_prompt, tools,
         memory_scope, model, created_by_scope)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4, '{}'::text[],
-             $5::jsonb, $6, $7)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5::text[],
+             $6::jsonb, $7, $8)
      ON CONFLICT (agent_id, role_key) DO NOTHING
      RETURNING id`,
     [
@@ -117,6 +129,7 @@ export async function upsertWorkerRole(
       roleKey,
       spec.displayName ?? roleKey,
       spec.systemPrompt,
+      requestedTools,
       JSON.stringify(spec.memoryScope ?? {}),
       DEFAULT_ROLE.model, // model preference inherits default; can be tuned per-row later
       createdByScope,
@@ -177,8 +190,10 @@ export type WorkerResult = {
     outputTokens?: number;
     latencyMs?: number;
   };
-  /** How many memory chunks were merged into the prompt. */
+  /** How many memory chunks were merged into the prompt (proactive recall, NOT tool). */
   recallCount: number;
+  /** Tool calls the model invoked during this dispatch (if any). */
+  toolCalls?: ToolCall[];
   errors: string[];
 };
 
@@ -273,29 +288,88 @@ export async function dispatchWorker(
   const userPrompt = userPromptParts.join("\n\n");
 
   // --- LLM call ---
-  let llmOut: Awaited<ReturnType<ModeratorLlm["call"]>>;
-  try {
-    llmOut = await deps.llm.call({
-      systemPrompt: role.systemPrompt,
-      userPrompt,
-      maxTokens: WORKER_MAX_OUTPUT_TOKENS,
-      temperature: 0.4,
-    });
-  } catch (e) {
-    return {
-      taskId: task.taskId,
-      roleKey: role.roleKey,
-      ok: false,
-      answer: "",
-      questionText: cleanedQ,
-      topicTag,
-      llm: {},
-      recallCount,
-      errors: [`llm-call-failed: ${(e as Error).message}`],
-    };
+  // Two paths:
+  //   - No tools allowlisted → single-shot (current behavior, zero regression)
+  //   - Tools available     → one round of tool-call → execute → final answer
+  const tools = resolveTools(role.tools);
+  const totals = { inputTokens: 0, outputTokens: 0, model: undefined as string | undefined };
+  const startLatency = Date.now();
+  let toolCallsExecuted: ToolCall[] = [];
+
+  if (tools.length === 0) {
+    // ----- single-shot path -----
+    const res = await chatSingle(deps.workerLlm, role.systemPrompt, userPrompt, WORKER_MAX_OUTPUT_TOKENS);
+    if (!res.ok) {
+      return failureResult(task, role, cleanedQ, topicTag, recallCount, res.error);
+    }
+    totals.inputTokens = res.inputTokens ?? 0;
+    totals.outputTokens = res.outputTokens ?? 0;
+    totals.model = res.model;
+    return successResult(task, role, res.text, cleanedQ, topicTag, recallCount, totals, Date.now() - startLatency, toolCallsExecuted);
   }
 
-  const answer = (llmOut.text ?? "").trim();
+  // ----- tool-call path: one round max -----
+  const turn1 = await deps.workerLlm.chat({
+    systemPrompt: role.systemPrompt,
+    history: [{ role: "user", text: userPrompt }],
+    tools,
+    maxOutputTokens: WORKER_MAX_OUTPUT_TOKENS,
+    temperature: 0.4,
+  });
+  if (!turn1.ok) {
+    return failureResult(task, role, cleanedQ, topicTag, recallCount, turn1.error);
+  }
+  totals.inputTokens += turn1.inputTokens ?? 0;
+  totals.outputTokens += turn1.outputTokens ?? 0;
+  totals.model = turn1.model;
+
+  // Model didn't call any tool — accept the text it returned (this is the
+  // expected path when the question is trivial).
+  if (!turn1.toolCalls || turn1.toolCalls.length === 0) {
+    return successResult(task, role, turn1.text, cleanedQ, topicTag, recallCount, totals, Date.now() - startLatency, toolCallsExecuted);
+  }
+
+  // Execute the tools, then ask for the final answer.
+  toolCallsExecuted = turn1.toolCalls;
+  deps.logger.info(
+    `worker[${task.taskId}]: model invoked ${turn1.toolCalls.length} tool(s): ${turn1.toolCalls.map((c) => c.name).join(",")}`,
+  );
+  const toolResults = await executeToolsBatch(
+    { pool: deps.pool, embedding: deps.embedding, cfg: deps.cfg, agentId: deps.agentId, viewer },
+    turn1.toolCalls,
+  );
+  const turn2 = await deps.workerLlm.chat({
+    systemPrompt: role.systemPrompt,
+    history: [
+      { role: "user", text: userPrompt },
+      ...exportToolResultsAsHistory(turn1.toolCalls, toolResults),
+    ],
+    tools, // still present in case model wants to refuse another call cleanly
+    maxOutputTokens: WORKER_MAX_OUTPUT_TOKENS,
+    temperature: 0.4,
+  });
+  if (!turn2.ok) {
+    return failureResult(task, role, cleanedQ, topicTag, recallCount, turn2.error);
+  }
+  totals.inputTokens += turn2.inputTokens ?? 0;
+  totals.outputTokens += turn2.outputTokens ?? 0;
+  // If the model tries to call MORE tools on the second turn we just take
+  // whatever text it has — we don't go to a 3rd round (cost + latency).
+  return successResult(task, role, turn2.text, cleanedQ, topicTag, recallCount, totals, Date.now() - startLatency, toolCallsExecuted);
+}
+
+function successResult(
+  task: AnswerTask,
+  role: RoleSpec,
+  rawText: string,
+  cleanedQ: string,
+  topicTag: string | undefined,
+  recallCount: number,
+  totals: { inputTokens: number; outputTokens: number; model: string | undefined },
+  latencyMs: number,
+  toolCallsExecuted: ToolCall[],
+): WorkerResult {
+  const answer = (rawText ?? "").trim();
   const ok = answer.length > 0 && !answer.startsWith(`{"action":"ignore"`); // sentinel guard
   return {
     taskId: task.taskId,
@@ -305,13 +379,35 @@ export async function dispatchWorker(
     questionText: cleanedQ,
     topicTag,
     llm: {
-      model: llmOut.model,
-      inputTokens: llmOut.inputTokens,
-      outputTokens: llmOut.outputTokens,
-      latencyMs: llmOut.latencyMs,
+      model: totals.model,
+      inputTokens: totals.inputTokens,
+      outputTokens: totals.outputTokens,
+      latencyMs,
     },
     recallCount,
+    toolCalls: toolCallsExecuted.length > 0 ? toolCallsExecuted : undefined,
     errors: ok ? [] : ["empty-or-fallback-llm-output"],
+  };
+}
+
+function failureResult(
+  task: AnswerTask,
+  role: RoleSpec,
+  cleanedQ: string,
+  topicTag: string | undefined,
+  recallCount: number,
+  errorMsg: string,
+): WorkerResult {
+  return {
+    taskId: task.taskId,
+    roleKey: role.roleKey,
+    ok: false,
+    answer: "",
+    questionText: cleanedQ,
+    topicTag,
+    llm: {},
+    recallCount,
+    errors: [`llm-call-failed: ${errorMsg}`],
   };
 }
 


### PR DESCRIPTION
## Why

Per project principle (\`feedback_complementary_not_replacement.md\`): give the LLM **strict new capabilities** it cannot prompt-engineer its way into.

\`memory_search\` lets the worker pull arbitrary context from \`semantic.chunks\` mid-answer. No amount of context-window growth can substitute for direct access to a persistent multi-session store.

This sets up the **tool runtime rails** — future tools (\`escalate_to_human\`, \`schedule_followup\`, \`kb_lookup\`, \`record_correction\`) are 30-line additions to one registry file.

## What

- \`src/moderator/worker-tools.ts\` — tool registry + executor (just \`memory_search\` for MVP)
- \`src/moderator/worker-llm.ts\` — tool-aware Gemini transport. Single tool-call round max. OpenAI single-shot fallback (tool-call shape TODO).
- \`src/moderator/workers.ts\` — \`dispatchWorker\` branches on \`role.tools.length > 0\`. Empty = exact prior single-shot path (no regression).
- \`AnswerTask.newRoleSpec.tools?: string[]\` — when the Moderator coins a new specialist (auto-register PR), it can grant tools. Whitelisted against the registered set; typos silently become \`[]\`.

## Guards

- Role-level allowlist (\`worker_roles.tools\`). DEFAULT_ROLE has no tools, so existing roles keep current behavior.
- One tool-call round max (no nested loops) — bounds cost/latency.
- Tool execution errors return as ToolResult content, never throw — the LLM sees the error and reacts.
- \`parseDecision\` caps \`newRoleSpec.tools\` at 8 entries.

## Test plan

- [x] \`npm run build\` clean
- [x] All 7 concurrency-sim scenarios pass; scenario G specifically:
  1. Register role with \`tools=['memory_search']\`
  2. Dispatch question inviting a search
  3. Verify \`result.toolCalls\` populated with \`memory_search({query, max})\`
  4. Final answer composed from tool results
- [x] Gateway restart clean
- [ ] Live test: configure a role with \`memory_search\` and verify mid-answer tool call in logs

## Deferred

- OpenAI tool-call format (request shape differs enough to warrant a separate code path)
- Additional tools: \`escalate_to_human\`, \`schedule_followup\`, \`kb_lookup\`
- Multi-round tool loops (today: 1 round max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)