### PR TITLE
Telegram WebApp dashboard: /dashboard bot command (in-app, auto-authenticated)

### DIFF
--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -336,6 +336,68 @@ OpenClaw's tavily plugin registers a search tool for the **codex agent loop** �
 
 ---
 
+## 5b. Cloudflare Tunnel (optional — public dashboard URL for Telegram WebApp)
+
+**Why:** to open the memory dashboard from a **Telegram WebApp button** (`/dashboard` bot command), the dashboard needs a public HTTPS URL. Cloudflare Tunnel gives you one for free, with no port forwarding and no public IP required. Telegram's WebApp SDK requires HTTPS — `http://` URLs are silently rejected.
+
+### Quick path (5 minutes, ephemeral URL)
+
+```bash
+mkdir -p ~/bin
+curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o ~/bin/cloudflared
+chmod +x ~/bin/cloudflared
+~/bin/cloudflared tunnel --url http://localhost:8765 --no-autoupdate
+# Outputs: Your quick Tunnel has been created! Visit it at:
+#   https://random-words-here.trycloudflare.com
+```
+
+Paste the URL into `openclaw.json`:
+
+```jsonc
+"dashboard": {
+  "enabled": true, "host": "127.0.0.1", "port": 8765,
+  "tokenEnv": "NEXTCLAW_DASH_TOKEN",
+  "publicUrl": "https://random-words-here.trycloudflare.com"
+}
+```
+
+Restart OpenClaw. Send `/dashboard` to your bot. Tap the button.
+
+> ⚠️ Quick-tunnel URLs **change every time cloudflared restarts**. Fine for testing; for prod use a named tunnel (below).
+
+### Stable path (named tunnel — one-time setup, ~15 minutes)
+
+Requires: a Cloudflare account (free) + a domain on Cloudflare DNS.
+
+```bash
+~/bin/cloudflared tunnel login                            # browser auth
+~/bin/cloudflared tunnel create memory-dashboard          # creates UUID
+~/bin/cloudflared tunnel route dns memory-dashboard memory.yourdomain.com
+# Create ~/.cloudflared/config.yml:
+cat > ~/.cloudflared/config.yml <<'EOF'
+tunnel: memory-dashboard
+credentials-file: /home/youruser/.cloudflared/<UUID>.json
+ingress:
+  - hostname: memory.yourdomain.com
+    service: http://localhost:8765
+  - service: http_status:404
+EOF
+# Run as systemd --user service:
+~/bin/cloudflared service install
+sudo systemctl start cloudflared
+```
+
+Now `https://memory.yourdomain.com` is stable across restarts. Update `publicUrl` in openclaw.json and stop touching it.
+
+### How auth works (no token leakage)
+
+- The dashboard's `/api/*` endpoints reject any request without a valid token (`X-Token` header / `?token=` query).
+- When Telegram opens the WebApp, it injects `window.Telegram.WebApp.initData` — a signed payload containing the user's Telegram id + auth_date + HMAC.
+- The dashboard JS POSTs that initData to `/api/auth/telegram`. The server HMAC-validates with the bot token, checks `user.id` is in `commands.ownerAllowFrom`, and issues a **per-user session token** (in-memory, 1h TTL).
+- Session token rides as `X-Token` on all subsequent calls. No global token in the URL means **forwarding the link doesn't leak access**.
+
+---
+
 ## 6. Credbroker (optional — multi-host setups only)
 
 **Why:** if you have multiple machines on a Tailscale tailnet and want **zero API keys on caller hosts**, run a credential broker on one trusted "mainserver" and point everything at it. The broker injects credentials from its vault based on Tailscale identity.

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,73 @@ let MODULE_MODERATOR_HANDLE: ModeratorServiceHandle | null = null;
 let MODULE_TRANSCRIPT_WATCHERS: TranscriptWatcherHandle[] = [];
 let MODULE_REFLECTION_HANDLE: ReflectionDaemonHandle | null = null;
 let MODULE_INGEST_DEPS: import("./src/ingest/pipeline.js").IngestDeps | null = null;
