### PR TITLE
worker_role → SKILL.md synergy (group/DM specialist sharing)

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -361,6 +361,69 @@ async function scenarioH_webSearch() {
   await pool.query("DELETE FROM moderator.worker_roles WHERE agent_id=$1 AND role_key=$2", [AGENT, roleKey]);
 }
 
+async function scenarioI_skillEmit() {
+  console.log("\n=== I. Skill emit — Moderator-coined role also lands as a SKILL.md ===");
+  const { mkdtempSync, readFileSync, existsSync, rmSync } = await import("node:fs");
+  const tmpRoot = mkdtempSync("/tmp/nextclaw-sim-skills-");
+  console.log(`  tmp skills dir: ${tmpRoot}`);
+
+  const workerLlm = buildWorkerLlmFromConfig({
+    format: "gemini",
+    baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini",
+    model: "gemini-2.5-flash",
+  });
+  const cfg = {
+    pluginId: "memory-postgres",
+    storage: { schema: "public", chunksTable: "chunks", chunkIndexesTable: "chunk_indexes" },
+    embedding: { model: "qwen3-embedding:0.6b" },
+    moderator: { model: { format: "gemini", model: "gemini-2.5-flash" } },
+  };
+  const logger = { info: (m) => console.log("    log:", m), warn: () => {} };
+  const wkDeps = { pool, workerLlm, embedding, cfg, agentId: AGENT, logger, publishSkillsDir: tmpRoot };
+
+  const uid = randomUUID().slice(0, 6);
+  const roleKey = `sim_skillemit_${uid}`;
+  const task = {
+    taskId: `t_skillemit_${uid}`,
+    roleKey,
+    taskPrompt: "用一句话回答：1+1=?",
+    canParallel: true,
+    newRoleSpec: {
+      systemPrompt: `你是一个 [${uid}] 测试 specialist：用 8 个字以内回答任何数学题。`,
+      displayName: `Sim Skill Specialist ${uid}`,
+      memoryScope: { topic: "sim.skill-emit" },
+      tools: [],
+    },
+  };
+
+  const result = await dispatchWorker(
+    wkDeps,
+    task,
+    { userId: "u-sim", chatId: "-1003789981008" },
+    task.taskPrompt,
+    SCOPE,
+  );
+  console.log(`  worker ok: ${result.ok}`);
+
+  const skillPath = `${tmpRoot}/${roleKey}/SKILL.md`;
+  const skillFileExists = existsSync(skillPath);
+  console.log(`  SKILL.md exists at ${skillPath}: ${skillFileExists ? "✓" : "✗"}`);
+  if (skillFileExists) {
+    const content = readFileSync(skillPath, "utf8");
+    const hasFrontmatter = content.startsWith("---\n");
+    const hasRoleKey = content.includes(`name: ${roleKey}`);
+    const hasSystemPrompt = content.includes("测试 specialist");
+    console.log(`  frontmatter present: ${hasFrontmatter ? "✓" : "✗"}`);
+    console.log(`  name field matches: ${hasRoleKey ? "✓" : "✗"}`);
+    console.log(`  systemPrompt body present: ${hasSystemPrompt ? "✓" : "✗"}`);
+    console.log(`  first 200 chars:\n    ${content.slice(0, 200).replace(/\n/g, "\n    ")}`);
+  }
+
+  // Cleanup
+  await pool.query("DELETE FROM moderator.worker_roles WHERE agent_id=$1 AND role_key=$2", [AGENT, roleKey]);
+  rmSync(tmpRoot, { recursive: true, force: true });
+}
+
 async function main() {
   console.log("Concurrency simulation — Moderator cache + worker pipeline");
   console.log("==========================================================");
@@ -373,6 +436,7 @@ async function main() {
     await scenarioF_roleAutoRegister();
     await scenarioG_workerTools();
     await scenarioH_webSearch();
+    await scenarioI_skillEmit();
   } finally {
     await pool.end();
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -596,6 +596,18 @@
             "default": 1500,
             "description": "Per (scope,user) burst window — multiple messages within this window coalesce into one decision."
           },
+          "publishAsSkills": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "When enabled, every Moderator-coined worker role also gets a SKILL.md emitted to a directory OpenClaw scans for skills. Lets codex (in DMs) use the same specialist the Moderator designed for a group. Off by default — only meaningful when you want group↔DM specialist sharing.",
+            "properties": {
+              "enabled": { "type": "boolean", "default": false },
+              "dir": {
+                "type": "string",
+                "description": "Absolute path of the directory holding per-role subfolders. Default: ~/.openclaw/skills/nextclaw-roles (a workspace skills location OpenClaw scans by default)."
+              }
+            }
+          },
           "model": {
             "type": "object",
             "additionalProperties": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -167,6 +167,16 @@ export type ModeratorConfig = {
   };
   /** Per (scope, user) burst-collapse window. Default 1500ms. */
   debounceMs?: number;
+  /** When enabled, every Moderator-coined worker role also gets a
+   *  SKILL.md emitted so codex (in DMs) can invoke the same specialist
+   *  via the regular OpenClaw skills mechanism. Off by default. */
+  publishAsSkills?: {
+    enabled?: boolean;
+    /** Directory the per-role SKILL.md folders are written into. Must
+     *  be a directory OpenClaw scans for skills (typically a workspace
+     *  skills subdir). Default: `~/.openclaw/skills/nextclaw-roles`. */
+    dir?: string;
+  };
 };
 
 export type ReflectionConfig = {
@@ -332,6 +342,8 @@ export type ResolvedModeratorConfig = {
     model: string;
     apiKeyEnv?: string;
   };
+  /** Resolved skill-emit directory, or `null` when disabled. */
+  publishSkillsDir: string | null;
 };
 
 export type ResolvedReflectionConfig = {
@@ -513,6 +525,22 @@ function resolveModeratorConfig(
   const format = modelBlock.format === "gemini" ? "gemini" : "openai";
   // Credbroker proxies Gemini only — for openai we never derive.
   const credbrokerFallback = format === "gemini" ? credbroker.geminiUrl : null;
+  // Skill emit directory: enabled gates the whole feature; dir defaults to
+  // ~/.openclaw/skills/nextclaw-roles via defaultSkillEmitDir(). We resolve
+  // to `null` when disabled so the worker dispatch path can skip emit
+  // cheaply, OR to a fully-resolved absolute path string.
+  const publishBlock = (block as { publishAsSkills?: { enabled?: unknown; dir?: unknown } }).publishAsSkills ?? {};
+  let publishSkillsDir: string | null = null;
+  if (publishBlock.enabled === true) {
+    if (isString(publishBlock.dir) && publishBlock.dir.length > 0) {
+      publishSkillsDir = publishBlock.dir;
+    } else {
+      // Substitute the default lazily to avoid pulling the moderator module
+      // into the config-resolution import graph (circular concern).
+      const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp";
+      publishSkillsDir = `${home}/.openclaw/skills/nextclaw-roles`;
+    }
+  }
   return {
     enabled: bool(block.enabled, false),
     agentId: isString((block as { agentId?: unknown }).agentId)
@@ -526,6 +554,7 @@ function resolveModeratorConfig(
         : format === "gemini" ? "gemini-2.5-flash" : "gpt-5.5",
       apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
     },
+    publishSkillsDir,
   };
 }
 

--- a/src/moderator/service.ts
+++ b/src/moderator/service.ts
@@ -285,6 +285,7 @@ export function startModeratorService(config: ModeratorServiceConfig): Moderator
           cfg: config.cfg,
           agentId: agentId,
           tavilyApiKey: config.tavilyApiKey ?? null,
+          publishSkillsDir: config.cfg.moderator.publishSkillsDir,
           logger: config.logger,
         };
         const viewer = { userId: senderUserId, chatId };

