### PR TITLE
Lean on OpenClaw lifecycle hooks (compaction + session_end → transcript flush + reflection)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -49,9 +49,15 @@ import { startModeratorService, type ModeratorServiceHandle } from "./src/modera
  * Module-level state side-steps that.
  */
 let MODULE_MODERATOR_HANDLE: ModeratorServiceHandle | null = null;
+/** Module-level handles for the event-driven hooks (after_compaction,
+ *  session_end). Same closure-isolation rationale as above. */
+let MODULE_TRANSCRIPT_WATCHERS: TranscriptWatcherHandle[] = [];
+let MODULE_REFLECTION_HANDLE: ReflectionDaemonHandle | null = null;
+let MODULE_INGEST_DEPS: import("./src/ingest/pipeline.js").IngestDeps | null = null;
 import { startTranscriptWatcherDaemon, type TranscriptWatcherHandle } from "./src/workers/transcript-watcher.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
+import { ingestCompactionSummary } from "./src/workers/compaction-ingest.js";
 
 const SERVICE_ID = "memory-postgres-dashboard";
 
@@ -167,6 +173,63 @@ export default definePluginEntry({
         );
       } catch (err) {
         api.logger.warn(`memory-postgres: moderator message_received hook threw: ${(err as Error).message}`);
+      }
+    });
+
+    /**
+     * after_compaction — codex just folded N messages into one LLM-driven
+     * summary in this session's JSONL. We promote that summary into
+     * `semantic.chunks` with kind='compaction', retention='pinned' so
+     * recall can find it later. Without this hook the summary lives only
+     * in the session file. Best-effort; failure logged.
+     */
+    api.on("after_compaction", async (event, hookCtx) => {
+      const ev = event as { messageCount?: number; tokenCount?: number; compactedCount?: number; sessionFile?: string };
+      if (!ev?.sessionFile || !ev.compactedCount) {return;}
+      const agentId = (hookCtx as { agentId?: string })?.agentId ?? "main";
+      const agentSessionId = (hookCtx as { sessionKey?: string; sessionId?: string })?.sessionId
+        ?? (hookCtx as { sessionKey?: string })?.sessionKey;
+      if (!MODULE_INGEST_DEPS) {return;}
+      void ingestCompactionSummary(
+        { ...MODULE_INGEST_DEPS, logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) } },
+        {
+          sessionFile: ev.sessionFile,
+          agentId,
+          agentSessionId,
+          messageCount: ev.messageCount ?? 0,
+          tokenCount: ev.tokenCount,
+          compactedCount: ev.compactedCount,
+        },
+      ).catch(() => undefined);
+    });
+
+    /**
+     * session_end — codex just finished a session. Two synergies:
+     *   1. Flush the transcript watcher NOW (don't wait ~10s for next
+     *      tick) so the session's tail lines land in memory immediately.
+     *   2. Trigger per-agent reflection (throttled per agent so a burst
+     *      of session-ends doesn't run 10 reflections in a row).
+     */
+    api.on("session_end", async (event, hookCtx) => {
+      const ev = event as { sessionId?: string; sessionKey?: string; reason?: string };
+      const ctxAgent = (hookCtx as { agentId?: string })?.agentId ?? "main";
+      // (1) immediate transcript flush for ALL watchers (cheap; each only
+      // re-reads new lines since its last offset cursor).
+      for (const w of MODULE_TRANSCRIPT_WATCHERS) {
+        w.flushNow().catch((err) =>
+          api.logger.warn(`session_end transcript flush failed (${w.watcherId}): ${(err as Error).message}`),
+        );
+      }
+      // (2) event-driven reflection. We only trigger for "natural" end
+      // reasons that imply a chunk of completed work — not for shutdown
+      // / restart (those are infra noise).
+      const productiveReasons = new Set(["new", "reset", "idle", "daily", "compaction"]);
+      const reason = typeof ev?.reason === "string" ? ev.reason : "unknown";
+      if (MODULE_REFLECTION_HANDLE && productiveReasons.has(reason)) {
+        void MODULE_REFLECTION_HANDLE.triggerForAgent(ctxAgent, `session_end:${reason}`)
+          .catch((err) =>
+            api.logger.warn(`session_end reflection trigger failed: ${(err as Error).message}`),
+          );
       }
     });
 