+/** Set on service start when we have what /dashboard needs (bot token,
+ *  owner allowlist, public URL). Cleared on stop. */
+type DashboardCommandCtx = {
+  telegram: import("./src/moderator/telegram-api.js").TelegramBotApi;
+  publicUrl: string;
+  ownerIds: Set<string>;
+};
+let MODULE_DASHBOARD_CMD: DashboardCommandCtx | null = null;
+
+/**
+ * Handle `/dashboard` text from a Telegram user. Replies with an
+ * inline-keyboard WebApp button that opens the dashboard inside Telegram.
+ * Owner-only (checked against `commands.ownerAllowFrom`). Returns true
+ * when the message was handled (caller should claim); false to let
+ * normal routing continue.
+ */
+async function handleDashboardCommand(
+  api: { logger: { info: (m: string) => void; warn: (m: string) => void } },
+  ctxObj: { conversationId?: string; senderId?: string },
+): Promise<boolean> {
+  const cmd = MODULE_DASHBOARD_CMD;
+  if (!cmd) {
+    api.logger.warn("dashboard cmd: not configured (publicUrl + telegram bot token both required)");
+    return false;
+  }
+  const senderRaw = (ctxObj.senderId ?? "").replace(
+    /^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/,
+    "",
+  );
+  if (!cmd.ownerIds.has(senderRaw)) {
+    api.logger.info(`dashboard cmd: rejecting non-owner sender=${senderRaw}`);
+    // Reply with a polite refusal (still consume the message).
+    const chatId = (ctxObj.conversationId ?? "").replace(
+      /^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/,
+      "",
+    );
+    if (chatId) {
+      await cmd.telegram.sendMessage({
+        chatId,
+        text: "Dashboard 仅限运营者使用。",
+      }).catch(() => undefined);
+    }
+    return true;
+  }
+  const chatId = (ctxObj.conversationId ?? "").replace(
+    /^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/,
+    "",
+  );
+  if (!chatId) {return false;}
+  // WebApp button: when tapped, Telegram opens the URL inside its
+  // in-app browser AND injects window.Telegram.WebApp.initData which
+  // the dashboard JS exchanges for a session token at
+  // /api/auth/telegram. No URL token leakage.
+  await cmd.telegram.sendMessage({
+    chatId,
+    text: "📊 OpenClaw Memory Dashboard\n\n点下面的按钮，dashboard 在 Telegram 内部打开（自动鉴权，只有你看得到）。",
+    replyMarkup: {
+      inline_keyboard: [[{
+        text: "📈 Open Dashboard",
+        web_app: { url: cmd.publicUrl },
+      }]],
+    },
+  });
+  api.logger.info(`dashboard cmd: sent WebApp button to sender=${senderRaw}`);
+  return true;
+}
+
 import { startTranscriptWatcherDaemon, type TranscriptWatcherHandle } from "./src/workers/transcript-watcher.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
