### PR TITLE
2-hop graph walk + entity-centric reflection (GraphRAG's useful half)

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -424,6 +424,84 @@ async function scenarioI_skillEmit() {
   rmSync(tmpRoot, { recursive: true, force: true });
 }
 
+async function scenarioJ_entityReflection() {
+  console.log("\n=== J. Entity-centric reflection — N mentions of one entity → entity_profile chunk ===");
+  const { randomUUID: uuid, createHash } = await import("node:crypto");
+  const { buildReflectionClient, runEntityReflectionForAgent } = await import(
+    "./dist/src/workers/reflection.js"
+  );
+
+  // Seed: ONE entity + 10 chunks mentioning it, all under a sim agent_id.
+  const simAgent = `sim-entity-${uuid().slice(0, 6)}`;
+  const entityId = uuid();
+  const entityName = `Project_Sim_${uuid().slice(0, 4)}`;
+  await pool.query(
+    `INSERT INTO structured.entities (id, type, canonical_name, confidence, first_seen_at, last_seen_at)
+     VALUES ($1, 'project', $2, 0.9, now() - interval '5 days', now() - interval '1 hour')`,
+    [entityId, entityName],
+  );
+  const chunkIds = [];
+  for (let i = 0; i < 10; i++) {
+    const cid = uuid();
+    const text = `Yao mentioned ${entityName} — context note ${i+1}: it ${i % 2 === 0 ? "ships next Tuesday" : "uses pgvector + HNSW"}.`;
+    const er = await embedding.embed({ inputs: [text] }).catch(() => null);
+    if (!er) {continue;}
+    const vec = "[" + er.embeddings[0].join(",") + "]";
+    const textHash = createHash("sha256").update(text, "utf8").digest();
+    await pool.query(
+      `INSERT INTO semantic.chunks (id, source, kind, text, text_hash, embedding, embedding_model, agent_id, retention_class, importance, created_at)
+       VALUES ($1, 'sim-seed', 'session', $2, $3, $4::vector, $5, $6, 'standard', 0.3, now() - ($7 || ' hours')::interval)`,
+      [cid, text, textHash, vec, er.model, simAgent, String(24 - i)],
+    );
+    await pool.query(
+      `INSERT INTO semantic.chunk_indexes (chunk_id, kind, value) VALUES ($1, 'entity_ref', $2)`,
+      [cid, entityId],
+    );
+    chunkIds.push(cid);
+  }
+  console.log(`  seeded entity=${entityName} (id=${entityId.slice(0, 8)}…) + ${chunkIds.length} chunks under agent=${simAgent}`);
+
+  // Trigger entity reflection.
+  const llm = buildReflectionClient({
+    enabled: true, intervalMs: 86400000, lookbackHours: 24, maxInputChars: 8000,
+    model: {
+      format: "gemini",
+      baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini",
+      model: "gemini-2.5-flash",
+    },
+  });
+  const cfg = {
+    enabled: true, intervalMs: 86400000, lookbackHours: 24 * 30, maxInputChars: 8000,
+    model: { format: "gemini", baseUrl: "http://100.79.97.110:8800/v1/proxy/gemini", model: "gemini-2.5-flash" },
+  };
+  const outcomes = await runEntityReflectionForAgent(
+    { pool, embedding, llm, cfg },
+    simAgent,
+  );
+  console.log(`  outcomes: ${outcomes.length} candidate(s)`);
+  for (const o of outcomes) {
+    console.log(`    - ${o.entityName} ok=${o.ok} mentions=${o.mentionsConsidered} chunk=${o.profileChunkId?.slice(0,8) ?? "-"}`);
+  }
+
+  // Verify: entity_profile chunk exists AND is back-indexed under this entity.
+  const r = await pool.query(
+    `SELECT c.id::text, left(c.text, 120) AS text, c.kind, c.retention_class, c.importance
+       FROM semantic.chunks c
+       JOIN semantic.chunk_indexes ci ON ci.chunk_id = c.id AND ci.kind = 'entity_ref' AND ci.value = $2
+      WHERE c.agent_id = $1 AND c.kind = 'entity_profile'`,
+    [simAgent, entityId],
+  );
+  console.log(`  entity_profile rows under entity=${entityName}: ${r.rows.length} ${r.rows.length > 0 ? "✓" : "✗"}`);
+  if (r.rows.length > 0) {
+    console.log(`  retention=${r.rows[0].retention_class} importance=${r.rows[0].importance}`);
+    console.log(`  summary first 120: ${r.rows[0].text}`);
+  }
+
+  // Cleanup
+  await pool.query("DELETE FROM semantic.chunks WHERE agent_id = $1", [simAgent]);
+  await pool.query("DELETE FROM structured.entities WHERE id = $1", [entityId]);
+}
+
 async function main() {
   console.log("Concurrency simulation — Moderator cache + worker pipeline");
   console.log("==========================================================");
@@ -437,6 +515,7 @@ async function main() {
     await scenarioG_workerTools();
     await scenarioH_webSearch();
     await scenarioI_skillEmit();
+    await scenarioJ_entityReflection();
   } finally {
     await pool.end();
   }

--- a/src/recall/routes.ts
+++ b/src/recall/routes.ts
@@ -358,34 +358,68 @@ export async function routeGraphWalk(
   }
   if (seeds.length === 0) {return [];}
 
-  // Step 2: 1-hop neighbors via relations, then chunks indexed under those.
-  // GROUP BY neighbor + chunk and aggregate so a chunk that gets reached
-  // via multiple neighbors scores higher than one reached via just one.
-  const rows = await pool.query<RouteRow & { neighbors: number; avg_conf: number }>(
-    `WITH neighbors AS (
+  // Step 2: walk up to 2 hops via relations, score chunks by how easily
+  // they're reachable. Recursive CTE finds all neighbors at depth 1 and 2;
+  // we down-weight depth-2 contributions (a 1-hop relation is a stronger
+  // signal than a 2-hop chain). Closed relations (`ended_at < now`) older
+  // than 180d don't participate.
+  //
+  // This is the multi-hop extension HippoRAG / GraphRAG papers argue is
+  // the real graph win — answers questions like "what is the project Bob
+  // mentioned in his message that Alice replied to" where the chain
+  // crosses through two relation edges. 1-hop alone misses these.
+  const DEPTH2_DAMPENING = 0.5; // 2-hop neighbors count as half a 1-hop neighbor
+  const rows = await pool.query<RouteRow & { neighbors: number; min_depth: number; avg_conf: number }>(
+    `WITH RECURSIVE hops(neighbor_id, depth, confidence) AS (
+       -- depth 1: direct neighbors of any seed
        SELECT DISTINCT
-         CASE WHEN r.subject_id = ANY($1::uuid[]) THEN r.object_id
-              ELSE r.subject_id
-         END AS neighbor_id,
-         r.confidence
-       FROM structured.relations r
-       WHERE (r.subject_id = ANY($1::uuid[]) OR r.object_id = ANY($1::uuid[]))
-         AND (r.ended_at IS NULL OR r.ended_at > now() - interval '180 days')
+              CASE WHEN r.subject_id = ANY($1::uuid[]) THEN r.object_id
+                   ELSE r.subject_id END,
+              1,
+              r.confidence
+         FROM structured.relations r
+        WHERE (r.subject_id = ANY($1::uuid[]) OR r.object_id = ANY($1::uuid[]))
+          AND (r.ended_at IS NULL OR r.ended_at > now() - interval '180 days')
+       UNION ALL
+       -- depth 2: neighbors of depth-1 nodes; exclude seeds (no walking back)
+       SELECT DISTINCT
+              CASE WHEN r.subject_id = h.neighbor_id THEN r.object_id
+                   ELSE r.subject_id END,
+              2,
+              r.confidence * h.confidence  -- compound confidence along the path
+         FROM hops h
+         JOIN structured.relations r
+           ON (r.subject_id = h.neighbor_id OR r.object_id = h.neighbor_id)
+        WHERE h.depth = 1
+          AND (r.ended_at IS NULL OR r.ended_at > now() - interval '180 days')
+     ),
+     reachable AS (
+       -- Deduplicate to (neighbor_id, min_depth, best_conf) so the same
+       -- entity reached via both 1-hop and 2-hop gets credited at depth 1.
+       SELECT neighbor_id, min(depth) AS min_depth, max(confidence) AS confidence
+         FROM hops
+        WHERE neighbor_id IS NOT NULL
+          AND neighbor_id <> ALL($1::uuid[])
+        GROUP BY neighbor_id
      )
      SELECT c.id AS chunk_id, c.source, c.source_ref, c.text,
             count(DISTINCT n.neighbor_id)::int AS neighbors,
-            avg(n.confidence)::float AS avg_conf
-       FROM neighbors n
+            min(n.min_depth)::int AS min_depth,
+            avg(
+              CASE WHEN n.min_depth = 1 THEN n.confidence
+                   ELSE n.confidence * $4::float
+              END
+            )::float AS avg_conf
+       FROM reachable n
        JOIN semantic.chunk_indexes ci
          ON ci.kind = 'entity_ref' AND ci.value = n.neighbor_id::text
        JOIN semantic.chunks c ON c.id = ci.chunk_id
-      WHERE n.neighbor_id IS NOT NULL
-        AND c.retention_class != 'ephemeral'
+      WHERE c.retention_class != 'ephemeral'
         AND c.agent_id = $3
       GROUP BY c.id, c.source, c.source_ref, c.text
-      ORDER BY neighbors DESC, avg_conf DESC
+      ORDER BY min_depth ASC, neighbors DESC, avg_conf DESC
       LIMIT $2`,
-    [seeds, k, aid],
+    [seeds, k, aid, DEPTH2_DAMPENING],
   );
   if (rows.rows.length === 0) {return [];}
   const maxN = rows.rows.reduce((m, r) => Math.max(m, r.neighbors), 0);
@@ -394,9 +428,12 @@ export async function routeGraphWalk(
       build(
         r,
         r.neighbors,
-        // Composite: neighbor count (0..1) × avg confidence (0..1).
-        // A chunk reached via 3 distinct related entities each at 0.9
-        // confidence beats a chunk reached via 1 neighbor at 1.0.
+        // Composite: neighbor count (0..1) × avg confidence × depth bonus.
+        // A chunk reached via 3 distinct 1-hop neighbors at 0.9 conf beats
+        // one reached via 1 neighbor at 1.0; a 1-hop chunk beats a 2-hop
+        // chunk with same neighbor count (depth already baked into avg_conf
+        // via DEPTH2_DAMPENING, but we also use it as a stable sort key
+        // above to preserve tie-break behavior).
         maxN === 0 ? 0 : (r.neighbors / maxN) * Math.min(1, Math.max(0, r.avg_conf)),
       ),
     ),

--- a/src/workers/reflection.ts
+++ b/src/workers/reflection.ts
@@ -283,6 +283,187 @@ async function writeChunk(
   }
 }
 
+/* ---------------------- entity-centric reflection ------------------------- */
+
+/**
+ * Entity-centric reflection: pick entities that have accumulated enough
+ * mentions since their last entity_profile chunk, and have the LLM write
+ * a short "what do we know about X" summary. The result is stored as
+ * kind='entity_profile' AND indexed via chunk_indexes(kind='entity_ref')
+ * so future graph_walk for that entity finds the profile directly.
+ *
+ * This is the GraphRAG community-summary idea, scoped down to ONE
+ * entity at a time (cheap; no Leiden clustering needed). The "提炼"
+ * judgement test is satisfied:
+ *   raw mentions → one dense reusable profile chunk (importance 0.7,
+ *   pinned, T0-eligible) → future questions about this entity skip the
+ *   N-chunk dump and hit one paragraph.
+ */
+
+const ENTITY_REFLECTION_MIN_MENTIONS = 8;
+const ENTITY_REFLECTION_LOOKBACK_DAYS = 30;
+const ENTITY_REFLECTION_PROFILE_TTL_DAYS = 7;
+const ENTITY_REFLECTION_MAX_PER_RUN = 3;
+const ENTITY_REFLECTION_MAX_CHUNKS_PER_ENTITY = 60;
+const ENTITY_REFLECTION_MAX_CHARS = 6000;
+
+const ENTITY_SYSTEM_PROMPT =
+  "You are summarising what the agent's memory knows about ONE specific " +
+  "entity. Read all the mentions (chronological order, oldest first) and " +
+  "write a 3-6 sentence factual summary in the user's language. Focus on: " +
+  "what this entity IS (one phrase), notable facts, relationships, and any " +
+  "preferences / patterns. No greetings, no caveats, no markdown headers. " +
+  "Just the summary text.";
+
+export type EntityReflectionOutcome = {
+  entityId: string;
+  entityName: string;
+  ok: boolean;
+  mentionsConsidered: number;
+  profileChunkId?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  error?: string;
+};
+
+export async function runEntityReflectionForAgent(
+  deps: ReflectionDeps,
+  agentId: string,
+): Promise<EntityReflectionOutcome[]> {
+  // 1. Find candidate entities: ≥N mentions in lookback, no entity_profile in TTL window.
+  const candidates = await deps.pool.query<{
+    id: string; canonical_name: string; type: string; mention_count: number;
+  }>(
+    `SELECT e.id::text, e.canonical_name, e.type,
+            count(DISTINCT ci.chunk_id)::int AS mention_count
+       FROM structured.entities e
+       JOIN semantic.chunk_indexes ci
+         ON ci.kind = 'entity_ref' AND ci.value = e.id::text
+       JOIN semantic.chunks c ON c.id = ci.chunk_id
+      WHERE c.agent_id = $1
+        AND c.created_at > now() - ($2 || ' days')::interval
+        AND e.deleted_at IS NULL
+        AND c.kind NOT IN ('entity_profile', 'reflection', 'profile')
+        AND NOT EXISTS (
+          SELECT 1
+            FROM semantic.chunks p
+            JOIN semantic.chunk_indexes pi
+              ON pi.chunk_id = p.id AND pi.kind = 'entity_ref' AND pi.value = e.id::text
+           WHERE p.kind = 'entity_profile'
+             AND p.agent_id = $1
+             AND p.created_at > now() - ($3 || ' days')::interval
+        )
+      GROUP BY e.id, e.canonical_name, e.type
+      HAVING count(DISTINCT ci.chunk_id) >= $4
+      ORDER BY count(DISTINCT ci.chunk_id) DESC
+      LIMIT $5`,
+    [
+      agentId,
+      String(ENTITY_REFLECTION_LOOKBACK_DAYS),
+      String(ENTITY_REFLECTION_PROFILE_TTL_DAYS),
+      ENTITY_REFLECTION_MIN_MENTIONS,
+      ENTITY_REFLECTION_MAX_PER_RUN,
+    ],
+  );
+
+  const outcomes: EntityReflectionOutcome[] = [];
+  for (const e of candidates.rows) {
+    const outcome = await reflectOnEntity(deps, agentId, e);
+    outcomes.push(outcome);
+  }
+  return outcomes;
+}
+
+async function reflectOnEntity(
+  deps: ReflectionDeps,
+  agentId: string,
+  entity: { id: string; canonical_name: string; type: string; mention_count: number },
+): Promise<EntityReflectionOutcome> {
+  // 2. Gather mention chunks.
+  const chunks = await deps.pool.query<{ text: string; source: string; created_at: Date }>(
+    `SELECT c.text, c.source, c.created_at
+       FROM semantic.chunks c
+       JOIN semantic.chunk_indexes ci
+         ON ci.chunk_id = c.id AND ci.kind = 'entity_ref' AND ci.value = $2
+      WHERE c.agent_id = $1
+        AND c.created_at > now() - ($3 || ' days')::interval
+        AND c.kind NOT IN ('entity_profile', 'reflection', 'profile')
+      ORDER BY c.created_at DESC
+      LIMIT $4`,
+    [agentId, entity.id, String(ENTITY_REFLECTION_LOOKBACK_DAYS), ENTITY_REFLECTION_MAX_CHUNKS_PER_ENTITY],
+  );
+  if (chunks.rowCount === 0) {
+    return {
+      entityId: entity.id, entityName: entity.canonical_name,
+      ok: false, mentionsConsidered: 0, error: "no-mention-chunks",
+    };
+  }
+
+  // 3. Chronological dump, oldest first, cap by char count.
+  const ordered = chunks.rows.toReversed();
+  let dump = "";
+  let considered = 0;
+  for (const c of ordered) {
+    const line = `[${c.created_at.toISOString()}] (${c.source}) ${c.text}\n`;
+    if (dump.length + line.length > ENTITY_REFLECTION_MAX_CHARS) {break;}
+    dump += line;
+    considered += 1;
+  }
+  const userPrompt =
+    `Entity: ${entity.canonical_name} (type: ${entity.type})\n` +
+    `Mentions (chronological, ${considered}):\n\n${dump}`;
+
+  // 4. LLM call.
+  const llmResult = await deps.llm.chat({
+    systemPrompt: ENTITY_SYSTEM_PROMPT,
+    userPrompt,
+    maxOutputTokens: 400,
+    temperature: 0.3,
+  });
+  if (!llmResult.ok) {
+    return {
+      entityId: entity.id, entityName: entity.canonical_name,
+      ok: false, mentionsConsidered: considered, error: llmResult.error,
+    };
+  }
+  const summary = llmResult.text.trim();
+  if (summary.length < 20) {
+    return {
+      entityId: entity.id, entityName: entity.canonical_name,
+      ok: false, mentionsConsidered: considered, error: "summary-too-short",
+      inputTokens: llmResult.inputTokens, outputTokens: llmResult.outputTokens,
+    };
+  }
+
+  // 5. Write chunk + back-link to the entity via chunk_indexes so future
+  // graph_walk for this entity surfaces the profile.
+  const chunkId = await writeChunk(deps, {
+    agentId,
+    text: summary,
+    kind: "entity_profile",
+    source: `entity-reflection:${entity.canonical_name.slice(0, 60)}`,
+    retentionClass: "pinned",
+    importance: 0.7,
+  });
+  if (chunkId) {
+    await deps.pool.query(
+      `INSERT INTO semantic.chunk_indexes (chunk_id, kind, value)
+         VALUES ($1, 'entity_ref', $2)
+       ON CONFLICT DO NOTHING`,
+      [chunkId, entity.id],
+    ).catch(() => undefined);
+  }
+  return {
+    entityId: entity.id,
+    entityName: entity.canonical_name,
+    ok: chunkId !== null,
+    mentionsConsidered: considered,
+    profileChunkId: chunkId ?? undefined,
+    inputTokens: llmResult.inputTokens,
+    outputTokens: llmResult.outputTokens,
+  };
+}
+
 /* ----------------------- daemon (interval + event-driven) ----------------- */
 
 export type ReflectionDaemonHandle = {
@@ -326,6 +507,20 @@ export function startReflectionDaemon(args: {
         );
       } else if (!outcome.ok) {
         args.logger.warn(`memory-postgres: reflection (${reason}) agent=${agentId} err=${outcome.error}`);
+      }
+      // Entity-centric reflection: same trigger; runs alongside time-window
+      // reflection. Internally throttled by the 7-day TTL filter in the
+      // candidate query, so back-to-back triggers are no-ops.
+      const entOutcomes = await runEntityReflectionForAgent(args.deps, agentId);
+      const writtenCount = entOutcomes.filter((o) => o.ok && o.profileChunkId).length;
+      if (writtenCount > 0) {
+        const summary = entOutcomes
+          .filter((o) => o.ok && o.profileChunkId)
+          .map((o) => `${o.entityName}(${o.mentionsConsidered})`)
+          .join(", ");
+        args.logger.info(
+          `memory-postgres: entity-reflection (${reason}) agent=${agentId} wrote=${writtenCount} → ${summary}`,
+        );
       }
     } catch (err) {
       args.logger.warn(`memory-postgres: reflection (${reason}) failed for ${agentId}: ${(err as Error).message}`);


### PR DESCRIPTION
## Why

Per \"提炼\" project principle: GraphRAG's actually-useful parts (multi-hop recall + per-entity distillation), without the expensive Leiden community detection that doesn't fit our small + high-update + privacy-bound corpus.

## A. \`routeGraphWalk\` 1-hop → 2-hop

- Recursive CTE over \`structured.relations\`; depth-2 entities deduplicated against depth-1
- 0.5 dampening on 2-hop confidence contributions
- Stable sort: \`min_depth ASC, neighbors DESC, avg_conf DESC\`
- **No ingest cost change** — same entity/relation tables

Answers HippoRAG-style chain questions (\"what project did Bob mention in the message Alice replied to\") that 1-hop misses.

## B. Entity-centric reflection

- New \`runEntityReflectionForAgent(agentId)\`: picks ≥8-mention entities (last 30d) with no \`entity_profile\` in last 7d, caps 3 per run
- LLM call → 5-6 sentence summary → \`kind='entity_profile'\`, \`retention='pinned'\`, \`importance=0.7\`
- Back-indexed via \`chunk_indexes(kind='entity_ref')\` so future graph_walk for that entity finds the profile directly
- Daemon \`triggerForAgent()\` (session_end-driven) runs entity-reflection alongside time-window reflection
- SQL filter does the 7d throttle internally; in-memory daemon throttle covers the time-window side

This is GraphRAG's community-summary idea scoped to ONE entity at a time. One LLM call per entity vs one per Leiden cluster. Respects viewer-scope + multi-agent isolation.

## Test plan

- [x] \`npm run build\` clean
- [x] Sim scenario J: seed entity + 10 mention chunks → \`runEntityReflectionForAgent\` → \`entity_profile\` chunk pinned and back-indexed ✓
- [x] Gateway restarts clean
- [ ] Live: after a few group questions accumulating mentions of one topic, look for \`entity-reflection ... wrote=1 → topic.X(N)\` in logs

## 提炼 check

Yesterday's N mention chunks (high token cost to read together at query time) → today's 1 dense pinned chunk (one paragraph, retrieves once). Future queries about that entity skip the N-chunk dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)