### PR TITLE
Entity-reflection guards from live test (type allowlist + min-output)

### DIFF
--- a/concurrency-sim.mjs
+++ b/concurrency-sim.mjs
@@ -441,7 +441,7 @@ async function scenarioJ_entityReflection() {
     [entityId, entityName],
   );
   const chunkIds = [];
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 14; i++) {
     const cid = uuid();
     const text = `Yao mentioned ${entityName} — context note ${i+1}: it ${i % 2 === 0 ? "ships next Tuesday" : "uses pgvector + HNSW"}.`;
     const er = await embedding.embed({ inputs: [text] }).catch(() => null);
@@ -480,7 +480,7 @@ async function scenarioJ_entityReflection() {
   );
   console.log(`  outcomes: ${outcomes.length} candidate(s)`);
   for (const o of outcomes) {
-    console.log(`    - ${o.entityName} ok=${o.ok} mentions=${o.mentionsConsidered} chunk=${o.profileChunkId?.slice(0,8) ?? "-"}`);
+    console.log(`    - ${o.entityName} ok=${o.ok} mentions=${o.mentionsConsidered} chunk=${o.profileChunkId?.slice(0,8) ?? "-"} ${o.error ? "err=" + o.error : ""} tokens=${o.inputTokens}->${o.outputTokens}`);
   }
 
   // Verify: entity_profile chunk exists AND is back-indexed under this entity.

--- a/src/workers/reflection.ts
+++ b/src/workers/reflection.ts
@@ -300,12 +300,21 @@ async function writeChunk(
  *   N-chunk dump and hit one paragraph.
  */
 
-const ENTITY_REFLECTION_MIN_MENTIONS = 8;
+const ENTITY_REFLECTION_MIN_MENTIONS = 12;
 const ENTITY_REFLECTION_LOOKBACK_DAYS = 30;
 const ENTITY_REFLECTION_PROFILE_TTL_DAYS = 7;
 const ENTITY_REFLECTION_MAX_PER_RUN = 3;
 const ENTITY_REFLECTION_MAX_CHUNKS_PER_ENTITY = 60;
 const ENTITY_REFLECTION_MAX_CHARS = 6000;
+/** Reflect ONLY on entity types that capture conversational meaning.
+ *  Excludes `file` and `repo` which the deterministic extractor collects
+ *  liberally from doc/KB ingest (file paths get extracted as entities).
+ *  Live test showed: a "repo/ssh/id_ed25519" entity fed Gemini a doc
+ *  dump it couldn't summarize, output truncated at 16 tokens. */
+const ENTITY_REFLECTION_TYPE_ALLOWLIST = [
+  "person", "concept", "project", "topic", "organization", "technology", "tool",
+];
+const ENTITY_REFLECTION_MIN_SUMMARY_CHARS = 80;
 
 const ENTITY_SYSTEM_PROMPT =
   "You are summarising what the agent's memory knows about ONE specific " +
@@ -330,7 +339,10 @@ export async function runEntityReflectionForAgent(
   deps: ReflectionDeps,
   agentId: string,
 ): Promise<EntityReflectionOutcome[]> {
-  // 1. Find candidate entities: ≥N mentions in lookback, no entity_profile in TTL window.
+  // 1. Find candidate entities. Three filters stack:
+  //    - type in allowlist (drop file-path noise)
+  //    - mention count >= threshold (drop one-off mentions)
+  //    - no entity_profile chunk written for this entity in TTL window
   const candidates = await deps.pool.query<{
     id: string; canonical_name: string; type: string; mention_count: number;
   }>(
@@ -343,6 +355,7 @@ export async function runEntityReflectionForAgent(
       WHERE c.agent_id = $1
         AND c.created_at > now() - ($2 || ' days')::interval
         AND e.deleted_at IS NULL
+        AND e.type = ANY($6::text[])
         AND c.kind NOT IN ('entity_profile', 'reflection', 'profile')
         AND NOT EXISTS (
           SELECT 1
@@ -363,6 +376,7 @@ export async function runEntityReflectionForAgent(
       String(ENTITY_REFLECTION_PROFILE_TTL_DAYS),
       ENTITY_REFLECTION_MIN_MENTIONS,
       ENTITY_REFLECTION_MAX_PER_RUN,
+      ENTITY_REFLECTION_TYPE_ALLOWLIST,
     ],
   );
 
@@ -427,10 +441,13 @@ async function reflectOnEntity(
     };
   }
   const summary = llmResult.text.trim();
-  if (summary.length < 20) {
+  // Min-output guard: caught a real bug live where Gemini truncated to
+  // 16 tokens on a noisy entity ("`ssh/id_ed25519` refers to an SSH") and
+  // wrote it to cache as a "pinned" T0 chunk — worse than no profile.
+  if (summary.length < ENTITY_REFLECTION_MIN_SUMMARY_CHARS) {
     return {
       entityId: entity.id, entityName: entity.canonical_name,
-      ok: false, mentionsConsidered: considered, error: "summary-too-short",
+      ok: false, mentionsConsidered: considered, error: `summary-too-short(${summary.length}<${ENTITY_REFLECTION_MIN_SUMMARY_CHARS})`,
       inputTokens: llmResult.inputTokens, outputTokens: llmResult.outputTokens,
     };
   }


### PR DESCRIPTION
## Live test findings

Ran \`runEntityReflectionForAgent('main')\` against the real DB. Three findings:

### ✓ Wiring works
Picked up \`ssh/id_ed25519\` (10 mentions), Gemini ran 3.4s, wrote pinned chunk, back-indexed via \`chunk_indexes\`. The plumbing is solid.

### ⚠ Output was bad (now guarded)
Gemini truncated at 16 output tokens producing a 33-char chunk: \`\`\`\`ssh/id_ed25519\` refers to an SSH\`\`\`\` — written as **pinned T0** resident. Worse than no profile.

Root cause: entity extractor over-collects file paths as \"entities\" with wrong types. Top entities on live DB:
\`\`\`
10× repo/ssh/id_ed25519       ← file path, type \"repo\" wrong
6×  person/week1-arm          ← folder name, type \"person\" wrong
4×  file/03-ssh.md            ← file path
\`\`\`

**Guards added:**
- \`ENTITY_REFLECTION_TYPE_ALLOWLIST = {person, concept, project, topic, organization, technology, tool}\` — skip file/repo noise
- \`ENTITY_REFLECTION_MIN_SUMMARY_CHARS = 80\` — refuse to write below this; silent > garbage T0
- Mention threshold 8 → 12; sim J seeds 14 to match
- Polluted ssh/id_ed25519 chunk deleted by hand

### ⚠ \`structured.relations\` is empty (separate finding, logged not fixed)
0 rows. The deterministic + sidecar extractor isn't producing relation triples from our content (mostly KB docs). Consequence: \`routeGraphWalk\` has been dead code on this deployment — both old 1-hop and new 2-hop walk \`structured.relations\`. Other recall routes absorbed the gap silently.

Not blocking; future investigation into the extractor. Likely needs conversational chunks + sidecar LLM stage enabled.

## Per 提炼 principle

Guards prevent T0 pollution while the entity layer is noisy. Entity-reflection sits quietly until there's something worth distilling. **No regressions, higher quality bar.**

## Test plan

- [x] \`npm run build\` clean
- [x] Live run on agent='main' verified the chunk-writing path; new guards now reject the bad output
- [x] Sim J updated to 14 mentions (matching new threshold), passes when Gemini isn't rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)