### PR TITLE
docs: SERVICES.md service catalog + INSTALL.md capability levels A→D

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@
 - **Self-tuning loop** (daily / weekly / monthly proposals)
 - **Universal HTTP ingest gateway** — any cron / skill / external script can write memory through the same Stage 0–6 pipeline
 
-## Quick start
+## Quick start (Level A — memory only, ~20 min)
+
+For the Telegram Moderator, web_search, and reflection upgrades, see the [INSTALL.md](docs/INSTALL.md) bolt-ons. **Read [SERVICES.md](docs/SERVICES.md) first** to know which external services each capability needs.
 
 ```bash
-# 1. Install OpenClaw
+# 1. Install OpenClaw (the host runtime — required)
 git clone https://github.com/openclaw/openclaw.git ~/openclaw
 cd ~/openclaw && pnpm install && pnpm build
 
@@ -60,35 +62,61 @@ cd ~/openclaw && pnpm install && pnpm build
 git clone https://github.com/NextAgentBC/nextclaw.git ~/openclaw/extensions/memory-postgres
 cd ~/openclaw/extensions/memory-postgres/dev && docker compose up -d
 
-# 3. Get a free Jina embedding key (no card, 1M tokens)
-#    https://jina.ai/embeddings/  → copy the key
+# 3. Get a free Jina embedding key — 30 seconds, no card, 1M tokens/key.
+#    https://jina.ai/embeddings/  → click "Get API key for free" → copy
 export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+echo 'export JINA_API_KEY=...' >> ~/.bashrc
 
 # 4. Build the plugin
 cd ~/openclaw && pnpm install && pnpm build
 
-# 5. Configure ~/.openclaw/openclaw.json — minimal:
-#      "plugins": {
-#        "slots": { "memory": "memory-postgres" },
-#        "entries": { "memory-postgres": { "enabled": true, "config": {
-#          "postgres": { "url": "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw" }
-#        }}}
-#      }
-#    (embedding block is OPTIONAL — defaults to Jina free with JINA_API_KEY)
+# 5. Configure ~/.openclaw/openclaw.json — minimum to boot:
+cat > ~/.openclaw/openclaw.json <<'EOF'
+{
+  "plugins": {
+    "slots": { "memory": "memory-postgres" },
+    "entries": {
+      "memory-postgres": {
+        "enabled": true,
+        "config": {
+          "postgres": { "url": "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw" },
+          "dashboard": { "enabled": true, "tokenEnv": "NEXTCLAW_DASH_TOKEN" }
+        }
+      }
+    }
+  }
+}
+EOF
+# (embedding block is OPTIONAL — defaults to Jina free with JINA_API_KEY)
 
 # 6. Start
 export NEXTCLAW_DASH_TOKEN=$(openssl rand -hex 24)
 pnpm openclaw gateway start
 
-# 7. Smoke test
+# 7. Smoke test — write then recall
 curl -sS -X POST http://127.0.0.1:8765/api/ingest \
   -H "Authorization: Bearer $NEXTCLAW_DASH_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"text":"My favorite Postgres extension is pgvector.","source":"smoke","agentId":"main"}'
+
+curl -sS -X POST http://127.0.0.1:8765/api/recall \
+  -H "Authorization: Bearer $NEXTCLAW_DASH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What is my favorite Postgres extension?","agentId":"main"}'
+# → returns the chunk with hitTier: "t2_hybrid"
 ```
 
