### PR TITLE
docs: link companion skill openclaw-skill-reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@
 - **Self-tuning loop** (daily / weekly / monthly proposals)
 - **Universal HTTP ingest gateway** — any cron / skill / external script can write memory through the same Stage 0–6 pipeline
 
+## Companion skills
+
+Standalone OpenClaw skills that compose well with nextclaw:
+
+- **[openclaw-skill-reminder](https://github.com/NextAgentBC/openclaw-skill-reminder)** — privacy-conscious time-based reminders. The cron config file only sees opaque `reminder:<short-id>` names; the actual detail (names, addresses, appointments) lives in a mode-600 file. Used by `/dashboard` users to schedule follow-ups without leaking PII into `jobs.json`.
+
 ## Quick start (Level A — memory only, ~20 min)
 
 For the Telegram Moderator, web_search, and reflection upgrades, see the [INSTALL.md](docs/INSTALL.md) bolt-ons. **Read [SERVICES.md](docs/SERVICES.md) first** to know which external services each capability needs.


### PR DESCRIPTION
Cross-links to https://github.com/NextAgentBC/openclaw-skill-reminder so anyone on nextclaw also discovers the reminder skill. The skill solves a specific PII-in-cron-config-file problem hit live (medical appointment details ending up in `jobs.json` `name` field). Skill is standalone (not a nextclaw plugin) but composes well — nextclaw is dashboard + memory, the skill is scheduled triggers, both share openclaw runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)