### PR TITLE
Fix cache pollution by non-answers + clarify fallback + vague follow-up prompt hint

### DIFF
--- a/src/moderator/decisions.ts
+++ b/src/moderator/decisions.ts
@@ -39,6 +39,10 @@ Picking rules:
   • Speaker states durable fact ("我是初二的") → write-only
   • Group chatter, no mention → ignore
   • "我不懂" x3 OR "找老师" → escalate
+  • Vague follow-up (e.g. "research", "再查一下", "上网看看") with
+    no noun phrase → inherit the most recent prior user question's
+    topic; answer-direct against THAT topic. Only clarify if no
+    recent question exists.
   • Intent unclear → clarify
 
 memoryWrites scope: "user" = about speaker, "chat" = about this room,

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -491,15 +491,19 @@ function ensureUserFacingReply(decision: import("./types.js").ModeratorDecision)
   if (hasUserFacing) {return;}
   let text: string;
   if (decision.action === "clarify") {
-    // Strip "the bot needs..." / "the user's ..." model-talk; if rationale
-    // is empty or model-meta, fall back to a generic Chinese prompt.
-    const r = decision.rationale?.trim() ?? "";
-    text = r.length > 0 && r.length < 280
-      ? `能不能再说具体一点？${r}`
-      : "能不能再说具体一点？我不太确定你想问什么。";
+    // Never echo the model's rationale verbatim — it's English model-meta
+    // like "The user is instructing the bot to..." which leaks into the
+    // Chinese reply. Keep this generic and Chinese. The Moderator can
+    // emit a richer custom clarify message via telegramActions if it
+    // wants; this is the last-resort backstop.
+    text = "能不能再说具体一点？我没看懂你想问什么。";
   } else {
+    // For escalate the summary is usually clean enough to surface, but
+    // still gate on it being non-English-model-meta. Strict ASCII-only
+    // summary → suppress to generic.
     const sum = decision.escalation?.summary?.trim() ?? "";
-    text = sum.length > 0
+    const isAscii = sum.length > 0 && /^[\x00-\x7F]+$/.test(sum);
+    text = sum.length > 0 && !isAscii
       ? `这个问题我先转给人工：${sum}`
       : "这个问题超出我能处理的范围，已转给人工。";
   }

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -469,6 +469,38 @@ export async function runWorkersForDecision(
 const CACHE_TTL_DAYS_DEFAULT = 90;
 
 /**
+ * Heuristics for "the worker said it doesn't know". We must NOT write
+ * these to cache.qa — otherwise the L2 semantic precheck happily serves
+ * "I don't know" forever to anyone asking a similar question, blocking
+ * the worker (and thus web_search) from ever running again. This bug
+ * was seen live: an "openclaw latest update" question got cached as
+ * "记忆里没有信息" → next semantically-close question hit that row at
+ * sim=0.95 and the user got the stale non-answer.
+ *
+ * The patterns intentionally err on the side of OVER-rejecting (better
+ * to cache nothing than to cache a non-answer). Real answers that
+ * legitimately contain "我不知道" as part of a longer response (rare)
+ * will be skipped — that's acceptable.
+ */
+const NON_ANSWER_PATTERNS: RegExp[] = [
+  /没有.{0,20}(信息|记录|资料|内容|结果)/,
+  /(知识库|记忆|材料|历史).{0,8}(没有|不包含|找不到)/,
+  /(暂无|没找到|查不到|没有找到|未找到).{0,20}/,
+  /(无法|不能).{0,10}提供.{0,20}/,
+  /我不知道|不太清楚|无从得知/,
+  /\bI (don'?t|do not) (know|have)\b/i,
+  /\b(no|not) (information|data|results?) (available|found)\b/i,
+  /\bcannot (provide|find|access)\b/i,
+];
+
+function looksLikeNonAnswer(text: string): boolean {
+  const t = text.trim();
+  // Very short replies are likely non-answers ("不知道。" / "Unknown").
+  if (t.length < 12) {return true;}
+  return NON_ANSWER_PATTERNS.some((p) => p.test(t));
+}
+
+/**
  * Persist a successful worker answer into cache.qa so the next equivalent
  * question hits the pre-check. Fire-and-forget — failure is logged but
  * doesn't block the user reply.
@@ -484,6 +516,13 @@ export async function writeAnswerToCache(
   task: AnswerTask,
 ): Promise<string | null> {
   if (!result.ok || !result.answer || result.answer.length < 2) {return null;}
+  // Don't cache non-answers — see NON_ANSWER_PATTERNS rationale above.
+  if (looksLikeNonAnswer(result.answer)) {
+    deps.logger.info(
+      `worker[${result.taskId}]: skipping cache write — answer looks like a non-answer`,
+    );
+    return null;
+  }
   try {
     // Embed the CLEANED question (matches what precheck.ts hashes/embeds).
     // taskPrefix: null — we're embedding the *question* as a passage for


### PR DESCRIPTION
## Three live bugs from one test session

**1. Cache pollution by 'I don't know' answers**
- Live: openclaw-update question got a non-answer; it got cached; next similar question hit it at sim=0.95 → user saw the stale non-answer forever → web_search never had a chance to run because cache pre-check short-circuited the worker.
- Fix: \`looksLikeNonAnswer()\` guard in \`writeAnswerToCache\`. Refuses to cache rows matching decline patterns (zh + en). Polluted row id=04222d42 deleted by hand.

**2. Clarify fallback leaked English rationale into Chinese reply**
- Live: user saw \"能不能再说具体一点？The user is instructing the bot to 'research and look online'...\" — model's English rationale concatenated into the user reply.
- Fix: \`ensureUserFacingReply\` uses generic Chinese only; never echoes rationale. Escalate path keeps summary only if not ASCII-only.

**3. Moderator didn't carry context across vague follow-ups**
- Live: \"research 上网看一下\" after \"openclaw github 更新\" got \`action=clarify\` instead of inheriting prior topic. \`recentMessages\` state IS populated (verified 10 messages in DB) — model just chose clarify.
- Fix: one-line SYSTEM_PROMPT rule — vague follow-up without noun phrase inherits the most recent prior question's topic.

## Test plan

- [x] \`npm run build\` clean
- [x] Polluted cache row deleted, gateway restarted clean
- [ ] Live: same question \"最新的 openclaw github 更新\" should now miss cache, dispatch worker, worker invokes web_search, returns real info with URLs
- [ ] Live: \"研究一下\" after a concrete question → expect answer-direct on the prior topic, not clarify

🤖 Generated with [Claude Code](https://claude.com/claude-code)