-For the **0 → 1 walkthrough** with troubleshooting, persona files, and
-a Discord bot setup, see **[docs/INSTALL.md](docs/INSTALL.md)**.
+For the **full 0 → 1 walkthrough** with persona files, troubleshooting, Discord/Telegram bots, web_search, and multi-agent isolation, see **[docs/INSTALL.md](docs/INSTALL.md)**.
+
+### Installing nextclaw with help from an AI agent
+
+The docs are explicitly written to be read by both humans and LLM agents. If you'd like an agent to install nextclaw for you:
+
+1. Point the agent at **[docs/SERVICES.md](docs/SERVICES.md)** to enumerate which external services you'll need
+2. The agent walks through dependencies in order — Postgres → embedding → (optional) LLM → (optional) Telegram → (optional) Tavily — using each section's signup link, env-var name, and verification curl
+3. Final step: assemble the configured blocks into `openclaw.json` and run the smoke test in [INSTALL.md ⑦](docs/INSTALL.md#-start-then-verify-with-a-smoke-test)
+
+The "For AI agents" section at the bottom of SERVICES.md spells out the recommended dialogue flow.
 
 > **Want to self-host the embedder instead of Jina?** Run Ollama locally
 > and set `"embedding": { "format": "ollama" }` — the rest of the
@@ -104,7 +132,8 @@ a Discord bot setup, see **[docs/INSTALL.md](docs/INSTALL.md)**.
 
 | Doc | What it covers |
 |---|---|
-| **[docs/INSTALL.md](docs/INSTALL.md)** | Fresh-machine 0 → 1 walkthrough · Discord bot · multi-agent isolation · troubleshooting |
+| **[docs/SERVICES.md](docs/SERVICES.md)** | **Read first.** Every external service (Postgres, Jina, Gemini, Tavily, Telegram, OpenAI, credbroker) — signup links, env vars, config snippets, verification curls. Written for both AI agents and humans. |
+| **[docs/INSTALL.md](docs/INSTALL.md)** | Fresh-machine 0 → 1 walkthrough · Discord bot · Telegram Moderator · web_search · multi-agent isolation · troubleshooting. Four capability levels A → D you can ladder up through. |
 | **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** | Storage layout · 4-tier recall · 8-route hybrid · Stage 0–6 ingest · isolation guarantees · scoring · self-tuning · workers |
 | **[docs/CONFIG.md](docs/CONFIG.md)** | Every config field, default, tuning advice |
 | **[docs/LIVE_TESTS.md](docs/LIVE_TESTS.md)** | How to run live tests against a real PG + embedding endpoint |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,25 @@ This is the **fresh-machine** guide. If you already have OpenClaw + an
 embedding endpoint running, jump to step ④.
 
 Tested on Ubuntu 24.04 + macOS 14. Should work on any host with Docker +
-Node 22+. Estimated time: **30 minutes** end to end including downloads.
+Node 22+. Estimated time: **30 minutes** for the memory-only path, **+15
+minutes** if you also want the Telegram Moderator + `web_search`.
+
+> 📦 **Before you start: see [SERVICES.md](SERVICES.md)** for the
+> complete list of external services nextclaw can use (Postgres, Jina,
+> Gemini, Tavily, Telegram, OpenAI, credbroker), with signup links and
+> per-service verification commands. This walkthrough assumes you've
+> decided which services you want.
+
+### Capability levels (pick one before starting)
+
+| Level | What works | External services needed | Estimated time |
+|---|---|---|---|
+| **A. Memory only** | Recall, ingest, dashboard, isolation | Postgres + Jina | 20 min |
+| **B. + Reflection** | Above + nightly memory consolidation | Postgres + Jina + Gemini | 25 min |
+| **C. + Telegram Moderator** | Above + group `@bot` answers | Postgres + Jina + Gemini + Telegram bot | 40 min |
+| **D. + Web search** | Above + worker `web_search` for current info | Postgres + Jina + Gemini + Telegram + Tavily | 45 min |
+
+This walkthrough builds **Level A first**, then has bolt-on sections for B/C/D you can run later.
 
 ---
 
@@ -440,6 +458,140 @@ Verification — the club agent's `agent_id='club'` chunks are filtered at the
 SQL level on every recall path. A `WHERE c.agent_id = $X` clause stops
 cross-agent reads even if the prompt is adversarial. See
 [ARCHITECTURE.md](ARCHITECTURE.md) for the full isolation model.
+
+---
+
+## Bolt-on: nightly reflection (Level B)
+
+The reflection daemon reads the last 24h of conversation chunks and writes a single distilled `kind='reflection'` summary chunk + a `kind='profile'` set that gets primed into T0 (the model's working memory) on every recall. Result: long-running context survives across days without re-feeding history into the prompt.
+
+**Prerequisite:** an LLM endpoint. Free recommendation: **Gemini 2.5 Flash** — see [SERVICES.md §3](SERVICES.md#3-gemini-google-ai-studio--free-llm-for-moderator--reflection).
+
+```bash
+# Get a Gemini key from https://aistudio.google.com/apikey
+export GEMINI_API_KEY=AIza...
+```
+
+Add to `openclaw.json` under `memory-postgres.config`:
+
+```jsonc
+"reflection": {
+  "enabled": true,
+  "intervalMs": 86400000,
+  "lookbackHours": 24,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+Restart OpenClaw. Verify in logs:
+
+```
+memory-postgres: reflection daemon started — format=gemini model=gemini-2.5-flash intervalMs=86400000
+```
+
+The first reflection runs ~24h after startup. To force one early, manually call the dashboard endpoint (token required):
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8765/api/reflection/run-now" \
+  -H "Authorization: Bearer $NEXTCLAW_DASH_TOKEN"
+```
+
+---
+
+## Bolt-on: Telegram Moderator (Level C)
+
+The Moderator is an opinionated orchestrator-worker that **claims** Telegram group `@-mentions` away from codex (or whatever else would have answered) and runs a multi-step decision loop:
+
+1. Cache pre-check (L0/L1/L2) — repeats answered in <50ms with 0 LLM tokens
+2. Moderator decision — gpt-5.5 / gemini-flash picks `answer-direct` / `clarify` / `escalate` / etc.
+3. Worker dispatch — specialist role + memory_search + (optional) web_search
+4. Reply via Telegram Bot API — placeholder ⏳ first, edited with answer when ready
+5. Write answer back to cache.qa so next similar question hits the pre-check
+
+DMs are NOT claimed — codex handles them as before.
+
+**Prerequisites:**
+1. **Telegram bot token** — get from [@BotFather](https://t.me/BotFather), see [SERVICES.md §4](SERVICES.md#4-telegram-bot--required-for-moderator)
+2. **Your Telegram user ID** — get from [@userinfobot](https://t.me/userinfobot)
+3. **LLM endpoint** (Gemini recommended, same key as reflection works)
+
+```bash
+# Already have these from Level B; just adding the Telegram pieces:
+export GEMINI_API_KEY=AIza...
+TELEGRAM_BOT_TOKEN=1234567890:AAH...   # not exported — goes inline in config
+TELEGRAM_OWNER_ID=8064984663            # YOUR Telegram user id from @userinfobot
+```
+
+Add to `openclaw.json` (top level, alongside `plugins`):
+
+```jsonc
+"channels": {
+  "telegram": {
+    "enabled": true,
+    "botToken": "1234567890:AAH...",
+    "polling": { "enabled": true }
+  }
+},
+"commands": {
+  "ownerAllowFrom": ["telegram:8064984663"]
+}
+```
+
+And under `memory-postgres.config`:
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "agentId": "main",
+  "debounceMs": 1500,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+**Set the IPv6 workaround on Oracle Cloud / hosts with broken IPv6**: see [docs/CONFIG.md](CONFIG.md#telegram-on-ipv6-broken-hosts) — add `OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY=1` to the systemd drop-in.
+
+Restart OpenClaw. Add your bot to a Telegram group. Send `@my_tutor_bot hello`. Watch:
+
+```bash
+journalctl --user -u openclaw-gateway --since "1 min ago" | grep -E "moderator|before_dispatch"
+```
+
+You should see `[moderator/hook] before_dispatch CLAIMED` followed by `moderator: scope=tg:chat:... action=answer-direct`. Bot replies with placeholder ⏳ then the actual answer.
+
+**Common gotcha:** Telegram bots in groups only see messages that **@-mention them** or **reply to their messages** (default privacy mode). That's exactly what the Moderator wants. Do NOT use `/setprivacy` → Disable unless you want the Moderator processing every group message.
+
+---
+
+## Bolt-on: web_search worker tool (Level D)
+
+Without this, the worker can answer from memory + LLM training but says it can't browse for current info (news, latest version numbers, anything time-sensitive). Adding Tavily unlocks live web search inside the worker's tool-call loop.
+
+**Get a Tavily key:** [SERVICES.md §5](SERVICES.md#5-tavily--web-search-for-the-moderators-web_search-tool) — free 1,000 searches/month.
+
+```bash
+export TAVILY_API_KEY=tvly-...
+echo 'export TAVILY_API_KEY=tvly-...' >> ~/.bashrc
+```
+
+**That's literally it — no config change needed.** The worker tool registry picks up `TAVILY_API_KEY` automatically when the env var is set. Restart OpenClaw and the next time someone asks the bot about a recent event, the worker will invoke `web_search({"query":"..."}` and cite URLs in the answer.
+
+**Verify after restart:** ask the bot something current like "@my_tutor_bot 今天有什么 AI 新闻". The log should show:
+
+```
+worker[tN]: model invoked 1 tool(s): web_search
+```
+
+If you see this but no answer: Tavily call failed (check `journalctl ... | grep web_search`). If you don't see this line at all: the worker decided memory was enough — that's the model's call.
 
 ---
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -1,0 +1,385 @@
+# External services nextclaw uses
+
+This doc lists every external service nextclaw can talk to, **why** you'd want it, **where to sign up**, and the **exact env var / config snippet** to wire it in.
+
+Written so both an AI agent (looking for `bash` blocks + JSON paths to act on) and a human (looking for the "why") can use it.
+
+---
+
+## TL;DR — capability matrix
+
+| You want… | You need at minimum |
+|---|---|
+| Long-term memory + recall (the core) | **Postgres + pgvector** + an **embedding endpoint** (Jina free is fine) |
+| Real-time dashboard + HTTP ingest | Just the core (add a random `NEXTCLAW_DASH_TOKEN`) |
+| Nightly reflection (memory consolidation) | Core + an **LLM endpoint** (Gemini free or OpenAI) |
+| Telegram-group **Moderator** (orchestrator-worker, claims `@mentions`) | Core + a **Telegram bot token** + **Gemini** (or OpenAI) |
+| Worker `web_search` tool | Above + **Tavily API key** OR a credbroker |
+| Worker `memory_search` tool | Core (no extra service) |
+| Multi-agent isolation across one Postgres | Core; just set `cfg.moderator.agentId` per install |
+
+Everything past row 1 is optional. The plugin runs with just core; further services unlock more behavior.
+
+---
+
+## 1. Postgres + pgvector (required)
+
+**Why:** stores all chunks, embeddings, audit, cache. nextclaw is a thin layer over the DB — no in-memory state survives restart without it.
+
+**Get it:**
+
+```bash
+# Bundled docker compose (recommended for a clean install)
+git clone https://github.com/NextAgentBC/nextclaw.git ~/nextclaw-tmp
+cd ~/nextclaw-tmp/dev
+docker compose up -d
+```
+
+This brings up `pgvector/pgvector:pg16` bound to `127.0.0.1:55432`, never the public interface. Volume `nextclaw_pg` persists across restarts.
+
+**Verify:**
+
+```bash
+docker exec -e PGPASSWORD=nextclaw nextclaw-pg \
+  psql -U nextclaw -d nextclaw -c "SELECT extname FROM pg_extension;"
+# Must list: vector, pg_trgm, btree_gin
+```
+
+**Config (in `~/.openclaw/openclaw.json` → `plugins.entries.memory-postgres.config`):**
+
+```jsonc
+"postgres": { "url": "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw" }
+```
+
+**Already have Postgres?** Skip the docker step; just give the plugin a URL with `vector`, `pg_trgm`, and `btree_gin` extensions installed. The plugin runs its own schema migrations on first start (`src/storage/schema/*.sql`).
+
+---
+
+## 2. Jina embeddings — recommended default (free)
+
+**Why:** turns text into 1024-dim vectors so semantic recall works. Jina's free tier covers ~1M tokens per key (≈ 500 days of typical chat use). Works well for Chinese + English.
+
+**Get a key:**
+
+1. Open [https://jina.ai/embeddings](https://jina.ai/embeddings/)
+2. Click **"Get API key for free"** — no credit card
+3. Copy the key (looks like `jina_xxxxxxxxxxxxxxxxxx`)
+
+**Set the env var:**
+
+```bash
+export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Persist it:
+echo 'export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' >> ~/.bashrc
+```
+
+**Verify:**
+
+```bash
+curl -sS https://api.jina.ai/v1/embeddings \
+  -H "Authorization: Bearer $JINA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"jina-embeddings-v3","input":["hello"]}' | head -c 200
+# Must return JSON with a data[].embedding array
+```
+
+**Config:** *no config block needed* — when `embedding` is omitted from openclaw.json, the plugin defaults to Jina (`format=jina`, `baseUrl=https://api.jina.ai`, `apiKeyEnv=JINA_API_KEY`).
+
+---
+
+## 2b. Alternative: Ollama (self-hosted, no API key)
+
+**Why:** zero rate limits, full privacy, runs offline. Needs ~1–4 GB RAM/GPU.
+
+**Get it:**
+
+```bash
+# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+# macOS
+brew install ollama   # or download from https://ollama.com
+
+ollama serve &                              # listens on 127.0.0.1:11434
+ollama pull qwen3-embedding:0.6b            # ~1 GB, multilingual, recommended
+# OR
+ollama pull nomic-embed-text                # ~274 MB, English-leaning
+```
+
+**Verify:**
+
+```bash
+curl -sS http://127.0.0.1:11434/api/embed \
+  -d '{"model":"qwen3-embedding:0.6b","input":"hello"}' | head -c 200
+```
+
+**Config:**
+
+```jsonc
+"embedding": {
+  "format": "ollama",
+  "model": "qwen3-embedding:0.6b"
+}
+```
+
+`baseUrl` defaults to `http://127.0.0.1:11434`; override if Ollama is on another host.
+
+---
+
+## 2c. Alternative: OpenAI-compatible (any provider, vLLM, TEI, etc.)
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+```jsonc
+"embedding": {
+  "format": "openai",
+  "baseUrl": "https://api.openai.com",
+  "model": "text-embedding-3-small",
+  "apiKeyEnv": "OPENAI_API_KEY"
+}
+```
+
+> ⚠️ **Embedding dimension is one-way.** Auto-detected on first ingest and locked into the HNSW index. Switching from `jina-embeddings-v3` (1024d) to `qwen3-embedding:4b` (4096d) requires `TRUNCATE semantic.chunks RESTART IDENTITY CASCADE` and re-ingesting everything. Pick a model you can live with for a few months.
+
+---
+
+## 3. Gemini (Google AI Studio) — free LLM for Moderator + reflection
+
+**Why:** the Moderator decision loop and the nightly reflection daemon both need a chat LLM. Gemini 2.5 Flash has a generous free tier (~250 RPD per key).
+
+**Get a key:**
+
+1. Open [https://aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+2. Sign in with a Google account
+3. **Create API key** → copy (looks like `AIza...`)
+
+**Set the env var:**
+
+```bash
+export GEMINI_API_KEY=AIza...
+echo 'export GEMINI_API_KEY=AIza...' >> ~/.bashrc
+```
+
+**Verify:**
+
+```bash
+curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"say hi"}]}]}' | head -c 200
+```
+
+**Config — Moderator:**
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+**Config — reflection (optional, nightly summary):**
+
+```jsonc
+"reflection": {
+  "enabled": true,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+---
+
+## 3b. Alternative LLM: OpenAI / OpenAI-compatible
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "model": {
+    "format": "openai",
+    "baseUrl": "https://api.openai.com",
+    "model": "gpt-5.5",
+    "apiKeyEnv": "OPENAI_API_KEY"
+  }
+}
+```
+
+> ⚠️ **Tool-calling**: today the worker tool-call path (`web_search`, `memory_search`) only fully supports Gemini's `:generateContent` API. With `format=openai` the worker runs in single-shot mode — answers will still work, but no mid-answer tool calls. OpenAI tool format is a TODO. If you want web search now, use Gemini.
+
+---
+
+## 4. Telegram bot — required for Moderator
+
+**Why:** the Moderator lives on Telegram groups. Without a bot account, the Moderator has nothing to claim or reply to.
+
+**Get a token:**
+
+1. Open Telegram, search for **`@BotFather`**, start a chat
+2. Send `/newbot`
+3. Follow prompts — pick a display name (e.g. `My Tutor Bot`) and a username (must end in `bot`, e.g. `my_tutor_bot`)
+4. BotFather replies with a token like `1234567890:AAH...long-string...`. **Copy it.**
+
+**Get your own user id (for owner-only commands):**
+
+1. Talk to **`@userinfobot`** in Telegram
+2. It replies with your numeric user id (e.g. `8064984663`)
+
+**Add the bot to your group:**
+
+1. Open the group → add member → search the bot's username → add
+2. Make sure the bot can read messages: by default, Telegram bots in groups **only see messages that @-mention them** or replies to their messages. That's exactly what the Moderator wants — group chatter stays private; only explicit mentions get processed.
+3. If you want the bot to see all group messages (NOT recommended for the Moderator), use BotFather → `/setprivacy` → Disable.
+
+**Config:**
+
+```jsonc
+"channels": {
+  "telegram": {
+    "enabled": true,
+    "botToken": "1234567890:AAH...",
+    "polling": { "enabled": true }
+  }
+},
+"commands": {
+  "ownerAllowFrom": ["telegram:8064984663"]
+}
+```
+
+**Verify the bot is alive:**
+
+```bash
+curl -sS "https://api.telegram.org/bot<YOUR_TOKEN>/getMe"
+# Should return {"ok":true,"result":{"id":...,"username":"my_tutor_bot",...}}
+```
+
+After OpenClaw restarts with this config, go to your group and send `@my_tutor_bot hello`. Watch `tail -f /tmp/openclaw/openclaw-*.log` for the `[moderator/hook] before_dispatch CLAIMED` line.
+
+---
+
+## 5. Tavily — web search for the Moderator's `web_search` tool
+
+**Why:** the worker `web_search` tool wraps Tavily. Without it, the Moderator can answer from memory + LLM training but can't pull current info (news, latest version numbers, etc.). The worker will say so honestly.
+
+**Get a key:**
+
+1. Open [https://app.tavily.com/](https://app.tavily.com/)
+2. Sign in with Google / GitHub / email
+3. **API Keys** in the sidebar → **Create new key** (free tier: 1,000 searches / month)
+4. Copy (looks like `tvly-...`)
+
+**Set the env var:**
+
+```bash
+export TAVILY_API_KEY=tvly-...
+echo 'export TAVILY_API_KEY=tvly-...' >> ~/.bashrc
+```
+
+**Verify:**
+
+```bash
+curl -sS https://api.tavily.com/search \
+  -H "Content-Type: application/json" \
+  -d "{\"api_key\":\"$TAVILY_API_KEY\",\"query\":\"openclaw github\",\"max_results\":2}" | head -c 200
+# Returns JSON with results[]
+```
+
+**Config:** *no config needed* — when `TAVILY_API_KEY` is in env, the worker's web_search tool auto-uses it. If both `credbroker.baseUrl` and `TAVILY_API_KEY` are set, credbroker wins.
+
+**If you skip this:** `web_search` returns `{"error":"web_search is not configured on this deployment..."}` to the LLM; the LLM tells the user it can't search the web; everything else still works.
+
+---
+
+## 6. Credbroker (optional — multi-host setups only)
+
+**Why:** if you have multiple machines on a Tailscale tailnet and want **zero API keys on caller hosts**, run a credential broker on one trusted "mainserver" and point everything at it. The broker injects credentials from its vault based on Tailscale identity.
+
+This is a power-user setup. If you don't already have one, skip.
+
+**Config:**
+
+```jsonc
+"credbroker": {
+  "baseUrl": "http://<mainserver-tailscale-ip>:8800",
+  "services": {
+    "embedding": "local-embed",
+    "gemini":    "gemini",
+    "tavily":    "tavily"
+  }
+}
+```
+
+When set, any per-service `baseUrl` that's **omitted** auto-derives as `${baseUrl}/v1/proxy/${service}`. Explicit URLs always win. The `services` block is optional — defaults match a common credbroker setup.
+
+**With credbroker** all per-service `baseUrl` + `apiKeyEnv` fields can be dropped:
+
+```jsonc
+"credbroker": { "baseUrl": "http://100.x.y.z:8800" },
+"embedding":  { "format": "openai", "model": "qwen3-embedding:0.6b" },
+"moderator":  { "enabled": true, "model": { "format": "gemini", "model": "gemini-2.5-flash" } },
+"reflection": { "enabled": true, "model": { "format": "gemini", "model": "gemini-2.5-flash" } }
+```
+
+Setting up a credbroker itself is out of scope here — see your tailnet's docs.
+
+---
+
+## 7. OpenClaw (host runtime — required)
+
+nextclaw is a plugin for [OpenClaw](https://github.com/openclaw/openclaw), not standalone. OpenClaw provides the agent runtime, channel ingress, hook system, and CLI.
+
+**Install:**
+
+```bash
+git clone --depth 1 https://github.com/openclaw/openclaw.git ~/openclaw
+cd ~/openclaw && pnpm install && pnpm build
+```
+
+**Verify:**
+
+```bash
+pnpm openclaw --version    # 2026.x.x
+pnpm openclaw doctor
+```
+
+If `pnpm` is missing: `npm i -g pnpm@latest`.
+
+---
+
+## Quick reference — env vars
+
+| Env var | Service | Optional? |
+|---|---|---|
+| `JINA_API_KEY` | Jina embeddings | Optional if you use Ollama/OpenAI |
+| `GEMINI_API_KEY` | Gemini LLM (Moderator + reflection) | Optional if Moderator disabled or using OpenAI |
+| `OPENAI_API_KEY` | OpenAI (LLM or embeddings) | Optional alternative to Gemini/Jina |
+| `TAVILY_API_KEY` | Web search tool | Optional — feature degrades to "no web access" without it |
+| `NEXTCLAW_DASH_TOKEN` | Dashboard auth | Required if dashboard enabled |
+| `NEXTCLAW_WEB_SEARCH_URL` | Override Tavily endpoint | Power-user only |
+
+---
+
+## For AI agents installing nextclaw on behalf of a user
+
+If you're an LLM agent helping a user install nextclaw, here's the recommended dialogue flow:
+
+1. **Ask the user what they want** — just memory? Or also a Telegram Moderator? Or web search too? Use the capability matrix at the top of this doc.
+2. **Check what they already have** — Docker? Node? An existing Postgres? A Telegram bot? Existing API keys?
+3. **Walk through services in dependency order:** Postgres → embedding → (if Moderator) LLM → (if Moderator) Telegram bot → (if web search) Tavily.
+4. **For each service:** read aloud the "Why" sentence (so the user knows what they're agreeing to), then either get a key from them or guide them through signup using the linked URLs in this doc.
+5. **Verify each step** with the `curl` snippet before moving on. Catching a wrong API key early saves debugging time later.
+6. **Final config:** assemble all the wired-up blocks into `~/.openclaw/openclaw.json`. Start OpenClaw. Run smoke test 1 from [INSTALL.md ⑦](INSTALL.md#-start-then-verify-with-a-smoke-test).
+
+The smoke test must pass before declaring success. If recall returns 0 results, the embedding service probably isn't wired right — check `/api/recent` for ingest errors first.


### PR DESCRIPTION
## Why

Existing docs covered \"how to install the memory pipeline\" but not \"which services do I need to sign up for, and where\". A user (or an AI agent helping them) couldn't answer \"where do I get a Tavily key\" without going back to the wider internet for each service.

## New: docs/SERVICES.md

Single catalog of every external service nextclaw uses. Per service:
- **Why** (one-liner, human-friendly)
- **Signup link** (Jina, Tavily, AI Studio, BotFather, etc.)
- **Steps** to get a key
- **\`export\` command** for the env var
- **\`curl\`** verification snippet
- **JSON config block** to paste into openclaw.json

Top has a capability matrix; bottom has a \"For AI agents\" section spelling out the dialogue flow an agent should follow when helping a user install.

Services covered: **Postgres + pgvector**, **Jina embeddings**, **Ollama**, **OpenAI-compat**, **Gemini (Google AI Studio)**, **Telegram bot (BotFather + @userinfobot)**, **Tavily**, **credbroker**, **OpenClaw**.

## Expanded: docs/INSTALL.md

Header now lists 4 **capability levels A → D** so users pick what they actually want before starting:

| Level | What works | External services | Time |
|---|---|---|---|
| A | Memory + recall + dashboard | Postgres + Jina | 20 min |
| B | + Nightly reflection | + Gemini | 25 min |
| C | + Telegram Moderator | + Telegram bot | 40 min |
| D | + Web search | + Tavily | 45 min |

Three new bolt-on sections before the troubleshooting block:
- **Level B**: reflection daemon wiring
- **Level C**: Telegram Moderator (BotFather token, owner id, channel config, IPv6 workaround pointer, privacy-mode gotcha, live log verification)
- **Level D**: web_search via Tavily key (no config change — env var alone is enough)

## README.md

- Quick start labelled \"Level A — memory only, ~20 min\" so readers know the minimum
- Heredoc'd openclaw.json snippet (copy-pastes directly)
- Smoke test now covers ingest + recall
- New section \"Installing nextclaw with help from an AI agent\" — 3-step dialogue flow pointing at SERVICES.md
- Documentation table prepends SERVICES.md as the \"read first\" entry

## No code changes

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)