@@ -139,18 +206,30 @@ export default definePluginEntry({
     // forwards the inbound event into the Moderator pipeline; before_dispatch
     // only decides whether to suppress codex.
     api.on("before_dispatch", async (event, hookCtx) => {
-      const ctxObj = hookCtx as { channelId?: string; conversationId?: string };
+      const ctxObj = hookCtx as { channelId?: string; conversationId?: string; senderId?: string };
       if (ctxObj?.channelId !== "telegram") {return;}
+      const ev = event as { content?: string; isGroup?: boolean };
+      const content = (ev.content ?? "").trim();
+
+      // 0. /dashboard command — open the dashboard WebApp inline. Owner
+      //    only. Works in both DM and group. Always claims (the response
+      //    is sent below).
+      if (/^\/dashboard(?:@\w+_bot)?(?:\s|$)/i.test(content)) {
+        const handled = await handleDashboardCommand(api, ctxObj);
+        if (handled) {return { handled: true };}
+        // If we couldn't handle (missing publicUrl, etc.), fall through
+        // and let normal routing take over so the user sees SOMETHING.
+      }
+
       // event.isGroup is set directly by the dispatcher (see
       // hook-types: PluginHookBeforeDispatchEvent), preferred over
       // re-parsing the conversation id.
-      const ev = event as { content?: string; isGroup?: boolean };
       const isGroup = ev.isGroup === true ||
         (ctxObj.conversationId ?? "")
           .replace(/^(?:channel:|chat:|user:|tg-?|telegram:|slack:|discord:|whatsapp:)/, "")
           .startsWith("-");
       if (!isGroup) {return;} // DMs continue to codex
-      const addressed = /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(ev.content ?? "");
+      const addressed = /@\w+_bot|@bot\b|^\/(start|ask|help)/i.test(content);
       if (!addressed) {return;} // group chatter not for the bot — codex won't reply anyway
       api.logger.info(
         `[moderator/hook] before_dispatch CLAIMED: conv=${ctxObj.conversationId} ` +
@@ -306,8 +385,46 @@ export default definePluginEntry({
         if (cfg.dashboard.enabled) {
           try {
             const pool = await getPool(activePoolCfg);
-            server = await startDashboardServer(pool, cfg);
-            api.logger.info(`memory-postgres: dashboard listening at ${server.url}`);
+            // Pull Telegram bot token + owner allowlist so the dashboard
+            // can authenticate WebApp users via initData. When either is
+            // missing, the dashboard falls back to global-token only.
+            const liveCfg = ctx.config as unknown as {
+              channels?: { telegram?: { botToken?: string } };
+              commands?: { ownerAllowFrom?: string[] };
+            };
+            const tgBotToken = liveCfg.channels?.telegram?.botToken;
+            const allowedTgIds = new Set<string>(
+              (liveCfg.commands?.ownerAllowFrom ?? [])
+                .filter((s): s is string => typeof s === "string" && s.startsWith("telegram:"))
+                .map((s) => s.replace(/^telegram:/, "")),
+            );
+            server = await startDashboardServer(pool, cfg, {
+              telegramBotToken: tgBotToken,
+              allowedTelegramUserIds: allowedTgIds.size > 0 ? allowedTgIds : undefined,
+            });
+            api.logger.info(
+              `memory-postgres: dashboard listening at ${server.url}` +
+                (tgBotToken && allowedTgIds.size > 0
+                  ? ` (telegram-webapp-auth: ${allowedTgIds.size} allowed user(s))`
+                  : ""),
+            );
+            // Wire `/dashboard` Telegram command iff we have everything:
+            // a publicly reachable HTTPS URL + bot token + owner allowlist.
+            if (cfg.dashboard.publicUrl && tgBotToken && allowedTgIds.size > 0) {
+              const { TelegramBotApi: TgApi } = await import("./src/moderator/telegram-api.js");
+              MODULE_DASHBOARD_CMD = {
+                telegram: new TgApi({ botToken: tgBotToken }),
+                publicUrl: cfg.dashboard.publicUrl,
+                ownerIds: allowedTgIds,
+              };
+              api.logger.info(
+                `memory-postgres: /dashboard command armed → publicUrl=${cfg.dashboard.publicUrl}`,
+              );
+            } else if (cfg.dashboard.publicUrl) {
+              api.logger.warn(
+                "memory-postgres: dashboard.publicUrl set but missing telegram bot token or ownerAllowFrom — /dashboard command not armed",
+              );
+            }
           } catch (err) {
             api.logger.warn(
               `memory-postgres: dashboard failed to start: ${(err as Error).message}`,
@@ -624,6 +741,7 @@ export default definePluginEntry({
         }
         MODULE_MODERATOR_HANDLE = null;
         MODULE_INGEST_DEPS = null;
+        MODULE_DASHBOARD_CMD = null;
         if (moderatorEventUnsub) {
           try { moderatorEventUnsub(); } catch { /* ignore */ }
           moderatorEventUnsub = null;

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -406,17 +406,13 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "host": {
-            "type": "string"
-          },
-          "port": {
-            "type": "number"
-          },
-          "tokenEnv": {
-            "type": "string"
+          "enabled": { "type": "boolean" },
+          "host": { "type": "string", "description": "127.0.0.1 (default) or 0.0.0.0 for Tailscale/LAN access." },
+          "port": { "type": "number" },
+          "tokenEnv": { "type": "string" },
+          "publicUrl": {
+            "type": "string",
+            "description": "Public HTTPS URL where this dashboard is reachable (e.g. a Cloudflare Tunnel hostname). Required for the Telegram `/dashboard` command to render a WebApp button. Must start with https://."
           }
         }
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,12 @@ export type MemoryPostgresConfig = {
     host?: string;
     port?: number;
     tokenEnv?: string;
+    /** Public HTTPS URL the dashboard is reachable at (e.g. a Cloudflare
+     *  Tunnel `*.trycloudflare.com` or your own subdomain). When set,
+     *  the `/dashboard` Telegram bot command replies with an inline
+     *  WebApp button that opens this URL inside the Telegram client.
+     *  Required HTTPS — Telegram refuses WebApp buttons on http://. */
+    publicUrl?: string;
   };
   /**
    * Plugin-internal git watchers. Each entry polls a local repo on its own
@@ -323,7 +329,7 @@ export type ResolvedMemoryPostgresConfig = {
       relevanceFollowupWindowMs: number;
     };
   };
-  dashboard: { enabled: boolean; host: string; port: number; tokenEnv?: string };
+  dashboard: { enabled: boolean; host: string; port: number; tokenEnv?: string; publicUrl?: string };
   tuning: { autoApplyEnabled: boolean };
   gitWatchers: ResolvedGitWatcher[];
   transcriptWatchers: ResolvedTranscriptWatcher[];
@@ -480,6 +486,9 @@ export function resolveConfig(raw: MemoryPostgresConfig): ResolvedMemoryPostgres
       host: typeof dashboard.host === "string" ? dashboard.host : "127.0.0.1",
       port: num(dashboard.port, 8765),
       tokenEnv: dashboard.tokenEnv,
+      publicUrl: typeof dashboard.publicUrl === "string" && /^https:\/\//.test(dashboard.publicUrl)
+        ? dashboard.publicUrl.replace(/\/+$/, "")
+        : undefined,
     },
     tuning: { autoApplyEnabled: bool(tuning.autoApplyEnabled, false) },
     gitWatchers: (raw.gitWatchers ?? []).map(resolveGitWatcher),

--- a/src/dashboard/assets/dashboard.js
+++ b/src/dashboard/assets/dashboard.js
@@ -1,8 +1,41 @@
 // Memory dashboard front-end (no framework).
-// Token: ?token=XXX in URL is captured into sessionStorage and forwarded
-// on every API + SSE call as X-Token (or query for SSE which can't custom-header).
+// Token sources, in priority order:
+//   1. Telegram WebApp initData → POST /api/auth/telegram → session token
+//   2. ?token=XXX in URL        → sessionStorage
+//   3. sessionStorage from prior load
+// All three converge on TOKEN sent as X-Token on /api/*, or ?token= on SSE
+// (which can't set custom headers).
 
 const TOKEN_KEY = "memdash:token";
+let TOKEN = null;
+
+// Promise that resolves once we know whether we have a token. /api/* fetches
+// await this so they don't 401 before the Telegram auth exchange completes.
+let _tokenReady;
+const tokenReadyPromise = new Promise((r) => { _tokenReady = r; });
+
+// 1. Telegram WebApp path: detect, ready, expand, exchange initData → token.
+const tg = (window.Telegram && window.Telegram.WebApp) || null;
+const isTgWebApp = !!(tg && typeof tg.initData === "string" && tg.initData.length > 0);
+if (isTgWebApp) {
+  try { tg.ready(); tg.expand(); } catch { /* SDK quirks ignored */ }
+  fetch("/api/auth/telegram", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ initData: tg.initData }),
+  })
+    .then((r) => r.ok ? r.json() : r.text().then((t) => Promise.reject(t)))
+    .then((j) => {
+      if (j && j.ok && typeof j.token === "string") {
+        TOKEN = j.token;
+        sessionStorage.setItem(TOKEN_KEY, j.token);
+      }
+    })
+    .catch((err) => console.warn("Telegram WebApp auth failed:", err))
+    .finally(() => _tokenReady());
+}
+
+// 2. URL ?token= → sessionStorage (existing behaviour).
 const urlParams = new URLSearchParams(location.search);
 const tokenFromUrl = urlParams.get("token");
 if (tokenFromUrl) {
@@ -12,11 +45,19 @@ if (tokenFromUrl) {
   const cleanUrl = location.pathname + (cleanQuery ? `?${cleanQuery}` : "") + location.hash;
   history.replaceState(null, "", cleanUrl);
 }
-const TOKEN = sessionStorage.getItem(TOKEN_KEY);
-const headers = TOKEN ? { "X-Token": TOKEN } : {};
+
+// 3. Sync fallback: sessionStorage from this or a prior session.
+if (TOKEN === null) {
+  TOKEN = sessionStorage.getItem(TOKEN_KEY);
+  if (!isTgWebApp) {_tokenReady();}
+}
+
+const _hdr = () => (TOKEN ? { "X-Token": TOKEN } : {});
 const sseUrl = (path) => (TOKEN ? `${path}?token=${encodeURIComponent(TOKEN)}` : path);
-const apiFetch = (path, init = {}) =>
-  fetch(path, { ...init, headers: { ...(init.headers ?? {}), ...headers } });
+const apiFetch = async (path, init = {}) => {
+  await tokenReadyPromise;
+  return fetch(path, { ...init, headers: { ...(init.headers ?? {}), ..._hdr() } });
+};
 
 const $ = (id) => document.getElementById(id);
 
@@ -434,7 +475,11 @@ async function refresh() {
   }
 }
 
-function startStream() {
+async function startStream() {
+  // Wait for the auth path to settle before opening SSE — otherwise the
+  // initial EventSource opens with no token and gets a 401, only
+  // reconnecting once TOKEN is set. Gating here = clean first connect.
+  await tokenReadyPromise;
   const es = new EventSource(sseUrl("/api/stream"));
   const ul = $("stream");
 

--- a/src/dashboard/assets/index.html
+++ b/src/dashboard/assets/index.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OpenClaw Memory · memory-postgres</title>
+  <!-- Telegram WebApp SDK — loaded eagerly so the JS bootstrap can
+       detect window.Telegram and auto-exchange initData for a session
+       token before the dashboard makes any /api/* calls. Harmless when
+       not running inside Telegram (the SDK just defines an empty global). -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <link rel="stylesheet" href="/dashboard.css" />
 </head>
 <body>

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -31,6 +31,7 @@ import {
   storeCachedAnswer,
 } from "../cache/qa.js";
 import { ingestOne, type IngestInput } from "../ingest/pipeline.js";
+import { TelegramWebAppAuth } from "./telegram-auth.js";
 import { recall as recallFn, type RecallInput } from "../recall/router.js";
 import { readBotStats } from "./bot-stats.js";
 import { homedir } from "node:os";
@@ -74,12 +75,39 @@ async function ensureListener(pool: Pool): Promise<void> {
   await listenClient.query("LISTEN audit_events");
 }
 
-function tokenOk(req: IncomingMessage, expected: string | undefined): boolean {
+function tokenOk(
+  req: IncomingMessage,
+  expected: string | undefined,
+  tgAuth?: TelegramWebAppAuth,
+): boolean {
+  // Path 1: no token configured → wide open (local-only deploys)
   if (!expected) {return true;}
+  // Path 2: global static token via X-Token header or ?token=
   const headerTok = req.headers["x-token"];
   if (typeof headerTok === "string" && headerTok === expected) {return true;}
   const url = new URL(req.url ?? "/", "http://x");
-  return url.searchParams.get("token") === expected;
+  if (url.searchParams.get("token") === expected) {return true;}
+  // Path 3: per-user session token issued via /api/auth/telegram
+  // (the WebApp client POSTs initData → gets a session token → sends
+  //  it as X-Token on every subsequent /api/* call)
+  if (tgAuth && typeof headerTok === "string") {
+    if (tgAuth.consume(headerTok)) {return true;}
+  }
+  return false;
+}
+
+async function readBody(req: IncomingMessage, maxBytes = 4096): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let total = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {req.destroy(); reject(new Error("body too large"));}
+      else {chunks.push(chunk);}
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", (e) => reject(e));
+  });
 }
 
 function send(res: ServerResponse, status: number, body: string, contentType: string): void {
@@ -687,12 +715,34 @@ function handleStream(req: IncomingMessage, res: ServerResponse): void {
   });
 }
 
+export type DashboardServerExtras = {
+  /** Telegram bot token — when set together with `allowedTelegramUserIds`,
+   *  the dashboard accepts WebApp initData via POST /api/auth/telegram
+   *  and issues per-user session tokens. */
+  telegramBotToken?: string;
+  /** Telegram numeric user ids permitted to authenticate via WebApp.
+   *  Typically derived from `commands.ownerAllowFrom`. */
+  allowedTelegramUserIds?: Set<string>;
+};
+
 export async function startDashboardServer(
   pool: Pool,
   cfg: ResolvedMemoryPostgresConfig,
+  extras: DashboardServerExtras = {},
 ): Promise<DashboardServer> {
   await ensureListener(pool);
   const expected = cfg.dashboard.tokenEnv ? process.env[cfg.dashboard.tokenEnv] : undefined;
+
+  // Telegram WebApp auth — only enabled when both botToken and allowlist
+  // are present. Without one, the dashboard falls back to global-token
+  // auth only (existing behavior).
+  let tgAuth: TelegramWebAppAuth | undefined;
+  if (extras.telegramBotToken && extras.allowedTelegramUserIds && extras.allowedTelegramUserIds.size > 0) {
+    tgAuth = new TelegramWebAppAuth({
+      botToken: extras.telegramBotToken,
+      allowedUserIds: extras.allowedTelegramUserIds,
+    });
+  }
 
   // Static assets are public — they hold no user data, just the shell. Only
   // /api/* endpoints (which read audit + chunks data) require the token.
@@ -716,12 +766,47 @@ export async function startDashboardServer(
     const pathname = url.pathname;
     const isStatic = STATIC_PATHS.has(pathname);
 
-    if (!isStatic && !tokenOk(req, expected)) {
+    // /api/auth/telegram is open by design — it's HOW you get a token.
+    // The endpoint itself validates the initData HMAC + allowlist, so
+    // it can't be abused even though no upstream token gates it.
+    const isPublicAuth = pathname === "/api/auth/telegram";
+    if (!isStatic && !isPublicAuth && !tokenOk(req, expected, tgAuth)) {
       send(res, 401, "unauthorized", "text/plain");
       return;
     }
     try {
       switch (pathname) {
+        case "/api/auth/telegram": {
+          if (!tgAuth) {
+            sendJson(res, 503, { error: "telegram-webapp-auth-not-configured" });
+            return;
+          }
+          if (req.method !== "POST") {
+            sendJson(res, 405, { error: "POST required" });
+            return;
+          }
+          let initData = "";
+          try {
+            const body = await readBody(req);
+            const parsed = JSON.parse(body) as { initData?: string };
+            initData = parsed.initData ?? "";
+          } catch {
+            sendJson(res, 400, { error: "bad-json" });
+            return;
+          }
+          const result = tgAuth.verifyAndIssue(initData);
+          if (!result.ok) {
+            sendJson(res, 401, { error: result.error });
+            return;
+          }
+          sendJson(res, 200, {
+            ok: true,
+            token: result.token,
+            userId: result.userId,
+            expiresAtMs: result.expiresAtMs,
+          });
+          return;
+        }
         case "/":
         case "/index.html":
           await handleStaticAsset(res, "index.html");

--- a/src/dashboard/telegram-auth.ts
+++ b/src/dashboard/telegram-auth.ts
@@ -1,0 +1,167 @@
+/**
+ * Telegram Mini App (WebApp) initData verification + per-user session
+ * tokens for the dashboard.
+ *
+ * Why this exists:
+ *   When the dashboard is exposed publicly (e.g. via Cloudflare Tunnel)
+ *   so a Telegram WebApp button can open it, putting the global
+ *   `NEXTCLAW_DASH_TOKEN` in the URL is a security hole — anyone with
+ *   the link sees everything. Instead, we let the bot's `/dashboard`
+ *   command return a WebApp button pointing at the public URL; when
+ *   Telegram opens the WebApp it injects `window.Telegram.WebApp.initData`
+ *   which the dashboard JS POSTs here. We HMAC-verify it against the
+ *   bot token, check the user is in the owner allowlist, and issue a
+ *   short-lived session token the JS uses for subsequent `/api/*` calls.
+ *
+ * Spec reference: https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app
+ *
+ * Security:
+ *   - HMAC-SHA256 with key = HMAC-SHA256("WebAppData", botToken)
+ *   - auth_date freshness check (default 24h) to refuse replayed initData
+ *   - user.id allowlist (operator config `commands.ownerAllowFrom`)
+ *   - session tokens are 192-bit random, in-memory (lost on restart —
+ *     fine, user just re-opens the WebApp), 1h TTL, plus single-use
+ *     refresh on each successful API hit
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export type TelegramAuthConfig = {
+  /** Bot token from `channels.telegram.botToken`. Required. */
+  botToken: string;
+  /** Allowed Telegram numeric user ids, e.g. ["8064984663"].
+   *  Typically derived from `commands.ownerAllowFrom` ("telegram:<id>" entries). */
+  allowedUserIds: Set<string>;
+  /** Reject initData older than this many seconds. Default 86400 (24h). */
+  maxAuthAgeSec?: number;
+  /** Session token TTL in ms. Default 1h. */
+  sessionTtlMs?: number;
+};
+
+export type SessionRecord = {
+  token: string;
+  userId: string;
+  expiresAtMs: number;
+};
+
+const DEFAULT_MAX_AUTH_AGE_SEC = 24 * 60 * 60;
+const DEFAULT_SESSION_TTL_MS = 60 * 60 * 1000;
+
+export class TelegramWebAppAuth {
+  private readonly sessions = new Map<string, SessionRecord>();
+  private readonly maxAuthAgeSec: number;
+  private readonly sessionTtlMs: number;
+
+  constructor(private readonly cfg: TelegramAuthConfig) {
+    if (!cfg.botToken) {
+      throw new Error("[dashboard/telegram-auth] botToken required");
+    }
+    this.maxAuthAgeSec = cfg.maxAuthAgeSec ?? DEFAULT_MAX_AUTH_AGE_SEC;
+    this.sessionTtlMs = cfg.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+  }
+
+  /**
+   * Validate Telegram WebApp `initData` (URL-encoded query string from
+   * `window.Telegram.WebApp.initData`) and, on success, mint a session
+   * token for the verified user.
+   *
+   * Returns:
+   *   - `{ok: true, token, userId, expiresAtMs}` on success
+   *   - `{ok: false, error: ...}` on validation failure (bad hash,
+   *     stale, user not in allowlist, etc.)
+   */
+  verifyAndIssue(initData: string): { ok: true; token: string; userId: string; expiresAtMs: number }
+    | { ok: false; error: string } {
+    if (typeof initData !== "string" || initData.length === 0) {
+      return { ok: false, error: "missing-initData" };
+    }
+    // 1. Parse initData (URL-encoded; preserve raw values for hashing).
+    const params = new URLSearchParams(initData);
+    const providedHash = params.get("hash");
+    if (!providedHash) {return { ok: false, error: "missing-hash" };}
+
+    // 2. Build data_check_string per Telegram spec:
+    //    all params except `hash`, sorted by key alphabetically,
+    //    each as `key=value`, joined with \n.
+    const entries: Array<[string, string]> = [];
+    params.forEach((v, k) => {
+      if (k !== "hash") {entries.push([k, v]);}
+    });
+    entries.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    const dataCheckString = entries.map(([k, v]) => `${k}=${v}`).join("\n");
+
+    // 3. secret_key = HMAC-SHA256("WebAppData", botToken)
+    const secretKey = createHmac("sha256", "WebAppData").update(this.cfg.botToken).digest();
+    const computed = createHmac("sha256", secretKey).update(dataCheckString).digest();
+
+    // 4. Constant-time compare.
+    const providedBuf = Buffer.from(providedHash, "hex");
+    if (providedBuf.length !== computed.length || !timingSafeEqual(providedBuf, computed)) {
+      return { ok: false, error: "bad-hash" };
+    }
+
+    // 5. auth_date freshness.
+    const authDateStr = params.get("auth_date");
+    if (!authDateStr) {return { ok: false, error: "missing-auth_date" };}
+    const authDate = Number.parseInt(authDateStr, 10);
+    if (!Number.isFinite(authDate)) {return { ok: false, error: "bad-auth_date" };}
+    const ageSec = Math.floor(Date.now() / 1000) - authDate;
+    if (ageSec > this.maxAuthAgeSec) {
+      return { ok: false, error: `stale(${ageSec}s)` };
+    }
+
+    // 6. Parse `user` (JSON-encoded inside initData) and pull `user.id`.
+    const userJson = params.get("user");
+    if (!userJson) {return { ok: false, error: "missing-user" };}
+    let userObj: { id?: number | string; username?: string };
+    try {
+      userObj = JSON.parse(userJson);
+    } catch {
+      return { ok: false, error: "bad-user-json" };
+    }
+    const userIdRaw = userObj?.id;
+    if (userIdRaw === undefined || userIdRaw === null) {return { ok: false, error: "missing-user-id" };}
+    const userId = String(userIdRaw);
+
+    // 7. Allowlist check.
+    if (!this.cfg.allowedUserIds.has(userId)) {
+      return { ok: false, error: `user-not-allowed(${userId})` };
+    }
+
+    // 8. Mint session token.
+    const token = randomBytes(24).toString("base64url");
+    const expiresAtMs = Date.now() + this.sessionTtlMs;
+    this.sessions.set(token, { token, userId, expiresAtMs });
+    return { ok: true, token, userId, expiresAtMs };
+  }
+
+  /**
+   * Validate a session token. Returns the userId on success; null on
+   * miss/expired. Refreshes TTL on hit (sliding-window expiration).
+   */
+  consume(token: string): string | null {
+    if (!token) {return null;}
+    const rec = this.sessions.get(token);
+    if (!rec) {return null;}
+    if (Date.now() > rec.expiresAtMs) {
+      this.sessions.delete(token);
+      return null;
+    }
+    // Sliding-window refresh.
+    rec.expiresAtMs = Date.now() + this.sessionTtlMs;
+    return rec.userId;
+  }
+
+  /** Sweep expired entries. Called opportunistically; not load-bearing. */
+  sweep(): void {
+    const now = Date.now();
+    for (const [k, v] of this.sessions) {
+      if (now > v.expiresAtMs) {this.sessions.delete(k);}
+    }
+  }
+
+  stats(): { activeSessions: number } {
+    this.sweep();
+    return { activeSessions: this.sessions.size };
+  }
+}

--- a/src/moderator/telegram-api.ts
+++ b/src/moderator/telegram-api.ts
@@ -59,6 +59,9 @@ export type SendMessageParams = {
   parseMode?: "Markdown" | "MarkdownV2" | "HTML";
   /** When set, the message is sent inside this forum topic. */
   messageThreadId?: number;
+  /** Optional reply markup — used to attach inline keyboards including
+   *  WebApp buttons. Forwarded verbatim to Telegram. */
+  replyMarkup?: { inline_keyboard: Array<Array<Record<string, unknown>>> };
 };
 
 export type EditMessageTextParams = {
@@ -107,6 +110,7 @@ export class TelegramBotApi {
       ...(params.replyToMessageId ? { reply_to_message_id: params.replyToMessageId } : {}),
       ...(params.parseMode ? { parse_mode: params.parseMode } : {}),
       ...(params.messageThreadId ? { message_thread_id: params.messageThreadId } : {}),
+      ...(params.replyMarkup ? { reply_markup: params.replyMarkup } : {}),
     }).then((o) => (o.ok ? { ok: true as const, result: { messageId: o.result.message_id } } : o));
   }
 


### PR DESCRIPTION
## What

Bot owner sends \`/dashboard\` to the bot → gets an inline-keyboard button → taps → memory dashboard opens **inside Telegram client** (mobile + desktop), already authenticated as that Telegram user. No token in URL, no global secret leaks.

## How it works

1. \`/dashboard\` command handler replies with WebApp inline button targeting \`cfg.dashboard.publicUrl\`
2. Tap → Telegram opens the URL inside its in-app browser AND injects \`window.Telegram.WebApp.initData\` (signed payload: user_id, auth_date, HMAC)
3. Dashboard JS POSTs that initData to \`/api/auth/telegram\`
4. Server HMAC-validates with bot token + allowlist-checks \`user.id\` against \`commands.ownerAllowFrom\`
5. Returns a 192-bit per-user session token (in-memory, 1h sliding TTL)
6. Dashboard uses that token as \`X-Token\` for all subsequent \`/api/*\` calls

## Files

- **New** \`src/dashboard/telegram-auth.ts\` — initData HMAC + session map
- \`src/dashboard/server.ts\` — \`tokenOk\` accepts session tokens; new \`/api/auth/telegram\` endpoint
- \`src/dashboard/assets/{index.html, dashboard.js}\` — loads Telegram WebApp SDK, exchanges initData → token on boot
- \`index.ts\` — \`/dashboard\` before_dispatch handler; module-level command context; \`MODULE_DASHBOARD_CMD\` populated on service start
- \`src/moderator/telegram-api.ts\` — sendMessage accepts \`replyMarkup\` (inline keyboard)
- \`src/config.ts\` + \`openclaw.plugin.json\` — \`cfg.dashboard.publicUrl\` field
- \`docs/SERVICES.md\` §5b — Cloudflare Tunnel setup (quick + stable paths) + auth flow explanation

## Live smoke

```
~/bin/cloudflared tunnel --url http://localhost:8765
  → https://projector-simultaneously-williams-findarticles.trycloudflare.com

Restart gateway → logs:
  dashboard listening at http://127.0.0.1:8765/ (telegram-webapp-auth: 1 allowed user(s))
  /dashboard command armed → publicUrl=https://projector-simultaneously-...

curl /index.html              → 200
curl POST /api/auth/telegram  → 400 missing-initData
curl /api/stats (no token)    → 401 unauthorized
```

## Test plan

- [x] Build clean
- [x] Cloudflare quick tunnel up + reachable
- [x] Gateway restarts clean with auth + cmd armed
- [ ] Live: send \`/dashboard\` to bot DM → tap button → dashboard renders inside Telegram, authenticated
- [ ] Live: same from non-owner Telegram user → \"Dashboard 仅限运营者使用\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)