### PR TITLE
Reuse OpenClaw's tavily plugin key (one credential, two consumers)

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -576,14 +576,9 @@ You should see `[moderator/hook] before_dispatch CLAIMED` followed by `moderator
 
 Without this, the worker can answer from memory + LLM training but says it can't browse for current info (news, latest version numbers, anything time-sensitive). Adding Tavily unlocks live web search inside the worker's tool-call loop.
 
-**Get a Tavily key:** [SERVICES.md §5](SERVICES.md#5-tavily--web-search-for-the-moderators-web_search-tool) — free 1,000 searches/month.
+**Already configured OpenClaw's tavily plugin** (you can tell because `openclaw doctor` mentions tavily, or you see `tavily web search provider selected` in startup logs)? **You're done.** nextclaw's Moderator worker auto-reuses the same Tavily key from `plugins.entries.tavily.config.webSearch.apiKey`. No env var, no extra config.
 
-```bash
-export TAVILY_API_KEY=tvly-...
-echo 'export TAVILY_API_KEY=tvly-...' >> ~/.bashrc
-```
-
-**That's literally it — no config change needed.** The worker tool registry picks up `TAVILY_API_KEY` automatically when the env var is set. Restart OpenClaw and the next time someone asks the bot about a recent event, the worker will invoke `web_search({"query":"..."}` and cite URLs in the answer.
+**Getting Tavily for the first time?** See [SERVICES.md §5](SERVICES.md#5-tavily--web-search-for-the-moderators-web_search-tool) — free 1,000 searches/month. Recommended path: put the key in `plugins.entries.tavily.config.webSearch.apiKey` so BOTH codex and the Moderator worker reuse one credential.
 
 **Verify after restart:** ask the bot something current like "@my_tutor_bot 今天有什么 AI 新闻". The log should show:
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -273,14 +273,48 @@ After OpenClaw restarts with this config, go to your group and send `@my_tutor_b
 
 **Why:** the worker `web_search` tool wraps Tavily. Without it, the Moderator can answer from memory + LLM training but can't pull current info (news, latest version numbers, etc.). The worker will say so honestly.
 
-**Get a key:**
+### Already have OpenClaw's tavily plugin configured? You're done.
+
+If your `openclaw.json` already has:
+```jsonc
+"plugins": { "entries": { "tavily": { "enabled": true, "config": { "webSearch": { "apiKey": "tvly-..." } } } } }
+```
+(this is the standard place OpenClaw stores the codex-side tavily key — its setup wizard puts it here)
+
+**Then nextclaw's worker AUTOMATICALLY reuses the same key.** No `TAVILY_API_KEY` env, no extra config. At plugin startup we read `plugins.entries.tavily.config.webSearch.apiKey` and pass it to the worker's tool runtime. Both codex AND our Moderator worker hit Tavily with one configured credential.
+
+Resolution priority for the worker (first match wins):
+1. `cfg.credbroker.tavilyUrl` (if you have a Tailscale credential broker)
+2. OpenClaw's `plugins.entries.tavily.config.webSearch.apiKey` ← **most users land here**
+3. `NEXTCLAW_WEB_SEARCH_URL` env
+4. `TAVILY_API_KEY` env
+5. Nothing configured → `web_search` returns an honest error to the LLM; the LLM tells the user it can't search.
+
+### Don't have a Tavily key yet?
 
 1. Open [https://app.tavily.com/](https://app.tavily.com/)
 2. Sign in with Google / GitHub / email
 3. **API Keys** in the sidebar → **Create new key** (free tier: 1,000 searches / month)
 4. Copy (looks like `tvly-...`)
 
-**Set the env var:**
+**Configure it (option A — recommended, also gives codex web search):**
+
+Add to `openclaw.json` so BOTH codex and the Moderator worker reuse one key:
+
+```jsonc
+"plugins": {
+  "entries": {
+    "tavily": {
+      "enabled": true,
+      "config": {
+        "webSearch": { "apiKey": "tvly-..." }
+      }
+    }
+  }
+}
+```
+
+**Configure it (option B — Moderator-only, no codex web search):**
 
 ```bash
 export TAVILY_API_KEY=tvly-...
@@ -292,13 +326,13 @@ echo 'export TAVILY_API_KEY=tvly-...' >> ~/.bashrc
 ```bash
 curl -sS https://api.tavily.com/search \
   -H "Content-Type: application/json" \
-  -d "{\"api_key\":\"$TAVILY_API_KEY\",\"query\":\"openclaw github\",\"max_results\":2}" | head -c 200
+  -d "{\"api_key\":\"tvly-...\",\"query\":\"openclaw github\",\"max_results\":2}" | head -c 200
 # Returns JSON with results[]
 ```
 
-**Config:** *no config needed* — when `TAVILY_API_KEY` is in env, the worker's web_search tool auto-uses it. If both `credbroker.baseUrl` and `TAVILY_API_KEY` are set, credbroker wins.
+### Why two paths exist
 
-**If you skip this:** `web_search` returns `{"error":"web_search is not configured on this deployment..."}` to the LLM; the LLM tells the user it can't search the web; everything else still works.
+OpenClaw's tavily plugin registers a search tool for the **codex agent loop** — codex picks it up via `WebSearchProviderPlugin.createTool()`. Our Moderator worker is a **separate LLM call** outside codex's loop (it's the orchestrator dispatching specialists, not codex itself). So technically we run our own Tavily request. We just reuse codex's configured key so the operator doesn't pay attention twice.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -419,6 +419,14 @@ export default definePluginEntry({
               channels?: { telegram?: { botToken?: string } };
               commands?: { ownerAllowFrom?: string[] };
               gateway?: { auth?: { token?: string } };
+              plugins?: {
+                entries?: {
+                  tavily?: {
+                    enabled?: boolean;
+                    config?: { webSearch?: { apiKey?: string; apiKeyEnv?: string } };
+                  };
+                };
+              };
             };
             const botToken = live.channels?.telegram?.botToken ?? "";
             const ownerEntry = (live.commands?.ownerAllowFrom ?? [])
@@ -426,6 +434,23 @@ export default definePluginEntry({
             const ownerUserId = ownerEntry ? ownerEntry.replace(/^telegram:/, "") : undefined;
             const dashTokenEnv = cfg.dashboard.tokenEnv;
             const ingestToken = dashTokenEnv ? (process.env[dashTokenEnv] ?? "") : "";
+
+            // Reuse OpenClaw's tavily plugin credential when the operator
+            // has already configured it for codex — saves them configuring
+            // the same key twice. Resolution: inline apiKey wins; otherwise
+            // apiKeyEnv → env lookup; otherwise undefined (worker falls
+            // through to TAVILY_API_KEY env / credbroker / null).
+            const openclawTavily = live.plugins?.entries?.tavily;
+            let tavilyApiKey: string | undefined;
+            if (openclawTavily?.enabled !== false && openclawTavily?.config?.webSearch) {
+              const ws = openclawTavily.config.webSearch;
+              if (typeof ws.apiKey === "string" && ws.apiKey.length > 0) {
+                tavilyApiKey = ws.apiKey;
+              } else if (typeof ws.apiKeyEnv === "string") {
+                const v = process.env[ws.apiKeyEnv];
+                if (v && v.length > 0) {tavilyApiKey = v;}
+              }
+            }
 
             if (!botToken) {
               api.logger.warn(
@@ -466,6 +491,7 @@ export default definePluginEntry({
                 cfg,
                 pool,
                 agentId: cfg.moderator.agentId,
+                tavilyApiKey,
                 logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
                 debounceMs: cfg.moderator.debounceMs,
               });

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -61,6 +61,12 @@ export type ModeratorServiceConfig = {
    *  worker_roles). Default "main". Set to something else if you run a
    *  second openclaw instance against the same Postgres. */
   agentId?: string;
+  /** Tavily API key — used by the worker's `web_search` tool when
+   *  cfg.credbroker.tavilyUrl isn't set. We reuse OpenClaw's tavily plugin
+   *  credential here (read at startup from
+   *  `plugins.entries.tavily.config.webSearch.apiKey`) so operators don't
+   *  configure Tavily twice. Falls back to `TAVILY_API_KEY` env if undefined. */
+  tavilyApiKey?: string;
   /** Logger; the api.logger from openclaw works. */
   logger: { info: (m: string) => void; warn: (m: string) => void };
   /** Per-user debounce window in ms. Default 1500. */
@@ -278,6 +284,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           embedding: config.embedding,
           cfg: config.cfg,
           agentId: agentId,
+          tavilyApiKey: config.tavilyApiKey ?? null,
           logger: config.logger,
         };
         const viewer = { userId: senderUserId, chatId };

--- a/src/moderator/worker-tools.ts
+++ b/src/moderator/worker-tools.ts
@@ -43,10 +43,13 @@ export type ToolRuntimeDeps = {
   cfg: ResolvedMemoryPostgresConfig;
   agentId: string;
   viewer: ViewerScope | undefined;
-  /** Optional override for the Tavily endpoint. When omitted the
-   *  executor falls back to env-var resolution. Service.ts passes
-   *  `cfg.credbroker.tavilyUrl` here so the runtime URL is config-driven. */
+  /** Optional override for the Tavily endpoint URL (e.g. a credbroker
+   *  proxy). Set by service.ts from `cfg.credbroker.tavilyUrl`. */
   webSearchUrl?: string | null;
+  /** Optional Tavily API key — typically reused from OpenClaw's tavily
+   *  plugin config so operators don't configure Tavily twice. Used when
+   *  webSearchUrl isn't set; we then POST to api.tavily.com directly. */
+  tavilyApiKey?: string | null;
 };
 
 /* ------------------------------- definitions ------------------------------ */
@@ -137,7 +140,7 @@ export async function executeTool(
     return execMemorySearch(deps, call.args);
   }
   if (call.name === "web_search") {
-    return execWebSearch(call.args, deps.webSearchUrl ?? null);
+    return execWebSearch(call.args, deps.webSearchUrl ?? null, deps.tavilyApiKey ?? null);
   }
   return {
     name: call.name,
@@ -209,20 +212,22 @@ const WEB_SEARCH_TIMEOUT_MS = 12_000;
 const WEB_SEARCH_SNIPPET_CHARS = 400;
 
 /**
- * Resolve the Tavily endpoint:
- *   1. Explicit `webSearchUrl` from ToolRuntimeDeps (set by service.ts
- *      from `cfg.credbroker.tavilyUrl`) — preferred path.
- *   2. `NEXTCLAW_WEB_SEARCH_URL` env override.
- *   3. `TAVILY_API_KEY` env → direct api.tavily.com.
- *
- * Returns null when web_search is NOT configured on this deployment. The
- * caller (execWebSearch) then returns an honest error to the LLM rather
- * than silently hitting a hardcoded URL that only works in one developer's
- * tailnet — see the original bug: a placeholder URL pointing at the
- * author's home network would time out for everyone else.
+ * Resolve the Tavily endpoint. Priority order (first match wins):
+ *   1. `webSearchUrl` from deps (credbroker proxy URL set in cfg).
+ *   2. `tavilyApiKey` from deps — typically REUSED from OpenClaw's
+ *      `plugins.entries.tavily.config.webSearch.apiKey` so operators
+ *      who already configured tavily for codex don't configure it
+ *      twice. Hits api.tavily.com directly.
+ *   3. `NEXTCLAW_WEB_SEARCH_URL` env override (operator escape hatch).
+ *   4. `TAVILY_API_KEY` env → direct api.tavily.com (legacy env path).
+ *   5. null → execWebSearch returns an honest error to the LLM.
  */
-function resolveWebSearchEndpoint(fromDeps: string | null): { url: string; apiKey?: string } | null {
-  if (fromDeps) {return { url: fromDeps, apiKey: process.env.TAVILY_API_KEY };}
+function resolveWebSearchEndpoint(
+  fromDeps: string | null,
+  depsApiKey: string | null,
+): { url: string; apiKey?: string } | null {
+  if (fromDeps) {return { url: fromDeps, apiKey: depsApiKey ?? process.env.TAVILY_API_KEY };}
+  if (depsApiKey) {return { url: "https://api.tavily.com/search", apiKey: depsApiKey };}
   const explicit = process.env.NEXTCLAW_WEB_SEARCH_URL;
   if (explicit) {
     return { url: explicit, apiKey: process.env.TAVILY_API_KEY };
@@ -237,8 +242,9 @@ function resolveWebSearchEndpoint(fromDeps: string | null): { url: string; apiKe
 async function execWebSearch(
   args: Record<string, unknown>,
   webSearchUrl: string | null,
+  tavilyApiKey: string | null,
 ): Promise<ToolResult> {
-  const endpoint = resolveWebSearchEndpoint(webSearchUrl);
+  const endpoint = resolveWebSearchEndpoint(webSearchUrl, tavilyApiKey);
   if (!endpoint) {
     return {
       name: "web_search",

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -38,6 +38,11 @@ export type WorkerDeps = {
   embedding: EmbeddingClient;
   cfg: ResolvedMemoryPostgresConfig;
   agentId: string;
+  /** Tavily API key — typically pulled from OpenClaw's tavily plugin
+   *  config at startup so the same key codex uses is reused here. May
+   *  be null/undefined; the web_search tool then tries env / credbroker
+   *  / honest error. */
+  tavilyApiKey?: string | null;
   logger: { info: (m: string) => void; warn: (m: string) => void };
 };
 
@@ -416,9 +421,11 @@ export async function dispatchWorker(
       cfg: deps.cfg,
       agentId: deps.agentId,
       viewer,
-      // Pulled from cfg.credbroker.tavilyUrl when set; falls back to env
-      // / hardcoded default in worker-tools.resolveWebSearchEndpoint.
+      // Resolution priority (in worker-tools.resolveWebSearchEndpoint):
+      //   webSearchUrl from credbroker > tavilyApiKey from openclaw's
+      //   tavily plugin > NEXTCLAW_WEB_SEARCH_URL env > TAVILY_API_KEY env > null.
       webSearchUrl: deps.cfg.credbroker?.tavilyUrl ?? null,
+      tavilyApiKey: deps.tavilyApiKey ?? null,
     },
     turn1.toolCalls,
   );


### PR DESCRIPTION
## User caught it

> \"OpenClaw 自带 tavily search 啊，你这个不是 OpenClaw 已有的？\"

They were right. Two paths configuring the same Tavily key was the bug.

## Why we still need our own Tavily call

OpenClaw's tavily plugin is a \`WebSearchProviderPlugin\` — it registers a search tool for codex's agent loop. Our Moderator worker is a separate LLM call (gemini-flash via credbroker, outside codex), so there's no clean API for it to invoke codex's tool kit. The plugin SDK exposes provider registration, not provider consumption.

**But the API key doesn't have to be duplicated.** We can read OpenClaw's tavily config at startup and reuse the same credential.

## What changed

At plugin start (\`index.ts\`):
- Read \`ctx.config.plugins.entries.tavily.config.webSearch.apiKey\` (or \`.apiKeyEnv\` → env lookup)
- Pass through \`ModeratorServiceConfig.tavilyApiKey\` → \`WorkerDeps.tavilyApiKey\` → \`ToolRuntimeDeps.tavilyApiKey\` → \`resolveWebSearchEndpoint\`
- Worker's \`web_search\` tool now hits api.tavily.com with codex's existing key

Resolution priority (first match wins):
1. \`cfg.credbroker.tavilyUrl\` (Tailscale proxy — author's setup)
2. **OpenClaw's tavily plugin apiKey ← most users land here**
3. \`NEXTCLAW_WEB_SEARCH_URL\` env
4. \`TAVILY_API_KEY\` env
5. null → honest error to the LLM

## Docs

- **SERVICES.md §5** rewritten: leads with \"already have OpenClaw's tavily? You're done\"; env-var path is secondary; explains why two paths exist (codex vs worker LLM separation).
- **INSTALL.md Level D bolt-on** notes the auto-reuse and recommends configuring tavily in \`openclaw.json\` (which also enables codex web search) over the env-var path.

## Test plan

- [x] \`npm run build\` clean
- [x] 8/8 sim scenarios pass
- [x] Gateway restart clean (uses my existing openclaw.json tavily entry)
- [ ] Live: \"@bot 今天 AI 新闻\" — expect web_search call using the openclaw.json key, NOT the (unset) TAVILY_API_KEY env

🤖 Generated with [Claude Code](https://claude.com/claude-code)