### PR TITLE
Decouple plugin for fresh installs (multi-tenant, no hidden tailnet URLs, README scope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 - **Multi-key indexing** ("Xinhua dictionary"): every chunk reachable from many orthogonal angles — semantic / fulltext / trigram / concept tags / entity refs / time buckets / anchors / categories
 - **Deterministic-first ingest**: no LLM in the hot path; LLM exists only as a residual stage when deterministic extraction yields nothing
 - **Hard per-agent memory namespace isolation**: run a private agent and a public Discord agent on the same database — they physically can't see each other's memory (SQL-layer enforcement, not application-layer)
+- **Semantic Q&A cache** (`cache.qa`): repeat questions hit at sub-millisecond (L0 LRU) → ~5ms (L1 exact hash) → ~50ms (L2 HNSW). Skips the LLM entirely on repeat questions.
+- **Telegram-group Moderator** (optional, off by default): orchestrator-worker pattern à la Anthropic's "Building Effective Agents". Routes group `@-mentions` to specialist workers with tools (`memory_search`, `web_search` via Tavily), persists role designs so the registry compounds over time.
 - **Real-time dashboard** (bilingual CN/EN) with category breakdown, redaction for health/medical, bot-turn telemetry, side-by-side model comparison
 - **Self-tuning loop** (daily / weekly / monthly proposals)
 - **Universal HTTP ingest gateway** — any cron / skill / external script can write memory through the same Stage 0–6 pipeline
@@ -135,9 +137,41 @@ In a typical workload, ingest spends **0 LLM tokens** end-to-end. Recall LLM tok
 - Their `text_excerpt` is redacted in the dashboard's `/api/recent` response
 - Per-agent isolation means a public-facing agent **cannot** retrieve them even via adversarial prompting
 
+## Scope & limits
+
+Be explicit about what this plugin is and isn't, so you can decide if it fits before installing:
+
+### The **memory pipeline** (recall, ingest, dashboard, cache, isolation) is channel-agnostic
+Works with any openclaw agent — DM, Discord, Slack, WhatsApp, etc. Ingest accepts text from any source via the HTTP gateway. **No coupling to a specific channel or bot account.**
+
+### The **Moderator** (Phase C / D, opt-in) is **Telegram-group-only** today
+When `moderator.enabled=true`, the plugin registers a `before_dispatch` hook that claims **group @-mentions on the `telegram` channel** — codex (or whatever other plugin would have replied) is suppressed for those messages; the Moderator replies out-of-band via the Telegram Bot API.
+
+- **DMs are untouched** — codex handles them as before
+- **Group messages without an @-mention are untouched** — codex doesn't reply to those anyway
+- **Slack / Discord / WhatsApp `@-mentions` are NOT claimed** — only `channelId === "telegram"` matches today
+
+If you want the Moderator on another channel, the suppression rule (`index.ts` → `before_dispatch` hook) and the Telegram-Bot-API reply path (`src/moderator/telegram-api.ts`) both need adaptation. Issue/PR welcome.
+
+### Single-tenant by default; explicitly multi-tenant
+Every row this plugin writes carries an `agent_id` column. The Moderator uses `cfg.moderator.agentId` (default `"main"`). To run two openclaw instances against the same Postgres without collision, give each install a distinct `agentId`:
+
+```jsonc
+"moderator": { "enabled": true, "agentId": "tutor-bot" }
+```
+
+`worker_roles`, `moderator.state`, `moderator.decisions`, and `cache.qa` rows are all namespaced — the agents can't see each other's state.
+
+### `web_search` tool requires a Tavily endpoint
+Either `credbroker.baseUrl` (Tailscale credential broker that proxies Tavily — see [docs/CONFIG.md](docs/CONFIG.md)) or `TAVILY_API_KEY` in env. **Without one, `web_search` returns an honest error** to the LLM (which then explains the limitation to the user). No silent failures.
+
+### LLM transport
+- Moderator decision LLM: **OpenAI-compatible** or **Gemini `:generateContent`** (with tool calls). OpenAI tool-call format is single-shot only today; multi-turn tool calls require Gemini.
+- Embedding: **Jina, OpenAI-compat, or Ollama**. Default is Jina free tier.
+
 ## Status
 
-`v0.1.0` — initial public release. Core architecture is settled; APIs may evolve in `0.x` based on feedback. Live tests pass against the reference setup. See [CHANGELOG.md](CHANGELOG.md).
+`v0.2.x` — memory pipeline + dashboard stable; Moderator + worker-tools layer (Phase C/D) live-tested but newer. Live tests pass against the reference setup. Concurrency simulation covers 8 scenarios (cache stampede, cross-scope parallelism, viewer isolation, mixed load, worker round-trip, role auto-register, tool calls, web_search). See [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -465,6 +465,7 @@ export default definePluginEntry({
                 ingestToken,
                 cfg,
                 pool,
+                agentId: cfg.moderator.agentId,
                 logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
                 debounceMs: cfg.moderator.debounceMs,
               });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -582,9 +582,14 @@
       "moderator": {
         "type": "object",
         "additionalProperties": false,
-        "description": "Phase C orchestrator-worker Moderator. When enabled, hooks Telegram message_received events for groups + DMs (DMs continue through the existing per-DM agent path; groups get routed via the Moderator). Off by default.",
+        "description": "Phase C orchestrator-worker Moderator. When enabled, claims Telegram group @-mentions via the `before_dispatch` hook and runs an orchestrator-worker decision loop. DMs are untouched (codex still handles them). Off by default.",
         "properties": {
           "enabled": { "type": "boolean", "default": false },
+          "agentId": {
+            "type": "string",
+            "default": "main",
+            "description": "Namespace separator on every row this service writes (moderator.state, moderator.decisions, cache.qa rows produced by workers, moderator.worker_roles). Change this if you run a second openclaw instance against the same Postgres."
+          },
           "debounceMs": {
             "type": "number",
             "minimum": 100,

--- a/src/config.ts
+++ b/src/config.ts
@@ -155,10 +155,13 @@ export type MemoryPostgresConfig = {
 
 export type ModeratorConfig = {
   enabled?: boolean;
+  /** Namespace separator on every row this service writes. Default "main".
+   *  Set this if you run a second openclaw instance against the same DB. */
+  agentId?: string;
   /** LLM transport — mirrors reflection.model. Default: gpt-5.5 via OpenAI. */
   model?: {
     format: "openai" | "gemini";
-    baseUrl: string;
+    baseUrl?: string;
     model: string;
     apiKeyEnv?: string;
   };
@@ -321,6 +324,7 @@ export type ResolvedMemoryPostgresConfig = {
 
 export type ResolvedModeratorConfig = {
   enabled: boolean;
+  agentId: string;
   debounceMs: number;
   model: {
     format: "openai" | "gemini";
@@ -511,6 +515,9 @@ function resolveModeratorConfig(
   const credbrokerFallback = format === "gemini" ? credbroker.geminiUrl : null;
   return {
     enabled: bool(block.enabled, false),
+    agentId: isString((block as { agentId?: unknown }).agentId)
+      ? ((block as { agentId: string }).agentId)
+      : "main",
     debounceMs: Math.max(100, num(block.debounceMs, 1500)),
     model: {
       format,

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -56,6 +56,11 @@ export type ModeratorServiceConfig = {
   /** Resolved nextclaw config (mostly for agentId, pool). */
   cfg: ResolvedMemoryPostgresConfig;
   pool: Pool;
+  /** Owning agent id — the namespace separator on every row this service
+   *  writes (state, decisions, cache.qa rows produced by workers,
+   *  worker_roles). Default "main". Set to something else if you run a
+   *  second openclaw instance against the same Postgres. */
+  agentId?: string;
   /** Logger; the api.logger from openclaw works. */
   logger: { info: (m: string) => void; warn: (m: string) => void };
   /** Per-user debounce window in ms. Default 1500. */
@@ -99,6 +104,7 @@ export type PluginMessageContext = {
 export function startModeratorService(config: ModeratorServiceConfig): ModeratorServiceHandle {
   const tg = new TelegramBotApi({ botToken: config.telegramBotToken });
   const debounceMs = config.debounceMs ?? 1500;
+  const agentId = config.agentId ?? "main";
 
   // Per-scope serial queue: one in-flight cycle per scopeKey at a time.
   const scopeMutex = new Map<string, Promise<void>>();
@@ -159,10 +165,10 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
   ): Promise<void> {
     try {
       // 1. Load state (or init).
-      const state = await loadModeratorState(config.pool, config.cfg ? "main" : "main", scopeKey);
+      const state = await loadModeratorState(config.pool, agentId, scopeKey);
 
       // 2. Skip if scope is paused (operator did /takeover).
-      const status = await readScopeStatus(config.pool, scopeKey);
+      const status = await readScopeStatus(config.pool, agentId, scopeKey);
       if (status === "paused" || status === "archived") {
         config.logger.info(`moderator: scope ${scopeKey} is ${status}, skipping`);
         return;
@@ -173,7 +179,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
       //      The bulk of repeat-question savings lives here (~50ms vs 6s,
       //      0 vs 1500 Gemini tokens).
       const precheck = await tryCachePrecheck(
-        { pool: config.pool, embedding: config.embedding, agentId: "main" },
+        { pool: config.pool, embedding: config.embedding, agentId: agentId },
         {
           scopeKey,
           questionText: trigger.text,
@@ -195,7 +201,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           config.logger.warn(`moderator: cache-hit send failed: ${sendRes.error}`);
         }
         // Persist the inbound + a synthetic "cache-hit" decision row for audit.
-        await saveModeratorState(config.pool, "main", scopeKey, {
+        await saveModeratorState(config.pool, agentId, scopeKey, {
           ...state,
           recentMessages: [...state.recentMessages, trigger].slice(-50),
           messagesSinceLastReview: state.messagesSinceLastReview + 1,
@@ -205,7 +211,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           lastMessageAt: new Date(),
         });
         await logDecision(config.pool, {
-          agentId: "main",
+          agentId: agentId,
           scopeKey,
           triggerKind: "message",
           triggerUserId: senderUserId,
@@ -249,7 +255,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
         ingestUrl: config.ingestUrl,
         ingestToken: config.ingestToken,
         triggerSenderUserId: senderUserId,
-        agentId: "main",
+        agentId: agentId,
         logger: config.logger,
       });
 
@@ -271,7 +277,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           workerLlm: config.workerLlm,
           embedding: config.embedding,
           cfg: config.cfg,
-          agentId: "main",
+          agentId: agentId,
           logger: config.logger,
         };
         const viewer = { userId: senderUserId, chatId };
@@ -325,7 +331,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
       }
 
       // 6. Save state. If escalation asked to pause the scope, flip status.
-      await saveModeratorState(config.pool, "main", scopeKey, updatedState, {
+      await saveModeratorState(config.pool, agentId, scopeKey, updatedState, {
         bumpMessageCount: 1,
         bumpDecisionCount: 1,
         lastMessageAt: new Date(),
@@ -336,7 +342,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
 
       // 7. Decision audit log.
       await logDecision(config.pool, {
-        agentId: "main",
+        agentId: agentId,
         scopeKey,
         triggerKind: "message",
         triggerUserId: senderUserId,
@@ -510,10 +516,10 @@ function ensureUserFacingReply(decision: import("./types.js").ModeratorDecision)
   decision.telegramActions = [...acts, { kind: "send_message", text }];
 }
 
-async function readScopeStatus(pool: Pool, scopeKey: string): Promise<string | null> {
+async function readScopeStatus(pool: Pool, agentId: string, scopeKey: string): Promise<string | null> {
   const r = await pool.query<{ status: string }>(
-    `SELECT status FROM moderator.state WHERE agent_id = 'main' AND scope_key = $1`,
-    [scopeKey],
+    `SELECT status FROM moderator.state WHERE agent_id = $1 AND scope_key = $2`,
+    [agentId, scopeKey],
   );
   return r.rows[0]?.status ?? null;
 }

--- a/src/moderator/worker-tools.ts
+++ b/src/moderator/worker-tools.ts
@@ -214,10 +214,14 @@ const WEB_SEARCH_SNIPPET_CHARS = 400;
  *      from `cfg.credbroker.tavilyUrl`) — preferred path.
  *   2. `NEXTCLAW_WEB_SEARCH_URL` env override.
  *   3. `TAVILY_API_KEY` env → direct api.tavily.com.
- *   4. Hard-coded fallback (kept so an ill-configured deployment still
- *      tries something; logged as a soft warning the operator should fix).
+ *
+ * Returns null when web_search is NOT configured on this deployment. The
+ * caller (execWebSearch) then returns an honest error to the LLM rather
+ * than silently hitting a hardcoded URL that only works in one developer's
+ * tailnet — see the original bug: a placeholder URL pointing at the
+ * author's home network would time out for everyone else.
  */
-function resolveWebSearchEndpoint(fromDeps: string | null): { url: string; apiKey?: string } {
+function resolveWebSearchEndpoint(fromDeps: string | null): { url: string; apiKey?: string } | null {
   if (fromDeps) {return { url: fromDeps, apiKey: process.env.TAVILY_API_KEY };}
   const explicit = process.env.NEXTCLAW_WEB_SEARCH_URL;
   if (explicit) {
@@ -227,15 +231,26 @@ function resolveWebSearchEndpoint(fromDeps: string | null): { url: string; apiKe
   if (directKey) {
     return { url: "https://api.tavily.com/search", apiKey: directKey };
   }
-  // Last-resort placeholder. Real deployments should set credbroker or
-  // TAVILY_API_KEY; this URL is just so the call doesn't crash silently.
-  return { url: "http://100.79.97.110:8800/v1/proxy/tavily/search" };
+  return null;
 }
 
 async function execWebSearch(
   args: Record<string, unknown>,
   webSearchUrl: string | null,
 ): Promise<ToolResult> {
+  const endpoint = resolveWebSearchEndpoint(webSearchUrl);
+  if (!endpoint) {
+    return {
+      name: "web_search",
+      content: JSON.stringify({
+        error:
+          "web_search is not configured on this deployment. " +
+          "Operator: set credbroker.baseUrl in config OR export TAVILY_API_KEY. " +
+          "If the user's question needs current/live information, tell them you " +
+          "don't have web access here and suggest they check the source directly.",
+      }),
+    };
+  }
   const query = typeof args.query === "string" ? args.query.trim() : "";
   if (query.length < 2) {
     return {
@@ -245,7 +260,7 @@ async function execWebSearch(
   }
   const maxRaw = typeof args.max === "number" ? args.max : WEB_SEARCH_DEFAULT;
   const max = Math.min(WEB_SEARCH_MAX, Math.max(1, Math.floor(maxRaw)));
-  const { url, apiKey } = resolveWebSearchEndpoint(webSearchUrl);
+  const { url, apiKey } = endpoint;
   const body: Record<string, unknown> = { query, max_results: max };
   if (apiKey) {body.api_key = apiKey;}
   const ctrl = new AbortController();

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -114,6 +114,12 @@ export async function upsertWorkerRole(
   roleKey: string,
   spec: NonNullable<import("./types.js").AnswerTask["newRoleSpec"]>,
   createdByScope: string,
+  /** Model identifier to store in the row's `model` column. Advisory
+   *  only (runtime uses the injected WorkerLlmClient). When omitted
+   *  we fall back to DEFAULT_ROLE.model — but real deployments should
+   *  pass `${cfg.moderator.model.format}:${cfg.moderator.model.model}`
+   *  so the row reflects what's actually wired. */
+  modelIdentifier?: string,
 ): Promise<boolean> {
   // Soft cap — refuse silently if the agent has too many roles already.
   const cnt = await pool.query<{ n: string }>(
@@ -149,7 +155,7 @@ export async function upsertWorkerRole(
       spec.systemPrompt,
       requestedTools,
       JSON.stringify(spec.memoryScope ?? {}),
-      DEFAULT_ROLE.model, // model preference inherits default; can be tuned per-row later
+      modelIdentifier ?? DEFAULT_ROLE.model,
       createdByScope,
     ],
   );
@@ -265,12 +271,17 @@ export async function dispatchWorker(
   // DEFAULT_ROLE, mirroring the pre-leverage behavior.
   if (task.newRoleSpec) {
     try {
+      // Pass the deployment's actual configured Moderator model so the
+      // stored row reflects what's wired (not a hardcoded gemini-flash).
+      const runtimeModel =
+        `${deps.cfg.moderator.model.format}:${deps.cfg.moderator.model.model}`;
       const created = await upsertWorkerRole(
         deps.pool,
         deps.agentId,
         task.roleKey,
         task.newRoleSpec,
         scopeKey,
+        runtimeModel,
       );
       if (created) {
         deps.logger.info(
@@ -547,8 +558,10 @@ const NON_ANSWER_PATTERNS: RegExp[] = [
 
 function looksLikeNonAnswer(text: string): boolean {
   const t = text.trim();
-  // Very short replies are likely non-answers ("不知道。" / "Unknown").
-  if (t.length < 12) {return true;}
+  if (t.length === 0) {return true;}
+  // No length floor — a short answer like "2" to "1+1=?" is legit. The
+  // pattern set below catches real non-answers (declines, "I don't know",
+  // "no information found"); brevity alone isn't a signal.
   return NON_ANSWER_PATTERNS.some((p) => p.test(t));
 }
 


### PR DESCRIPTION
Audit found three things that would block a fresh install by anyone other than the author. Plus README updates to set scope honestly.

## P1 fixes

**1. \`web_search\` no-config path used to hit \`100.79.97.110:8800\`** (my tailnet IP) as silent fallback. Fresh installs without credbroker AND without TAVILY_API_KEY would time out trying to reach my home network. Now: \`resolveWebSearchEndpoint\` returns \`null\`; \`execWebSearch\` returns an honest error JSON to the LLM (\"web_search is not configured. Operator: set credbroker.baseUrl OR TAVILY_API_KEY\"). The model surfaces the limitation to the user instead of pretending to search.

**2. \`agentId: \"main\"\` was scattered as a literal** across service.ts (10+ sites) + readScopeStatus. Two openclaw instances on the same Postgres collide. Now \`ModeratorServiceConfig.agentId\` is a first-class field (default \"main\"); schema exposes \`cfg.moderator.agentId\` so each install can be namespaced.

## P2 fix

**3. \`DEFAULT_ROLE.model = 'gemini:gemini-2.5-flash'\`** was stored verbatim into \`worker_roles.model\` column regardless of what the deployment actually uses (OpenAI / local LLM users would see misleading rows). Now \`upsertWorkerRole\` accepts a runtime model identifier; dispatchWorker passes \`\${cfg.moderator.model.format}:\${cfg.moderator.model.model}\`.

## README — new \"Scope & limits\" section

Sets honest boundaries so installers know what they're getting:
- memory pipeline is channel-agnostic
- Moderator is **Telegram-group-only** today (before_dispatch hook only matches \`channelId === \"telegram\"\`)
- DMs / Slack / Discord / WhatsApp untouched — codex handles them
- single-tenant by default, explicitly multi-tenant via \`cfg.moderator.agentId\`
- web_search requires credbroker.baseUrl OR TAVILY_API_KEY (honest error otherwise)
- LLM transport matrix (OpenAI / Gemini, tool-calls Gemini-only today)

Status bumped to v0.2.x with sim coverage call-out.

## Bonus

Tiny bug surfaced by the sim: \`looksLikeNonAnswer\`'s \`length < 12\` guard over-rejected short legit answers like \"2\" (math). Pattern set is sufficient; dropped the length floor.

## Test plan

- [x] \`npm run build\` clean
- [x] concurrency-sim 8/8 pass
- [x] Gateway restart clean
- [ ] Fresh install on another machine: set Postgres URL + \`JINA_API_KEY\` + enable moderator, expect everything to work without my IP showing up anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)