@@ -359,6 +422,13 @@ export default definePluginEntry({
               logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
             });
             transcriptWatcherHandles.push(handle);
+            // Publish to module-level state so the session_end /
+            // after_compaction hooks (registered at top-level register())
+            // can invoke flushNow without crossing closures.
+            MODULE_TRANSCRIPT_WATCHERS.push(handle);
+            // Capture ingest deps once so the after_compaction hook can
+            // build a CompactionContext without duplicating wiring.
+            MODULE_INGEST_DEPS = { cfg, pool, embedding };
             api.logger.info(
               `memory-postgres: transcript-watcher started — id=${watcher.id} `
                 + `dir=${watcher.dir} interval=${watcher.intervalMs}ms`,
@@ -386,6 +456,9 @@ export default definePluginEntry({
               intervalMs: cfg.reflection.intervalMs,
               logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
             });
+            // Publish module-level so session_end hook can trigger
+            // event-driven reflection (throttled inside the daemon).
+            MODULE_REFLECTION_HANDLE = reflectionHandle;
             api.logger.info(
               `memory-postgres: reflection daemon started — ` +
                 `format=${cfg.reflection.model.format} model=${cfg.reflection.model.model} ` +
@@ -544,11 +617,13 @@ export default definePluginEntry({
           try { reflectionHandle.stop(); } catch { /* ignore */ }
           reflectionHandle = null;
         }
+        MODULE_REFLECTION_HANDLE = null;
         if (moderatorHandle) {
           try { moderatorHandle.stop(); } catch { /* ignore */ }
           moderatorHandle = null;
         }
         MODULE_MODERATOR_HANDLE = null;
+        MODULE_INGEST_DEPS = null;
         if (moderatorEventUnsub) {
           try { moderatorEventUnsub(); } catch { /* ignore */ }
           moderatorEventUnsub = null;
@@ -563,6 +638,7 @@ export default definePluginEntry({
           try { h.stop(); } catch { /* ignore */ }
         }
         transcriptWatcherHandles = [];
+        MODULE_TRANSCRIPT_WATCHERS = [];
         for (const h of shadowHandles) {
           try { h.stop(); } catch { /* ignore */ }
         }

--- a/src/workers/compaction-ingest.ts
+++ b/src/workers/compaction-ingest.ts
@@ -1,0 +1,153 @@
+/**
+ * Capture codex's `after_compaction` summary into long-term memory.
+ *
+ * When codex compacts a long session (LLM-driven summarization that
+ * folds N old messages into one summary), that summary is an
+ * already-paid-for distillation of expensive tokens. Instead of letting
+ * it live only in the session JSONL, we promote it into
+ * `semantic.chunks` with kind='compaction' so recall can find it later.
+ *
+ * The hook payload gives us `sessionFile + messageCount + tokenCount +
+ * compactedCount`. We tail the file looking for the summary marker (or
+ * fall back to the most recent assistant message) and write one chunk.
+ *
+ * Best-effort: any failure is logged, never throws.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import { ingestOne, type IngestDeps } from "../ingest/pipeline.js";
+
+const TAIL_LINES = 60;
+const MIN_SUMMARY_CHARS = 40;
+const MAX_TAIL_BYTES = 256 * 1024;
+
+export type CompactionContext = {
+  /** Absolute path to the session JSONL file. */
+  sessionFile: string;
+  agentId: string;
+  agentSessionId?: string;
+  messageCount: number;
+  tokenCount?: number;
+  compactedCount: number;
+};
+
+export type CompactionIngestOutcome = {
+  ok: boolean;
+  chunkId?: string;
+  summaryChars?: number;
+  reason?: string;
+};
+
+/**
+ * Read the trailing portion of a JSONL file. Files can be very large
+ * (~10 MB after months of chat), so we slice the last MAX_TAIL_BYTES
+ * before parsing. The first partial line in the slice is discarded
+ * (it'll be a fragment).
+ */
+async function readJsonlTail(path: string): Promise<unknown[]> {
+  const st = await stat(path);
+  const buf = await readFile(path);
+  const start = Math.max(0, buf.length - MAX_TAIL_BYTES);
+  const slice = buf.slice(start).toString("utf8");
+  const lines = slice.split("\n");
+  // If we sliced mid-line, drop the leading fragment.
+  if (start > 0 && lines.length > 0) {lines.shift();}
+  // Keep only the last TAIL_LINES (defensive cap on parse work).
+  const recent = lines.slice(-TAIL_LINES);
+  const out: unknown[] = [];
+  for (const ln of recent) {
+    const trimmed = ln.trim();
+    if (!trimmed) {continue;}
+    try {
+      out.push(JSON.parse(trimmed));
+    } catch {
+      // skip malformed
+    }
+  }
+  // Don't return the stat result; just keep behavior tight.
+  void st;
+  return out;
+}
+
+/**
+ * Try several shapes to find the compaction summary text. JSONL formats
+ * vary across openclaw versions; we walk recent entries and pick the
+ * first one that looks like a compaction artifact, falling back to the
+ * most recent assistant message if nothing matches.
+ */
+function extractSummary(entries: unknown[]): string | null {
+  let lastAssistant: string | null = null;
+  // Walk from newest to oldest.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i];
+    if (!e || typeof e !== "object") {continue;}
+    const obj = e as Record<string, unknown>;
+
+    // Shape 1: explicit compaction event with `summary` field
+    if (obj.type === "compaction" && typeof obj.summary === "string"
+        && obj.summary.length >= MIN_SUMMARY_CHARS) {
+      return obj.summary;
+    }
+    // Shape 2: compaction marker with embedded message
+    if (obj.kind === "compaction" && typeof obj.text === "string"
+        && obj.text.length >= MIN_SUMMARY_CHARS) {
+      return obj.text;
+    }
+    // Shape 3: assistant message with role + content (string OR array of parts)
+    if (obj.type === "message" && obj.role === "assistant") {
+      const c = obj.content;
+      if (typeof c === "string" && c.length >= MIN_SUMMARY_CHARS) {
+        if (!lastAssistant) {lastAssistant = c;}
+      } else if (Array.isArray(c)) {
+        // Codex sometimes emits content as parts: [{type:"text", text:"..."}]
+        const joined = c
+          .filter((p) => p && typeof p === "object" && typeof (p as Record<string, unknown>).text === "string")
+          .map((p) => (p as { text: string }).text)
+          .join("\n")
+          .trim();
+        if (!lastAssistant && joined.length >= MIN_SUMMARY_CHARS) {lastAssistant = joined;}
+      }
+    }
+  }
+  return lastAssistant;
+}
+
+export async function ingestCompactionSummary(
+  deps: IngestDeps & { logger?: { info?: (m: string) => void; warn?: (m: string) => void } },
+  ctx: CompactionContext,
+): Promise<CompactionIngestOutcome> {
+  try {
+    const entries = await readJsonlTail(ctx.sessionFile);
+    if (entries.length === 0) {
+      return { ok: false, reason: "empty-tail" };
+    }
+    const summary = extractSummary(entries);
+    if (!summary || summary.length < MIN_SUMMARY_CHARS) {
+      return { ok: false, reason: "no-summary-found" };
+    }
+
+    const outcome = await ingestOne(deps as IngestDeps, {
+      text: summary,
+      source: "compaction_event",
+      kind: "compaction",
+      agentId: ctx.agentId,
+      agentSessionId: ctx.agentSessionId,
+      retentionClass: "pinned",       // never decay — earned by token cost
+      importance: 0.7,                 // high; this is a distilled artifact
+      signals: {
+        compaction_messages_folded: ctx.compactedCount,
+        compaction_token_count: ctx.tokenCount,
+        compaction_session_file: ctx.sessionFile,
+      },
+    });
+    deps.logger?.info?.(
+      `compaction-ingest: agent=${ctx.agentId} session=${ctx.agentSessionId ?? "?"} ` +
+        `folded=${ctx.compactedCount} chars=${summary.length} outcome=${outcome.decision}`,
+    );
+    return { ok: outcome.decision === "accepted" || outcome.decision === "merged", chunkId: outcome.chunkId, summaryChars: summary.length };
+  } catch (e) {
+    const msg = (e as Error).message;
+    deps.logger?.warn?.(`compaction-ingest: failed for ${ctx.sessionFile}: ${msg}`);
+    return { ok: false, reason: msg };
+  }
+}

--- a/src/workers/reflection.ts
+++ b/src/workers/reflection.ts
@@ -283,21 +283,68 @@ async function writeChunk(
   }
 }
 
-/* ----------------------- daemon (interval scheduling) ---------------------- */
+/* ----------------------- daemon (interval + event-driven) ----------------- */
 
-export type ReflectionDaemonHandle = { stop: () => void };
+export type ReflectionDaemonHandle = {
+  stop: () => void;
+  /**
+   * Event-driven trigger — call when `session_end` fires (or any other
+   * "user finished a chunk of work" signal). Throttled per-agent so we
+   * don't re-reflect the same agent twice within `minGapMs`; the periodic
+   * fallback timer covers agents that never cleanly session_end.
+   */
+  triggerForAgent: (agentId: string, reason: string) => Promise<void>;
+};
 
 export function startReflectionDaemon(args: {
   deps: ReflectionDeps;
   intervalMs: number;
+  /** Minimum gap between event-driven runs for the same agent. Default = intervalMs / 2. */
+  minGapMs?: number;
   logger: { info: (m: string) => void; warn: (m: string) => void };
 }): ReflectionDaemonHandle {
-  // Run once 5 min after start so the first day isn't empty.
   let stopped = false;
+  const lastRunByAgent = new Map<string, number>();
+  const minGapMs = args.minGapMs ?? Math.max(60 * 60_000, Math.floor(args.intervalMs / 2));
+
+  const runFor = async (agentId: string, reason: string): Promise<void> => {
+    if (stopped) {return;}
+    const now = Date.now();
+    const last = lastRunByAgent.get(agentId) ?? 0;
+    if (now - last < minGapMs) {
+      // Within throttle window — silent skip; common case after many
+      // session_end events fire for one agent in a row.
+      return;
+    }
+    lastRunByAgent.set(agentId, now);
+    try {
+      const outcome = await runReflectionForAgent(args.deps, agentId);
+      if (outcome.ok && ((outcome.reflectionChunkId !== undefined) || (outcome.profileChunksWritten ?? 0) > 0)) {
+        args.logger.info(
+          `memory-postgres: reflection (${reason}) agent=${agentId} ` +
+            `${outcome.chunksConsidered}c/${outcome.profileChunksWritten ?? 0}p`,
+        );
+      } else if (!outcome.ok) {
+        args.logger.warn(`memory-postgres: reflection (${reason}) agent=${agentId} err=${outcome.error}`);
+      }
+    } catch (err) {
+      args.logger.warn(`memory-postgres: reflection (${reason}) failed for ${agentId}: ${(err as Error).message}`);
+    }
+  };
+
+  // Periodic safety-net sweep: catches agents whose sessions never cleanly
+  // session_end (long-running DM threads, gateway crashes). Effectively a
+  // fallback for the event-driven path. Throttle map ensures the periodic
+  // tick is a no-op when session_end-driven runs are keeping up.
   const tick = async (): Promise<void> => {
     if (stopped) {return;}
     try {
       const outcomes = await runReflectionForAllAgents(args.deps);
+      for (const o of outcomes) {
+        if (o.ok && ((o.reflectionChunkId !== undefined) || (o.profileChunksWritten ?? 0) > 0)) {
+          lastRunByAgent.set(o.agentId, Date.now());
+        }
+      }
       const anyWork = outcomes.some(
         (o) => (o.reflectionChunkId !== undefined) || (o.profileChunksWritten ?? 0) > 0,
       );
@@ -309,12 +356,13 @@ export function startReflectionDaemon(args: {
               : `${o.agentId}:err(${o.error})`,
           )
           .join(" ");
-        args.logger.info(`memory-postgres: reflection tick — ${summary}`);
+        args.logger.info(`memory-postgres: reflection sweep — ${summary}`);
       }
     } catch (err) {
-      args.logger.warn(`memory-postgres: reflection tick failed: ${(err as Error).message}`);
+      args.logger.warn(`memory-postgres: reflection sweep failed: ${(err as Error).message}`);
     }
   };
+
   const timer = setInterval(() => void tick(), args.intervalMs);
   timer.unref?.();
   const initialTimer = setTimeout(() => void tick(), 5 * 60_000);
@@ -325,6 +373,7 @@ export function startReflectionDaemon(args: {
       clearInterval(timer);
       clearTimeout(initialTimer);
     },
+    triggerForAgent: runFor,
   };
 }
 

--- a/src/workers/transcript-watcher.ts
+++ b/src/workers/transcript-watcher.ts
@@ -339,7 +339,16 @@ export async function pollTranscriptWatcher(
 
 export type TranscriptWatcherHandle = {
   watcherId: string;
+  agentId: string;
   stop: () => void;
+  /**
+   * Trigger an immediate poll instead of waiting for the next interval
+   * tick. Used by `session_end` / `after_compaction` hooks to ingest the
+   * just-finalised JSONL with sub-second latency instead of ~10s. Safe to
+   * call concurrently with the scheduled tick (poll has its own offset
+   * cursor; double-firing is a no-op for already-seen lines).
+   */
+  flushNow: () => Promise<void>;
 };
 
 export function startTranscriptWatcherDaemon(
@@ -374,10 +383,15 @@ export function startTranscriptWatcherDaemon(
 
   return {
     watcherId: deps.watcher.id,
+    agentId: deps.watcher.agentId,
     stop() {
       stopped = true;
       if (timer) {clearInterval(timer);}
       timer = null;
+    },
+    async flushNow() {
+      if (stopped) {return;}
+      await tick();
     },
   };
 }


### PR DESCRIPTION
## Why

Audit (https://github.com/NextAgentBC/nextclaw/pull/15 follow-up): three places where we polled or timer'd when OpenClaw was already firing the right event for us. Per principle \"we're a plugin, borrow what the host offers\" — wire each onto its native hook.

## A. \`after_compaction\` → ingest compaction summary as \`kind='compaction'\`

codex's compaction is an LLM-driven summarization that folds N old messages into one summary. That summary is already-paid-for distillation, and we were missing it — it lived only in the session JSONL.

- New file \`src/workers/compaction-ingest.ts\` — \`ingestCompactionSummary(deps, ctx)\` reads the sessionFile tail, finds the summary (3 shapes tried, falls back to last assistant message), ingests as \`{kind: 'compaction', source: 'compaction_event', retentionClass: 'pinned', importance: 0.7}\` with \`signals: {compactedCount, tokenCount, sessionFile}\`.
- Best-effort; failure logs, never throws.
- **Leverage**: stronger codex compaction → richer long-term memory at zero marginal cost to us.

## B. \`session_end\` → immediate transcript flush (instead of 10s poll wait)

- Transcript watcher handle gains \`flushNow()\` — runs the tick directly. Concurrent with scheduled tick is safe (offset cursor dedupes).
- \`session_end\` hook → \`flushNow()\` across all watchers.
- Interval poll stays as safety-net for sessions that don't cleanly session_end.

## C. \`session_end\` (productive reasons) → event-driven reflection

Reflection was a global \`setInterval(24h)\` that scanned ALL agents regardless of activity. Now event-driven per agent:

- \`ReflectionDaemonHandle\` gains \`triggerForAgent(agentId, reason)\`.
- Throttle map (in-memory) prevents re-running same agent in tight window. Default \`minGapMs = max(1h, intervalMs/2)\`.
- Periodic timer kept as **safety-net sweep** for non-cleanly-ending sessions; respects same throttle map.
- Hook only fires for productive reasons \`{new, reset, idle, daily, compaction}\` — excludes \`shutdown\`/\`restart\` (infra noise).

**Leverage**: reflection runs when there's something to reflect on, not on a wall clock. Quieter agents skip; chatty agents get fresh reflections when user returns.

## Wiring

Same \`MODULE_*_HANDLE\` module-level pattern as MODULE_MODERATOR_HANDLE (closure isolation between register(api) passes).

## Test plan

- [x] \`npm run build\` clean
- [x] All 9 concurrency-sim scenarios pass
- [x] Gateway restarts clean with all 3 hooks registered
- [ ] Live: trigger a session_end via shutdown, look for \`reflection (session_end:idle)\` log
- [ ] Live: long conversation that hits compaction → check \`semantic.chunks WHERE kind='compaction'\` for the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)