--- a/src/moderator/skill-emit.ts
+++ b/src/moderator/skill-emit.ts
@@ -1,0 +1,127 @@
+/**
+ * Emit a Moderator-coined worker role as an OpenClaw skill so the SAME
+ * specialist is available to BOTH paths:
+ *
+ *   1. Moderator dispatch path  — loads the role from moderator.worker_roles
+ *      and runs a worker LLM call (this is where the role was born).
+ *   2. Codex agent path         — reads SKILL.md from the configured skills
+ *      directory at session start and lists the skill in its prompt; the
+ *      user can then invoke it naturally in a DM.
+ *
+ * Concretely: when the Moderator designs `math_tutor_grade5` for a group
+ * question, the same persona becomes a skill the user can lean on in
+ * their DM with the bot — without anyone hand-writing a SKILL.md.
+ *
+ * Design choices:
+ *   - Atomic write: temp file + rename. OpenClaw's skill watcher should
+ *     never see a half-written SKILL.md.
+ *   - Path sanitization: roleKey is sanitized to [A-Za-z0-9_-] before
+ *     becoming a directory name. Garbage roleKeys can't escape the dir.
+ *   - Idempotent: re-emitting the same role overwrites; safe to retry.
+ *   - Best-effort: failure logs a warning, never throws. Skill emit is a
+ *     synergy feature; if it breaks the Moderator must still answer.
+ *   - Off by default: cfg.moderator.publishAsSkills.enabled gates the
+ *     whole feature (operators on shared boxes shouldn't accidentally
+ *     create files outside the plugin sandbox).
+ */
+
+import { writeFile, rename, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+
+export type SkillEmitParams = {
+  /** Absolute path to the directory that holds per-role subfolders.
+   *  Defaults to ~/.openclaw/skills/nextclaw-roles when omitted. */
+  dir: string;
+  roleKey: string;
+  displayName: string;
+  /** The role's systemPrompt — becomes the body of SKILL.md (after the frontmatter). */
+  systemPrompt: string;
+  /** A short description shown to the agent in its skills prompt. Falls
+   *  back to "Specialist '{roleKey}' — auto-registered by the Moderator." */
+  description?: string;
+  logger?: { info?: (m: string) => void; warn?: (m: string) => void };
+};
+
+const ROLE_KEY_SAFE = /^[A-Za-z0-9_-]{1,64}$/;
+
+function sanitizeRoleKey(raw: string): string | null {
+  // Strip whitespace + lowercase common variants we accept; reject anything
+  // we can't safely turn into a directory name.
+  const trimmed = raw.trim();
+  if (!trimmed) {return null;}
+  if (ROLE_KEY_SAFE.test(trimmed)) {return trimmed;}
+  // One last try: collapse non-safe chars into underscores. If still empty
+  // after collapse, reject.
+  const collapsed = trimmed.replace(/[^A-Za-z0-9_-]/g, "_").replace(/_+/g, "_").slice(0, 64);
+  return ROLE_KEY_SAFE.test(collapsed) ? collapsed : null;
+}
+
+/**
+ * Build the SKILL.md content. Body is just the role's systemPrompt; we
+ * don't add OpenClaw-specific scaffolding because the systemPrompt is
+ * the LLM-facing voice — adding meta-instructions on top would dilute it.
+ */
+function buildSkillMarkdown(params: SkillEmitParams, safeKey: string): string {
+  const description = (params.description ?? "").trim()
+    || `Specialist '${safeKey}' — auto-registered by the Moderator. ` +
+       `Trigger when the user's question matches this specialist's domain.`;
+  // YAML frontmatter — keep keys to the documented minimal set so we
+  // don't depend on OpenClaw's parser accepting extras. Description is
+  // ONE LINE (\n-escaped if needed); OpenClaw's prompt builder wants a
+  // single-line summary.
+  const yamlDescription = description.replace(/\n+/g, " ").trim();
+  const yamlName = params.displayName.trim() || safeKey;
+  const frontmatter = [
+    "---",
+    `name: ${safeKey}`,
+    `description: ${yamlDescription}`,
+    "---",
+    "",
+  ].join("\n");
+  return frontmatter + `# ${yamlName}\n\n${params.systemPrompt.trim()}\n`;
+}
+
+/**
+ * Atomic emit. Writes a temp file in tmpdir, then renames into place so
+ * a concurrent skill watcher never reads a partial file. Creates parent
+ * directories as needed.
+ */
+export async function emitRoleAsSkill(params: SkillEmitParams): Promise<{
+  ok: boolean;
+  path?: string;
+  error?: string;
+}> {
+  const safeKey = sanitizeRoleKey(params.roleKey);
+  if (!safeKey) {
+    return { ok: false, error: `unsafe roleKey: ${JSON.stringify(params.roleKey)}` };
+  }
+  const skillDir = path.join(params.dir, safeKey);
+  const skillFile = path.join(skillDir, "SKILL.md");
+  const tmpPath = path.join(tmpdir(), `nextclaw-skill-${randomBytes(6).toString("hex")}.md`);
+  const content = buildSkillMarkdown(params, safeKey);
+  try {
+    await mkdir(skillDir, { recursive: true, mode: 0o755 });
+    await writeFile(tmpPath, content, { encoding: "utf8", mode: 0o644 });
+    await rename(tmpPath, skillFile);
+    params.logger?.info?.(
+      `skill-emit: wrote ${skillFile} (${content.length} bytes, role=${safeKey})`,
+    );
+    return { ok: true, path: skillFile };
+  } catch (e) {
+    const msg = (e as Error).message;
+    params.logger?.warn?.(`skill-emit: failed for role ${safeKey}: ${msg}`);
+    return { ok: false, error: msg };
+  }
+}
+
+/**
+ * Default skill emit directory. Lives under the user's openclaw workspace
+ * skills root (which OpenClaw scans by default), under a subfolder we own
+ * so we don't collide with hand-written skills.
+ */
+export function defaultSkillEmitDir(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp";
+  return path.join(home, ".openclaw", "skills", "nextclaw-roles");
+}

--- a/src/moderator/workers.ts
+++ b/src/moderator/workers.ts
@@ -30,6 +30,7 @@ import type { ResolvedMemoryPostgresConfig } from "../config.js";
 import { storeCachedAnswer } from "../cache/qa.js";
 import { chatSingle, exportToolResultsAsHistory, type WorkerLlmClient } from "./worker-llm.js";
 import { executeToolsBatch, resolveTools, type ToolCall } from "./worker-tools.js";
+import { emitRoleAsSkill } from "./skill-emit.js";
 
 export type WorkerDeps = {
   pool: Pool;
@@ -43,6 +44,10 @@ export type WorkerDeps = {
    *  be null/undefined; the web_search tool then tries env / credbroker
    *  / honest error. */
   tavilyApiKey?: string | null;
+  /** When set, every Moderator-coined role that successfully upserts
+   *  ALSO gets a SKILL.md emitted to this directory so codex (in DMs)
+   *  can use the same specialist via the regular skills mechanism. */
+  publishSkillsDir?: string | null;
   logger: { info: (m: string) => void; warn: (m: string) => void };
 };
 
@@ -292,6 +297,22 @@ export async function dispatchWorker(
         deps.logger.info(
           `worker[${task.taskId}]: registered new role '${task.roleKey}' (${task.newRoleSpec.systemPrompt.length} chars)`,
         );
+        // Synergy: if skill publishing is enabled, also drop a SKILL.md
+        // into the configured directory so codex (DM users) can use the
+        // same specialist. Best-effort — never blocks the worker.
+        if (deps.publishSkillsDir && task.newRoleSpec.systemPrompt) {
+          void emitRoleAsSkill({
+            dir: deps.publishSkillsDir,
+            roleKey: task.roleKey,
+            displayName: task.newRoleSpec.displayName ?? task.roleKey,
+            systemPrompt: task.newRoleSpec.systemPrompt,
+            // memoryScope.topic gives the model a hint at "what topics this specialist owns"
+            description: task.newRoleSpec.memoryScope?.topic
+              ? `Specialist for topic '${task.newRoleSpec.memoryScope.topic}'. ${task.newRoleSpec.displayName ?? ""}`
+              : undefined,
+            logger: deps.logger,
+          }).catch(() => undefined);
+        }
       }
     } catch (e) {
       deps.logger.warn(`worker[${task.taskId}]: role upsert failed: ${(e as Error).message}`);


### PR DESCRIPTION
## Why

Audit caught it: Moderator coins specialist roles in \`moderator.worker_roles\` for **group @-mentions**, but **codex** (which handles DMs) doesn't see them. Codex loads skills from filesystem SKILL.md files, not our DB. So the same operator gets the same complaint twice — a math-tutor specialist the Moderator designed for the group can't help the user in DM.

## What

When \`upsertWorkerRole\` succeeds (= brand-new role from Moderator), **also** write a SKILL.md to a configured directory. OpenClaw's skill watcher picks it up. Next codex session in DM has the specialist in its prompt.

\`\`\`
群里 @bot "教我求最大公约数"
  └─ Moderator coins math_tutor role
       ├─ writes to moderator.worker_roles  (Moderator dispatch)
       └─ writes to ~/.openclaw/skills/nextclaw-roles/math_tutor/SKILL.md
             (codex DM agent picks it up)

DM 里同一用户："求最小公倍数"
  └─ codex sees math_tutor in its skill prompt → uses the same specialist
\`\`\`

## Design

- New \`src/moderator/skill-emit.ts\`:
  - Atomic write (temp + rename) — watcher never reads a partial file
  - Path sanitization (\`[A-Za-z0-9_-]{1,64}\`) — garbage roleKey can't escape the dir
  - Best-effort — failure logs a warning, never blocks the Moderator
- New config: \`cfg.moderator.publishAsSkills.{enabled, dir}\` — **off by default**
- Default dir when enabled but unset: \`~/.openclaw/skills/nextclaw-roles\` (workspace skills location OpenClaw scans natively)

## Test plan

- [x] \`npm run build\` clean
- [x] concurrency-sim scenario I: dispatch worker → verify SKILL.md lands with proper frontmatter + body
- [x] Gateway restart clean on Yao's live deployment with \`publishAsSkills: { enabled: true }\` set in openclaw.json
- [ ] Live: send a group question that coins a new specialist, then check \`~/.openclaw/skills/nextclaw-roles/\` for the new directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)