### PR TITLE
Curated recall + action-sensitive memory (memory_get, citations, commitments) + recall-signal fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memo
 - Self-tuning loop (daily / weekly / monthly proposals)
 - Dashboard via PG LISTEN/NOTIFY
 - Hard per-agent memory namespace isolation (`agent_id` column threaded through every recall path)
+- Action-sensitive commitments: directives the agent might act on are tagged (`safe_to_act` / `requires_confirmation` / `authority` / validity) and surfaced with a ⚠ on recall, so a stray remark can't trigger an action
 
 ## Layout
 
@@ -24,7 +25,7 @@ Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memo
 | `src/recall/` | Tier-walk + parallel route impls + intent + merge |
 | `src/workers/` | context-primer, spreading-activator, compactor, feedback, scoring, tuning, git-watcher, transcript-watcher, shadow-comparator |
 | `src/cache/` | CacheBackend abstraction + PG UNLOGGED impl |
-| `src/structured/` | entity / event / metric / preference extractors + reconcile + categorizer |
+| `src/structured/` | entity / event / metric / preference / commitment extractors + reconcile + categorizer (+ `commitments.ts` recall-side reader) |
 | `src/sdk/` | StructuredMemoryAPI public exports |
 | `src/dashboard/` | HTTP server + SPA assets + bot-stats |
 | `src/cli/` | tail (router-explain, audit, stats, etc. live in dashboard) |
@@ -54,6 +55,6 @@ Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memo
 
 ## Cross-extension contracts
 
-- Reuses `MemoryEmbeddingProviderAdapter` from `openclaw/plugin-sdk/memory-core-host-engine-embeddings`
+- Self-embeds: an internal `EmbeddingClient` (manager-runtime → OpenAI-compat / Ollama endpoint) does its own embedding. nextclaw is an embedding **consumer**, not a host provider — it does **not** register a `MemoryEmbeddingProviderAdapter` and declares no `contracts.embeddingProviders`
 - Implements `MemorySearchManager` from `openclaw/plugin-sdk/memory-core-host-engine-storage`
 - Exposes `StructuredMemoryAPI` barrel for plugins that want SQL-shaped access

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## Unreleased — Curated recall + action-sensitive memory
+
+Memory-quality work on top of 0.2.1 (branch `feat/memory-0-1`, stacked on
+`fix/dedup-signal-and-tuning-dedup`). Migrations 60/61/62 apply automatically on
+gateway restart. No packaging change — `package.json` stays 0.2.1 until release.
+
+### Recall correctness (migrations 60 / 61)
+
+- **Ingest dedup no longer pollutes the recall signal.** A duplicate re-ingest
+  used to bump `last_recalled_at` (the transcript-watcher re-ingests ~every
+  10s), so re-seen chunks looked perpetually "recalled" and the cold-gist
+  compactor — which ages chunks by `last_recalled_at` — could never demote
+  them. Dedup now bumps a separate `last_seen_at` / `dup_count`;
+  `last_recalled_at` + `recall_count` are reserved for genuine recalls. On the
+  live store this de-polluted 422/500 chunks (84%).
+- **Tuning proposals are deduped.** The daily analyzer re-emitted identical
+  pending proposals every run; `audit.tuning_proposals` had accumulated 23
+  duplicates. A partial unique index `(scope, proposal_type) WHERE
+  status='pending'` + `ON CONFLICT … DO UPDATE` now refreshes the open proposal
+  in place (collapsed 23 → 2 live).
+
+### New agent tools / features (migration 62)
+
+- **`memory_get(chunkId)`** — fetch one chunk in full when a search snippet was
+  truncated. Read-only; fail-closed per-agent isolation (a chunk owned by
+  another agent reads as not-found).
+- **Cited recall** — `memory_search` results now carry an inline
+  `pg://<source>/<chunkId>` citation in the model-visible text (plus a
+  `citation` field in structured details) so the agent can attribute a claim
+  and re-fetch via `memory_get`.
+- **Action-sensitive commitments** — directives the agent might *act* on
+  (cancel / send / authorize / appointments / reminders) are extracted into
+  `structured.commitments` (agent-isolated) with `safe_to_act` /
+  `requires_confirmation` / `authority` / validity fields, and surfaced with a
+  ⚠ flag on recall. Conservative by default: side-effecting directives require
+  confirmation; only "set me a reminder" is safe to act on.
+
+### Hygiene
+
+- Declared `memory_get` in `openclaw.plugin.json` `contracts.tools`.
+- Removed the vestigial `contracts.memoryEmbeddingProviders: ["openai-compat"]`
+  declaration. nextclaw self-embeds and never registered such an adapter, so
+  the declaration was orphaned and only triggered a deprecation advisory in
+  `openclaw plugins inspect`. (nextclaw is an embedding *consumer*, not a
+  host-facing provider.)
+
 ## 0.2.1 — Curl-first install + distribution fixes
 
 0.2.1 is a packaging / install-UX release. No new runtime features — the focus

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 - **Real-time dashboard** (bilingual CN/EN) with category breakdown, redaction for health/medical, bot-turn telemetry, side-by-side model comparison
 - **Self-tuning loop** (daily / weekly / monthly proposals)
 - **Universal HTTP ingest gateway** — any cron / skill / external script can write memory through the same Stage 0–6 pipeline
+- **Curated, cited recall**: `memory_search` results carry `pg://` citations so the agent can attribute a claim and re-fetch it in full via `memory_get(chunkId)`; `memory_update` / `memory_forget` let the agent actively curate rather than only append
+- **Action-sensitive memory**: directives the agent might *act* on (cancel, send, authorize, appointments) are tagged with `safe_to_act` / `requires_confirmation` / `authority` and surfaced with a ⚠ on recall — a stale or stray remark can't trigger a real-world action without a check
 
 ## Companion skills
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,7 +23,7 @@ import { startDashboardServer } from "./src/dashboard/server.js";
 import { buildPromptSection } from "./src/prompt-section.js";
 import { migrate, ensureHnswIndex } from "./src/storage/migrate.js";
 import { closePool, getPool } from "./src/storage/pool.js";
-import { buildForgetTool, buildSearchTool, buildStoreTool, buildUpdateTool, } from "./src/tools.js";
+import { buildForgetTool, buildGetTool, buildSearchTool, buildStoreTool, buildUpdateTool, } from "./src/tools.js";
 import { compactCold } from "./src/workers/compactor.js";
 import { startGitWatcherDaemon } from "./src/workers/git-watcher.js";
 import { buildReflectionClient, startReflectionDaemon, } from "./src/workers/reflection.js";
@@ -114,6 +114,13 @@ export default definePluginEntry({
             }
             return buildSearchTool({ config, sessionKey: ctx.sessionKey });
         }, { names: ["memory_search"] });
+        api.registerTool((ctx) => {
+            const config = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
+            if (!config) {
+                throw new Error("memory-postgres: no runtime config available in tool context");
+            }
+            return buildGetTool({ config, sessionKey: ctx.sessionKey });
+        }, { names: ["memory_get"] });
         api.registerTool((ctx) => {
             const config = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
             if (!config) {
@@ -688,7 +695,7 @@ export default definePluginEntry({
             },
         });
         api.logger.info("memory-postgres: capability + tools registered "
-            + "(memory_search, memory_store, memory_update, memory_forget; "
+            + "(memory_search, memory_get, memory_store, memory_update, memory_forget; "
             + "services: dashboard, tuning, compactor, reflection)");
     },
 });

--- a/dist/src/edit/operations.js
+++ b/dist/src/edit/operations.js
@@ -125,3 +125,36 @@ export async function forgetChunk(deps, params) {
         .catch(() => undefined);
     return { ok: true, chunkId: params.chunkId, mode, deletedRow: params.hardDelete === true };
 }
+/**
+ * Fetch one chunk in full by id. Read-only — does NOT bump warmth / recall_count
+ * (the agent already holds the id from a prior recall; treating a targeted
+ * re-read as a recall would re-pollute the cold-aging signal — see
+ * 60-last-seen.sql). Fail-closed isolation: the id + agent_id filter is in the
+ * WHERE, so a chunk owned by another agent reads as not-found (we don't even
+ * reveal it exists).
+ */
+export async function getChunk(deps, params) {
+    const rows = await deps.pool.query(`SELECT id, text, source, source_ref, kind, retention_class,
+            importance, recall_count, created_at
+       FROM semantic.chunks
+      WHERE id = $1 AND agent_id = $2`, [params.chunkId, params.agentId]);
+    if (rows.rowCount === 0) {
+        return { ok: false, reason: "not-found" };
+    }
+    const r = rows.rows[0];
+    return {
+        ok: true,
+        chunk: {
+            chunkId: r.id,
+            text: r.text,
+            source: r.source,
+            sourceRef: r.source_ref,
+            kind: r.kind,
+            retentionClass: r.retention_class,
+            importance: r.importance,
+            recallCount: r.recall_count,
+            createdAt: r.created_at.toISOString(),
+            citation: `pg://${r.source}/${r.id}`,
+        },
+    };
+}

--- a/dist/src/ingest/pipeline.js
+++ b/dist/src/ingest/pipeline.js
@@ -290,6 +290,7 @@ export async function ingestOne(deps, input) {
         rawExcerpt: text,
         result: extractor,
         dreamRunId,
+        agentId,
     });
     await writeEntityRefIndexes(deps.pool, chunkId, reconcileOut.entityIds);
     if (reconcileOut.entityIds.length > 0) {

--- a/dist/src/ingest/pipeline.js
+++ b/dist/src/ingest/pipeline.js
@@ -223,7 +223,10 @@ export async function ingestOne(deps, input) {
     const dup = await deps.pool.query("SELECT id FROM semantic.chunks WHERE text_hash = $1 AND source = $2", [textHash, source]);
     if (dup.rowCount && dup.rowCount > 0) {
         const id = dup.rows[0].id;
-        await deps.pool.query("UPDATE semantic.chunks SET last_recalled_at = now() WHERE id = $1", [id]);
+        // Re-ingest (dedup), not a recall — bump last_seen_at / dup_count only.
+        // last_recalled_at stays reserved for genuine recall hits so the cold
+        // compactor can still age these chunks. See storage/schema/60-last-seen.sql.
+        await deps.pool.query("UPDATE semantic.chunks SET last_seen_at = now(), dup_count = dup_count + 1 WHERE id = $1", [id]);
         return finalize(deps, source, text, earlyAgentId, dreamRunId, start, {
             decision: "merged",
             ingestPath: path,

--- a/dist/src/ingest/sidecar.js
+++ b/dist/src/ingest/sidecar.js
@@ -164,6 +164,7 @@ const EMPTY = {
     events: [],
     preferences: [],
     metrics: [],
+    commitments: [],
     extractorVersion: SIDECAR_VERSION,
 };
 export function parseSidecar(text, now) {
@@ -207,6 +208,9 @@ export function parseSidecar(text, now) {
                 .map((v) => coerceMetric(v, now))
                 .filter((m2) => m2 !== null)
             : [],
+        // Commitments are extracted deterministically (extractors.ts); the LLM
+        // sidecar prompt doesn't emit them yet, so default to none here.
+        commitments: [],
         extractorVersion: SIDECAR_VERSION,
     };
     return { found: true, ok: true, result };
@@ -224,6 +228,7 @@ export function mergeExtractorResults(primary, secondary) {
         events: dedupBy([...primary.events, ...secondary.events], (e) => `${e.ts.toISOString().slice(0, 16)}|${e.type}`),
         preferences: dedupBy([...primary.preferences, ...secondary.preferences], (p) => `${p.scope}|${p.key}`),
         metrics: dedupBy([...primary.metrics, ...secondary.metrics], (m) => `${m.ts.toISOString()}|${m.metric}|${JSON.stringify(m.dim ?? {})}`),
+        commitments: dedupBy([...primary.commitments, ...secondary.commitments], (c) => `${c.kind}|${c.directive}`),
         extractorVersion: primary.extractorVersion,
     };
 }

--- a/dist/src/manager.js
+++ b/dist/src/manager.js
@@ -141,7 +141,12 @@ export async function writeChunk(pool, embedding, input) {
     const textHash = hashTextBytes(input.text);
     const dup = await pool.query("SELECT id FROM semantic.chunks WHERE text_hash = $1 AND source = $2", [textHash, input.source]);
     if (dup.rowCount && dup.rowCount > 0) {
-        await pool.query("UPDATE semantic.chunks SET last_recalled_at = now() WHERE id = $1", [dup.rows[0].id]);
+        // Dedup hit: this is a re-ingest, not a recall. Bump last_seen_at / dup_count
+        // and leave last_recalled_at + recall_count untouched — the cold-gist
+        // compactor ages chunks by last_recalled_at, so conflating the two would
+        // keep re-seen chunks perpetually "warm" and they'd never compact.
+        // See src/storage/schema/60-last-seen.sql.
+        await pool.query("UPDATE semantic.chunks SET last_seen_at = now(), dup_count = dup_count + 1 WHERE id = $1", [dup.rows[0].id]);
         return { id: dup.rows[0].id, written: false };
     }
     const embed = await embedding.embed({ inputs: [input.text] });

--- a/dist/src/storage/schema/60-last-seen.sql
+++ b/dist/src/storage/schema/60-last-seen.sql
@@ -1,0 +1,26 @@
+-- Separate "re-ingested / seen again" from "genuinely recalled".
+--
+-- The ingest dedup path used to bump last_recalled_at on every duplicate
+-- re-ingest (the transcript-watcher re-runs every ~10s), polluting the recall
+-- signal the cold-gist compactor relies on (src/workers/compactor.ts ages
+-- chunks by last_recalled_at). Frequently re-seen chunks looked perpetually
+-- "recalled" and could never age into the cold tier.
+--
+-- Going forward, dedup bumps last_seen_at + dup_count; last_recalled_at and
+-- recall_count stay reserved for real recall hits (router.promoteToHotCache).
+
+ALTER TABLE semantic.chunks
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS dup_count    INT NOT NULL DEFAULT 0;
+
+-- Seed the new column from whatever timestamp we already had.
+UPDATE semantic.chunks
+   SET last_seen_at = COALESCE(last_recalled_at, created_at)
+ WHERE last_seen_at IS NULL;
+
+-- Undo historical pollution: a chunk that was never genuinely recalled
+-- (recall_count = 0) had its last_recalled_at set purely by the old dedup
+-- path. Clear it so the compactor can age these chunks on real recency.
+UPDATE semantic.chunks
+   SET last_recalled_at = NULL
+ WHERE recall_count = 0;

--- a/dist/src/storage/schema/61-tuning-dedup.sql
+++ b/dist/src/storage/schema/61-tuning-dedup.sql
@@ -1,0 +1,26 @@
+-- One open proposal per (scope, proposal_type).
+--
+-- The daily analyzer re-runs and re-emitted identical proposals every pass, so
+-- audit.tuning_proposals accumulated duplicate pending rows (observed in the
+-- field: 15x score_regression, 8x cache.recall.ttl). Collapse the existing
+-- duplicates (keep the most recent per scope+type), then enforce uniqueness so
+-- re-runs refresh the open proposal instead of duplicating it (writeProposal
+-- now upserts via ON CONFLICT — see src/workers/tuning.ts).
+
+DELETE FROM audit.tuning_proposals
+ WHERE id IN (
+   SELECT id FROM (
+     SELECT id,
+            row_number() OVER (
+              PARTITION BY scope, proposal_type
+              ORDER BY ts DESC, id DESC
+            ) AS rn
+       FROM audit.tuning_proposals
+       WHERE status = 'pending'
+   ) ranked
+   WHERE ranked.rn > 1
+ );
+
+CREATE UNIQUE INDEX IF NOT EXISTS tuning_one_open_per_scope
+  ON audit.tuning_proposals (scope, proposal_type)
+  WHERE status = 'pending';

--- a/dist/src/storage/schema/62-commitments.sql
+++ b/dist/src/storage/schema/62-commitments.sql
@@ -1,0 +1,31 @@
+-- Action-sensitive memory: directives the agent might ACT on, tagged so a
+-- stale or low-authority remark can't trigger a real-world side effect without
+-- a check. Populated deterministically by extractCommitments (extractors.ts),
+-- persisted by reconcile(), surfaced on recall (memory_search / memory_get).
+--
+-- agent_id is present here (unlike the other structured.* tables) because
+-- acting on another agent's commitment is exactly the leak we must prevent.
+-- chunk_id is a direct link so recall can fetch a chunk's commitments in one
+-- cheap lookup (ON DELETE CASCADE so a hard-forget cleans them up).
+
+CREATE TABLE IF NOT EXISTS structured.commitments (
+  id                    UUID PRIMARY KEY,
+  agent_id              TEXT NOT NULL DEFAULT 'main',
+  chunk_id              UUID REFERENCES semantic.chunks(id) ON DELETE CASCADE,
+  directive             TEXT NOT NULL,
+  kind                  TEXT NOT NULL,            -- task|authorization|appointment|reminder|other
+  safe_to_act           BOOLEAN NOT NULL DEFAULT false,
+  requires_confirmation BOOLEAN NOT NULL DEFAULT true,
+  authority             TEXT,                     -- user_direct|overheard|inferred|system
+  valid_from            TIMESTAMPTZ,
+  expires_at            TIMESTAMPTZ,
+  supersedes            UUID REFERENCES structured.commitments(id),
+  confidence            REAL NOT NULL,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  invalidated_at        TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS commitments_active
+  ON structured.commitments (agent_id, kind)
+  WHERE invalidated_at IS NULL;
+CREATE INDEX IF NOT EXISTS commitments_chunk
+  ON structured.commitments (chunk_id);

--- a/dist/src/structured/commitments.js
+++ b/dist/src/structured/commitments.js
@@ -1,0 +1,26 @@
+/**
+ * Read-side helper for action-sensitive memory. Given a set of recalled
+ * chunks, return the active commitments attached to them — scoped to a single
+ * agent (hard isolation: a caller never sees another agent's directives).
+ *
+ * Rows are ordered so the most restrictive (requires_confirmation) commitment
+ * per chunk sorts first, letting callers take the first per chunk as the
+ * dominant flag to surface.
+ */
+export async function getActiveCommitmentsByChunk(pool, chunkIds, agentId) {
+    if (chunkIds.length === 0) {
+        return [];
+    }
+    const rows = await pool.query(`SELECT chunk_id, kind, safe_to_act, requires_confirmation, authority, directive
+       FROM structured.commitments
+      WHERE chunk_id = ANY($1::uuid[]) AND agent_id = $2 AND invalidated_at IS NULL
+      ORDER BY requires_confirmation DESC, created_at DESC`, [chunkIds, agentId]);
+    return rows.rows.map((r) => ({
+        chunkId: r.chunk_id,
+        kind: r.kind,
+        safeToAct: r.safe_to_act,
+        requiresConfirmation: r.requires_confirmation,
+        authority: r.authority,
+        directive: r.directive,
+    }));
+}

--- a/dist/src/structured/extractors.js
+++ b/dist/src/structured/extractors.js
@@ -246,6 +246,37 @@ function extractRelations(ctx) {
     }
     return out;
 }
+/* ------------------------------- commitments ------------------------------ */
+// Action-sensitive directives. The patterns require the directive to be aimed
+// at the agent (帮我/请你 / please/can you / 提醒我 / remind me) so generic
+// imperatives in tutorial or reference text ("delete the file") don't get
+// tagged. Conservative defaults: anything side-effecting is safeToAct=false +
+// requiresConfirmation=true; only "set me a reminder" is safe to act on.
+// Task: an addressee marker followed (within a short span) by a side-effecting verb.
+const COMMIT_TASK = /(?:帮我|请你?|麻烦你?|你能不能|\b(?:please|can you|could you|would you)\b)[\s\S]{0,40}?(?:取消|退订|预订|预定|发送|发邮件|删除|支付|转账|下单|部署|发布|\b(?:cancel|unsubscribe|book|send|email|delete|remove|pay|transfer|order|deploy|publish)\b)/i;
+const COMMIT_AUTH = /(?:我?授权你?|你可以(?:直接)?去?|准许你?|\b(?:I authorize|you (?:can|may|are authorized)|go ahead and|feel free to)\b)/i;
+const COMMIT_APPT = /(?:预约|约了|挂号|\b(?:appointment|booked|reservation|reschedule)\b)/i;
+const COMMIT_REMIND = /(?:提醒我|别忘了|记得(?:要)?|\b(?:remind me|don'?t forget)\b)/i;
+function extractCommitments(ctx) {
+    const t = ctx.text;
+    const authority = ctx.source === "manual" || ctx.source === "session" ? "user_direct" : "inferred";
+    const directive = t.replace(/\s+/g, " ").trim().slice(0, 240);
+    // Highest action-sensitivity wins → at most one commitment per chunk.
+    if (COMMIT_TASK.test(t)) {
+        return [{ directive, kind: "task", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+    }
+    if (COMMIT_AUTH.test(t)) {
+        return [{ directive, kind: "authorization", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+    }
+    if (COMMIT_APPT.test(t)) {
+        return [{ directive, kind: "appointment", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+    }
+    if (COMMIT_REMIND.test(t)) {
+        // Setting a reminder is itself safe; the underlying task still isn't.
+        return [{ directive, kind: "reminder", safeToAct: true, requiresConfirmation: false, authority, confidence: 0.5 }];
+    }
+    return [];
+}
 /* --------------------------------- combine --------------------------------- */
 export function extractAll(ctx) {
     const result = emptyResult(EXTRACTOR_VERSION);
@@ -254,5 +285,6 @@ export function extractAll(ctx) {
     result.events = extractEvents(ctx);
     result.preferences = extractPreferences(ctx);
     result.relations = extractRelations(ctx);
+    result.commitments = extractCommitments(ctx);
     return result;
 }

--- a/dist/src/structured/reconcile.js
+++ b/dist/src/structured/reconcile.js
@@ -24,6 +24,7 @@ export async function reconcile(pool, input) {
             eventIds: [],
             preferenceIds: [],
             metricIds: [],
+            commitmentIds: [],
             dedupCount: 0,
         };
         // 1. Entities first — relations/events refer to entity ids.
@@ -83,6 +84,14 @@ export async function reconcile(pool, input) {
                 out.dedupCount += 1;
             }
             out.metricIds.push(id);
+        }
+        const agentId = input.agentId ?? "main";
+        for (const c of input.result.commitments) {
+            const { id, deduped } = await upsertCommitment(client, c, agentId, input.chunkId);
+            if (deduped) {
+                out.dedupCount += 1;
+            }
+            out.commitmentIds.push(id);
         }
         // Provenance — one row per *new* structured insertion (skip dedups).
         await writeProvenance(client, input, out);
@@ -221,6 +230,27 @@ async function upsertMetric(client, m) {
      VALUES ($1, $2, $3, $4, $5, $6, $7)`, [id, m.ts, m.metric, m.value, m.unit ?? null, m.dim ?? {}, m.confidence]);
     return { id, deduped: false };
 }
+/* ------------------------------- commitments ------------------------------- */
+async function upsertCommitment(client, c, agentId, chunkId) {
+    // Dedup an identical active directive for the same agent (e.g. the same rule
+    // re-stated). The supersede chain (invalidated_at + supersedes) is left for a
+    // later pass; v1 just avoids exact-duplicate rows.
+    const existing = await client.query(`SELECT id FROM structured.commitments
+       WHERE agent_id = $1 AND kind = $2 AND directive = $3 AND invalidated_at IS NULL
+       LIMIT 1`, [agentId, c.kind, c.directive]);
+    if (existing.rowCount && existing.rowCount > 0) {
+        return { id: existing.rows[0].id, deduped: true };
+    }
+    const id = randomUUID();
+    await client.query(`INSERT INTO structured.commitments
+       (id, agent_id, chunk_id, directive, kind, safe_to_act, requires_confirmation,
+        authority, valid_from, expires_at, confidence)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`, [
+        id, agentId, chunkId, c.directive, c.kind, c.safeToAct, c.requiresConfirmation,
+        c.authority ?? null, c.validFrom ?? null, c.expiresAt ?? null, c.confidence,
+    ]);
+    return { id, deduped: false };
+}
 /* ------------------------------- provenance -------------------------------- */
 async function writeProvenance(client, input, out) {
     const rows = [];
@@ -238,6 +268,9 @@ async function writeProvenance(client, input, out) {
     }
     for (const id of out.metricIds) {
         rows.push(["metric", id, "metrics"]);
+    }
+    for (const id of out.commitmentIds) {
+        rows.push(["commitment", id, "commitments"]);
     }
     if (rows.length === 0) {
         return;

--- a/dist/src/structured/types.js
+++ b/dist/src/structured/types.js
@@ -13,5 +13,6 @@ export const emptyResult = (extractorVersion) => ({
     events: [],
     preferences: [],
     metrics: [],
+    commitments: [],
     extractorVersion,
 });

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -10,6 +10,7 @@ import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
+import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
 import { getPool } from "./storage/pool.js";
 const SEARCH_PARAMS = {
@@ -215,6 +216,7 @@ export function buildSearchTool(args) {
                 userId: p.viewerUserId ?? inferredViewer.userId,
                 chatId: p.viewerChatId ?? inferredViewer.chatId,
             };
+            const agentId = agentIdFromSessionKey(args.sessionKey);
             const result = await recall({ cfg, pool, embedding }, {
                 query: p.query,
                 maxResults: p.limit ?? 5,
@@ -225,7 +227,7 @@ export function buildSearchTool(args) {
                 },
                 timeBucket: p.timeBucket,
                 agentSessionId: args.sessionKey,
-                agentId: agentIdFromSessionKey(args.sessionKey),
+                agentId,
                 // Only attach viewer when we actually have something to filter on;
                 // an empty viewer object signals "no filtering" to the router.
                 viewer: viewer.userId || viewer.chatId ? viewer : undefined,
@@ -241,12 +243,27 @@ export function buildSearchTool(args) {
                     },
                 };
             }
+            // Action-sensitive flags: a recalled directive the agent might ACT on is
+            // marked so it won't fire on a stray remark. Agent-scoped (isolation).
+            const commitmentList = await getActiveCommitmentsByChunk(pool, result.results.map((c) => c.chunkId), agentId);
+            const commitmentByChunk = new Map();
+            for (const cm of commitmentList) {
+                if (!commitmentByChunk.has(cm.chunkId)) {
+                    commitmentByChunk.set(cm.chunkId, cm);
+                }
+            }
             const lines = result.results.map((c, i) => {
                 const tier = c.hits.join("+");
+                const cm = commitmentByChunk.get(c.chunkId);
+                const flag = cm
+                    ? cm.requiresConfirmation
+                        ? ` ⚠ ${cm.kind}: confirm with the user before acting`
+                        : ` ⚑ ${cm.kind}`
+                    : "";
                 // Inline citation (full chunkId) so the model can attribute a claim and
                 // re-fetch the complete text via memory_get. Same handle as
                 // details.results[].citation below.
-                return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
+                return `${i + 1}. [${tier}]${flag} ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
             });
             return {
                 content: [
@@ -271,6 +288,7 @@ export function buildSearchTool(args) {
                         text: c.text,
                         score: c.combinedScore,
                         hits: c.hits,
+                        commitment: commitmentByChunk.get(c.chunkId) ?? null,
                     })),
                 },
             };
@@ -340,14 +358,18 @@ export function buildGetTool(args) {
                 };
             }
             const c = outcome.chunk;
+            const cm = (await getActiveCommitmentsByChunk(pool, [c.chunkId], agentId))[0] ?? null;
+            const flag = cm?.requiresConfirmation
+                ? `\n⚠ action-sensitive (${cm.kind}) — confirm with the user before acting on this.`
+                : "";
             return {
                 content: [
                     {
                         type: "text",
-                        text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}`,
+                        text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}${flag}`,
                     },
                 ],
-                details: { found: true, ...c },
+                details: { found: true, ...c, commitment: cm },
             };
         },
     };

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -1,12 +1,13 @@
 /**
- * Agent tools exposed by memory-postgres: `memory_search` and `memory_store`.
+ * Agent tools exposed by memory-postgres: `memory_search`, `memory_get`,
+ * `memory_store`, `memory_update`, `memory_forget`.
  *
- * These are thin wrappers over the recall router and ingest pipeline so the
- * agent can read/write the long-term memory in turn.
+ * These are thin wrappers over the recall router, ingest pipeline, and
+ * single-chunk edit ops so the agent can read/write long-term memory in turn.
  */
 import { resolveConfig, validateConfig } from "./config.js";
 import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
-import { forgetChunk, updateChunk } from "./edit/operations.js";
+import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
@@ -118,6 +119,14 @@ const FORGET_PARAMS = {
         chunkId: { type: "string", description: "ID of the chunk to forget (from prior memory_search result)." },
         hardDelete: { type: "boolean", description: "When true, fully delete (breaks cold-gist back-references). When false (default), soft-trash so it stops appearing in recall but can be audited." },
         reason: { type: "string", description: "Why you're forgetting this — recorded in the audit row." },
+    },
+};
+const GET_PARAMS = {
+    type: "object",
+    additionalProperties: false,
+    required: ["chunkId"],
+    properties: {
+        chunkId: { type: "string", description: "ID of the chunk to fetch in full (from a prior memory_search result)." },
     },
 };
 /**
@@ -234,7 +243,10 @@ export function buildSearchTool(args) {
             }
             const lines = result.results.map((c, i) => {
                 const tier = c.hits.join("+");
-                return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}`;
+                // Inline citation (full chunkId) so the model can attribute a claim and
+                // re-fetch the complete text via memory_get. Same handle as
+                // details.results[].citation below.
+                return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
             });
             return {
                 content: [
@@ -255,6 +267,7 @@ export function buildSearchTool(args) {
                     results: result.results.map((c) => ({
                         chunkId: c.chunkId,
                         source: c.source,
+                        citation: `pg://${c.source}/${c.chunkId}`,
                         text: c.text,
                         score: c.combinedScore,
                         hits: c.hits,
@@ -301,6 +314,40 @@ export function buildUpdateTool(args) {
                     },
                 ],
                 details: { decision: "updated", chunkId: outcome.chunkId, reEmbedded: outcome.reEmbedded },
+            };
+        },
+    };
+    return tool;
+}
+export function buildGetTool(args) {
+    const tool = {
+        name: "memory_get",
+        label: "Memory Get",
+        description: "Fetch one memory chunk in full by its id (the chunkId from a prior "
+            + "memory_search result). Use when a search snippet was truncated and you "
+            + "need the complete text plus provenance (source / citation). Read-only. "
+            + "Per-agent isolation enforced — a chunk owned by another agent reads as not found.",
+        parameters: GET_PARAMS,
+        async execute(_toolCallId, params) {
+            const p = params;
+            const { cfg, pool, embedding } = await setup(pluginConfigOf(args.config));
+            const agentId = agentIdFromSessionKey(args.sessionKey);
+            const outcome = await getChunk({ cfg, pool, embedding }, { chunkId: p.chunkId, agentId });
+            if (!outcome.ok) {
+                return {
+                    content: [{ type: "text", text: `No memory chunk ${p.chunkId} (${outcome.reason}).` }],
+                    details: { found: false, reason: outcome.reason },
+                };
+            }
+            const c = outcome.chunk;
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}`,
+                    },
+                ],
+                details: { found: true, ...c },
             };
         },
     };

--- a/dist/src/workers/tuning.js
+++ b/dist/src/workers/tuning.js
@@ -14,11 +14,25 @@
  *     analyzer; the actual config patcher lives in OpenClaw core.
  */
 import { randomUUID } from "node:crypto";
+// One open proposal per (scope, proposal_type): the daily analyzer re-runs and
+// would otherwise pile up identical pending rows. ON CONFLICT against the
+// partial unique index (see storage/schema/61-tuning-dedup.sql) refreshes the
+// open proposal in place instead of duplicating it.
 const PROPOSAL_INSERT = `
   INSERT INTO audit.tuning_proposals
     (id, cadence, scope, proposal_type, current_value, proposed_value,
      evidence, risk_class, status, reason, config_path)
    VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, 'pending', $9, $10)
+   ON CONFLICT (scope, proposal_type) WHERE status = 'pending'
+     DO UPDATE SET
+       ts             = now(),
+       cadence        = EXCLUDED.cadence,
+       current_value  = EXCLUDED.current_value,
+       proposed_value = EXCLUDED.proposed_value,
+       evidence       = EXCLUDED.evidence,
+       risk_class     = EXCLUDED.risk_class,
+       reason         = EXCLUDED.reason,
+       config_path    = EXCLUDED.config_path
    RETURNING id`;
 async function writeProposal(pool, cadence, payload) {
     const id = randomUUID();

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import { migrate, ensureHnswIndex } from "./src/storage/migrate.js";
 import { closePool, getPool, type ResolvedPoolConfig } from "./src/storage/pool.js";
 import {
   buildForgetTool,
+  buildGetTool,
   buildSearchTool,
   buildStoreTool,
   buildUpdateTool,
@@ -152,6 +153,17 @@ export default definePluginEntry({
         return buildSearchTool({ config, sessionKey: ctx.sessionKey });
       },
       { names: ["memory_search"] },
+    );
+
+    api.registerTool(
+      (ctx) => {
+        const config = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;
+        if (!config) {
+          throw new Error("memory-postgres: no runtime config available in tool context");
+        }
+        return buildGetTool({ config, sessionKey: ctx.sessionKey });
+      },
+      { names: ["memory_get"] },
     );
 
     api.registerTool(
@@ -782,7 +794,7 @@ export default definePluginEntry({
 
     api.logger.info(
       "memory-postgres: capability + tools registered "
-        + "(memory_search, memory_store, memory_update, memory_forget; "
+        + "(memory_search, memory_get, memory_store, memory_update, memory_forget; "
         + "services: dashboard, tuning, compactor, reflection)",
     );
   },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -665,9 +665,6 @@
     }
   },
   "contracts": {
-    "memoryEmbeddingProviders": [
-      "openai-compat"
-    ],
     "tools": [
       "memory_search",
       "memory_get",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -670,6 +670,7 @@
     ],
     "tools": [
       "memory_search",
+      "memory_get",
       "memory_store",
       "memory_update",
       "memory_forget",

--- a/src/edit/get-chunk.test.ts
+++ b/src/edit/get-chunk.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { getChunk } from "./operations.js";
+
+/**
+ * getChunk is read-only and fail-closed: the agent_id filter lives in the
+ * WHERE clause, so a chunk owned by another agent reads as not-found (we never
+ * reveal it exists). Pure unit test — query-recording fake pool, no live PG.
+ */
+
+function fakePool(response: { rowCount: number; rows: unknown[] }) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  return {
+    calls,
+    query: async (sql: string, params: unknown[]) => {
+      calls.push({ sql, params });
+      return response;
+    },
+  };
+}
+
+const deps = (pool: unknown) =>
+  ({ pool, cfg: {}, embedding: {} }) as unknown as Parameters<typeof getChunk>[0];
+
+describe("getChunk", () => {
+  it("filters by id AND agent_id in the WHERE clause (hard isolation)", async () => {
+    const pool = fakePool({ rowCount: 0, rows: [] });
+    await getChunk(deps(pool), { chunkId: "abc", agentId: "main" });
+
+    expect(pool.calls).toHaveLength(1);
+    const { sql, params } = pool.calls[0];
+    expect(sql).toMatch(/WHERE\s+id\s*=\s*\$1\s+AND\s+agent_id\s*=\s*\$2/);
+    expect(params).toEqual(["abc", "main"]);
+  });
+
+  it("returns not-found when no row matches (covers wrong-agent — no leak)", async () => {
+    const pool = fakePool({ rowCount: 0, rows: [] });
+    const out = await getChunk(deps(pool), { chunkId: "abc", agentId: "club" });
+    expect(out).toEqual({ ok: false, reason: "not-found" });
+  });
+
+  it("maps a found row to the chunk shape with a pg:// citation, read-only", async () => {
+    const created = new Date("2026-05-20T10:00:00.000Z");
+    const pool = fakePool({
+      rowCount: 1,
+      rows: [
+        {
+          id: "11111111-2222-3333-4444-555555555555",
+          text: "the full chunk text",
+          source: "manual",
+          source_ref: null,
+          kind: "fact",
+          retention_class: "pinned",
+          importance: 0.9,
+          recall_count: 3,
+          created_at: created,
+        },
+      ],
+    });
+
+    const out = await getChunk(deps(pool), {
+      chunkId: "11111111-2222-3333-4444-555555555555",
+      agentId: "main",
+    });
+
+    expect(out.ok).toBe(true);
+    if (!out.ok) {return;}
+    expect(out.chunk).toEqual({
+      chunkId: "11111111-2222-3333-4444-555555555555",
+      text: "the full chunk text",
+      source: "manual",
+      sourceRef: null,
+      kind: "fact",
+      retentionClass: "pinned",
+      importance: 0.9,
+      recallCount: 3,
+      createdAt: "2026-05-20T10:00:00.000Z",
+      citation: "pg://manual/11111111-2222-3333-4444-555555555555",
+    });
+    // Read-only: exactly one query (the SELECT) — no warmth/recall_count UPDATE.
+    expect(pool.calls).toHaveLength(1);
+    expect(pool.calls[0].sql).toMatch(/^\s*SELECT/);
+  });
+});

--- a/src/edit/operations.ts
+++ b/src/edit/operations.ts
@@ -190,3 +190,75 @@ export async function forgetChunk(
 
   return { ok: true, chunkId: params.chunkId, mode, deletedRow: params.hardDelete === true };
 }
+
+export type GetChunkParams = {
+  chunkId: string;
+  agentId: string;
+};
+
+export type GetChunkOutcome =
+  | {
+      ok: true;
+      chunk: {
+        chunkId: string;
+        text: string;
+        source: string;
+        sourceRef: string | null;
+        kind: string;
+        retentionClass: string;
+        importance: number;
+        recallCount: number;
+        createdAt: string;
+        /** Stable provenance handle for QMD-style citation. */
+        citation: string;
+      };
+    }
+  | { ok: false; reason: "not-found" };
+
+/**
+ * Fetch one chunk in full by id. Read-only — does NOT bump warmth / recall_count
+ * (the agent already holds the id from a prior recall; treating a targeted
+ * re-read as a recall would re-pollute the cold-aging signal — see
+ * 60-last-seen.sql). Fail-closed isolation: the id + agent_id filter is in the
+ * WHERE, so a chunk owned by another agent reads as not-found (we don't even
+ * reveal it exists).
+ */
+export async function getChunk(
+  deps: EditDeps,
+  params: GetChunkParams,
+): Promise<GetChunkOutcome> {
+  const rows = await deps.pool.query<{
+    id: string;
+    text: string;
+    source: string;
+    source_ref: string | null;
+    kind: string;
+    retention_class: string;
+    importance: number;
+    recall_count: number;
+    created_at: Date;
+  }>(
+    `SELECT id, text, source, source_ref, kind, retention_class,
+            importance, recall_count, created_at
+       FROM semantic.chunks
+      WHERE id = $1 AND agent_id = $2`,
+    [params.chunkId, params.agentId],
+  );
+  if (rows.rowCount === 0) {return { ok: false, reason: "not-found" };}
+  const r = rows.rows[0];
+  return {
+    ok: true,
+    chunk: {
+      chunkId: r.id,
+      text: r.text,
+      source: r.source,
+      sourceRef: r.source_ref,
+      kind: r.kind,
+      retentionClass: r.retention_class,
+      importance: r.importance,
+      recallCount: r.recall_count,
+      createdAt: r.created_at.toISOString(),
+      citation: `pg://${r.source}/${r.id}`,
+    },
+  };
+}

--- a/src/ingest/pipeline.ts
+++ b/src/ingest/pipeline.ts
@@ -307,8 +307,11 @@ export async function ingestOne(deps: IngestDeps, input: IngestInput): Promise<I
   );
   if (dup.rowCount && dup.rowCount > 0) {
     const id = dup.rows[0].id;
+    // Re-ingest (dedup), not a recall — bump last_seen_at / dup_count only.
+    // last_recalled_at stays reserved for genuine recall hits so the cold
+    // compactor can still age these chunks. See storage/schema/60-last-seen.sql.
     await deps.pool.query(
-      "UPDATE semantic.chunks SET last_recalled_at = now() WHERE id = $1",
+      "UPDATE semantic.chunks SET last_seen_at = now(), dup_count = dup_count + 1 WHERE id = $1",
       [id],
     );
     return finalize(

--- a/src/ingest/pipeline.ts
+++ b/src/ingest/pipeline.ts
@@ -385,6 +385,7 @@ export async function ingestOne(deps: IngestDeps, input: IngestInput): Promise<I
     rawExcerpt: text,
     result: extractor,
     dreamRunId,
+    agentId,
   });
   await writeEntityRefIndexes(deps.pool, chunkId, reconcileOut.entityIds);
   if (reconcileOut.entityIds.length > 0) {routes.push("entity_ref");}

--- a/src/ingest/sidecar.ts
+++ b/src/ingest/sidecar.ts
@@ -172,6 +172,7 @@ const EMPTY: ExtractorResult = {
   events: [],
   preferences: [],
   metrics: [],
+  commitments: [],
   extractorVersion: SIDECAR_VERSION,
 };
 
@@ -213,6 +214,9 @@ export function parseSidecar(text: string, now: Date): SidecarParseResult {
           .map((v) => coerceMetric(v, now))
           .filter((m2): m2 is MetricCandidate => m2 !== null)
       : [],
+    // Commitments are extracted deterministically (extractors.ts); the LLM
+    // sidecar prompt doesn't emit them yet, so default to none here.
+    commitments: [],
     extractorVersion: SIDECAR_VERSION,
   };
   return { found: true, ok: true, result };
@@ -246,6 +250,10 @@ export function mergeExtractorResults(
     metrics: dedupBy(
       [...primary.metrics, ...secondary.metrics],
       (m) => `${m.ts.toISOString()}|${m.metric}|${JSON.stringify(m.dim ?? {})}`,
+    ),
+    commitments: dedupBy(
+      [...primary.commitments, ...secondary.commitments],
+      (c) => `${c.kind}|${c.directive}`,
     ),
     extractorVersion: primary.extractorVersion,
   };

--- a/src/manager.dedup.test.ts
+++ b/src/manager.dedup.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { writeChunk } from "./manager.js";
+import { EmbeddingClient } from "./embedding/client.js";
+
+/**
+ * Regression guard for the dedup-signal bug: a duplicate re-ingest must bump
+ * last_seen_at / dup_count and MUST NOT touch last_recalled_at / recall_count.
+ * Conflating the two used to keep frequently re-seen chunks perpetually "warm"
+ * so the cold-gist compactor could never age them. See 60-last-seen.sql.
+ *
+ * Pure unit test — a query-recording fake Pool, no live Postgres.
+ */
+
+function fakePool(responses: Array<{ rowCount: number; rows: unknown[] }>) {
+  const queries: string[] = [];
+  let i = 0;
+  return {
+    queries,
+    query: async (sql: string) => {
+      queries.push(sql);
+      return responses[i++] ?? { rowCount: 0, rows: [] };
+    },
+  };
+}
+
+/** Fails the test if embedding is invoked — the dedup path must short-circuit. */
+class ExplodingEmbedding extends EmbeddingClient {
+  constructor() {
+    super({ baseUrl: "http://stub", model: "stub:16" });
+  }
+  override async embed(): Promise<never> {
+    throw new Error("embed() must not run on the dedup path");
+  }
+}
+
+describe("writeChunk dedup signal", () => {
+  it("on a duplicate, bumps last_seen_at + dup_count and leaves the recall signal alone", async () => {
+    const pool = fakePool([
+      { rowCount: 1, rows: [{ id: "existing-id" }] }, // dedup SELECT hits
+      { rowCount: 1, rows: [] }, // the UPDATE
+    ]);
+
+    const res = await writeChunk(
+      pool as unknown as Parameters<typeof writeChunk>[0],
+      new ExplodingEmbedding() as unknown as EmbeddingClient,
+      { text: "duplicate text", source: "test" },
+    );
+
+    expect(res).toEqual({ id: "existing-id", written: false });
+    expect(pool.queries).toHaveLength(2); // SELECT + UPDATE, no INSERT/BEGIN
+
+    const updateSql = pool.queries[1];
+    expect(updateSql).toMatch(/last_seen_at/);
+    expect(updateSql).toMatch(/dup_count/);
+    // The bug we're guarding against: dedup must not move the recall signal.
+    expect(updateSql).not.toMatch(/last_recalled_at/);
+    expect(updateSql).not.toMatch(/recall_count/);
+  });
+});

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -194,8 +194,13 @@ export async function writeChunk(
     [textHash, input.source],
   );
   if (dup.rowCount && dup.rowCount > 0) {
+    // Dedup hit: this is a re-ingest, not a recall. Bump last_seen_at / dup_count
+    // and leave last_recalled_at + recall_count untouched — the cold-gist
+    // compactor ages chunks by last_recalled_at, so conflating the two would
+    // keep re-seen chunks perpetually "warm" and they'd never compact.
+    // See src/storage/schema/60-last-seen.sql.
     await pool.query(
-      "UPDATE semantic.chunks SET last_recalled_at = now() WHERE id = $1",
+      "UPDATE semantic.chunks SET last_seen_at = now(), dup_count = dup_count + 1 WHERE id = $1",
       [dup.rows[0].id],
     );
     return { id: dup.rows[0].id, written: false };

--- a/src/storage/schema/60-last-seen.sql
+++ b/src/storage/schema/60-last-seen.sql
@@ -1,0 +1,26 @@
+-- Separate "re-ingested / seen again" from "genuinely recalled".
+--
+-- The ingest dedup path used to bump last_recalled_at on every duplicate
+-- re-ingest (the transcript-watcher re-runs every ~10s), polluting the recall
+-- signal the cold-gist compactor relies on (src/workers/compactor.ts ages
+-- chunks by last_recalled_at). Frequently re-seen chunks looked perpetually
+-- "recalled" and could never age into the cold tier.
+--
+-- Going forward, dedup bumps last_seen_at + dup_count; last_recalled_at and
+-- recall_count stay reserved for real recall hits (router.promoteToHotCache).
+
+ALTER TABLE semantic.chunks
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS dup_count    INT NOT NULL DEFAULT 0;
+
+-- Seed the new column from whatever timestamp we already had.
+UPDATE semantic.chunks
+   SET last_seen_at = COALESCE(last_recalled_at, created_at)
+ WHERE last_seen_at IS NULL;
+
+-- Undo historical pollution: a chunk that was never genuinely recalled
+-- (recall_count = 0) had its last_recalled_at set purely by the old dedup
+-- path. Clear it so the compactor can age these chunks on real recency.
+UPDATE semantic.chunks
+   SET last_recalled_at = NULL
+ WHERE recall_count = 0;

--- a/src/storage/schema/61-tuning-dedup.sql
+++ b/src/storage/schema/61-tuning-dedup.sql
@@ -1,0 +1,26 @@
+-- One open proposal per (scope, proposal_type).
+--
+-- The daily analyzer re-runs and re-emitted identical proposals every pass, so
+-- audit.tuning_proposals accumulated duplicate pending rows (observed in the
+-- field: 15x score_regression, 8x cache.recall.ttl). Collapse the existing
+-- duplicates (keep the most recent per scope+type), then enforce uniqueness so
+-- re-runs refresh the open proposal instead of duplicating it (writeProposal
+-- now upserts via ON CONFLICT — see src/workers/tuning.ts).
+
+DELETE FROM audit.tuning_proposals
+ WHERE id IN (
+   SELECT id FROM (
+     SELECT id,
+            row_number() OVER (
+              PARTITION BY scope, proposal_type
+              ORDER BY ts DESC, id DESC
+            ) AS rn
+       FROM audit.tuning_proposals
+       WHERE status = 'pending'
+   ) ranked
+   WHERE ranked.rn > 1
+ );
+
+CREATE UNIQUE INDEX IF NOT EXISTS tuning_one_open_per_scope
+  ON audit.tuning_proposals (scope, proposal_type)
+  WHERE status = 'pending';

--- a/src/storage/schema/62-commitments.sql
+++ b/src/storage/schema/62-commitments.sql
@@ -1,0 +1,31 @@
+-- Action-sensitive memory: directives the agent might ACT on, tagged so a
+-- stale or low-authority remark can't trigger a real-world side effect without
+-- a check. Populated deterministically by extractCommitments (extractors.ts),
+-- persisted by reconcile(), surfaced on recall (memory_search / memory_get).
+--
+-- agent_id is present here (unlike the other structured.* tables) because
+-- acting on another agent's commitment is exactly the leak we must prevent.
+-- chunk_id is a direct link so recall can fetch a chunk's commitments in one
+-- cheap lookup (ON DELETE CASCADE so a hard-forget cleans them up).
+
+CREATE TABLE IF NOT EXISTS structured.commitments (
+  id                    UUID PRIMARY KEY,
+  agent_id              TEXT NOT NULL DEFAULT 'main',
+  chunk_id              UUID REFERENCES semantic.chunks(id) ON DELETE CASCADE,
+  directive             TEXT NOT NULL,
+  kind                  TEXT NOT NULL,            -- task|authorization|appointment|reminder|other
+  safe_to_act           BOOLEAN NOT NULL DEFAULT false,
+  requires_confirmation BOOLEAN NOT NULL DEFAULT true,
+  authority             TEXT,                     -- user_direct|overheard|inferred|system
+  valid_from            TIMESTAMPTZ,
+  expires_at            TIMESTAMPTZ,
+  supersedes            UUID REFERENCES structured.commitments(id),
+  confidence            REAL NOT NULL,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  invalidated_at        TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS commitments_active
+  ON structured.commitments (agent_id, kind)
+  WHERE invalidated_at IS NULL;
+CREATE INDEX IF NOT EXISTS commitments_chunk
+  ON structured.commitments (chunk_id);

--- a/src/structured/commitments.ts
+++ b/src/structured/commitments.ts
@@ -1,0 +1,50 @@
+/**
+ * Read-side helper for action-sensitive memory. Given a set of recalled
+ * chunks, return the active commitments attached to them — scoped to a single
+ * agent (hard isolation: a caller never sees another agent's directives).
+ *
+ * Rows are ordered so the most restrictive (requires_confirmation) commitment
+ * per chunk sorts first, letting callers take the first per chunk as the
+ * dominant flag to surface.
+ */
+
+import type { Pool } from "pg";
+
+export type CommitmentSummary = {
+  chunkId: string;
+  kind: string;
+  safeToAct: boolean;
+  requiresConfirmation: boolean;
+  authority: string | null;
+  directive: string;
+};
+
+export async function getActiveCommitmentsByChunk(
+  pool: Pool,
+  chunkIds: string[],
+  agentId: string,
+): Promise<CommitmentSummary[]> {
+  if (chunkIds.length === 0) {return [];}
+  const rows = await pool.query<{
+    chunk_id: string;
+    kind: string;
+    safe_to_act: boolean;
+    requires_confirmation: boolean;
+    authority: string | null;
+    directive: string;
+  }>(
+    `SELECT chunk_id, kind, safe_to_act, requires_confirmation, authority, directive
+       FROM structured.commitments
+      WHERE chunk_id = ANY($1::uuid[]) AND agent_id = $2 AND invalidated_at IS NULL
+      ORDER BY requires_confirmation DESC, created_at DESC`,
+    [chunkIds, agentId],
+  );
+  return rows.rows.map((r) => ({
+    chunkId: r.chunk_id,
+    kind: r.kind,
+    safeToAct: r.safe_to_act,
+    requiresConfirmation: r.requires_confirmation,
+    authority: r.authority,
+    directive: r.directive,
+  }));
+}

--- a/src/structured/extractors.commitments.test.ts
+++ b/src/structured/extractors.commitments.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { extractAll } from "./extractors.js";
+
+/**
+ * Commitment extraction is the action-sensitive layer: tag directives the
+ * agent might ACT on so a stale/low-authority remark can't trigger a real
+ * side effect. Tested via the public extractAll() entry. Conservative defaults
+ * + precision (no tagging of bare imperatives in reference text) are the point.
+ */
+
+const NOW = new Date("2026-05-31T12:00:00.000Z");
+const run = (text: string, source = "session") =>
+  extractAll({ text, source, now: NOW }).commitments;
+
+describe("extractCommitments", () => {
+  it("tags an addressed side-effecting directive as task, confirm-required", () => {
+    const cs = run("帮我取消明天上午的牙医预约");
+    expect(cs).toHaveLength(1);
+    expect(cs[0]).toMatchObject({ kind: "task", safeToAct: false, requiresConfirmation: true });
+  });
+
+  it("tags an English 'please <verb>' directive as task", () => {
+    const cs = run("Please cancel my newsletter subscription.");
+    expect(cs[0]).toMatchObject({ kind: "task", requiresConfirmation: true });
+  });
+
+  it("treats a reminder as safe to act on, no confirmation", () => {
+    const cs = run("提醒我周五下午三点上小龙虾课");
+    expect(cs[0]).toMatchObject({ kind: "reminder", safeToAct: true, requiresConfirmation: false });
+  });
+
+  it("tags an authorization but still requires confirmation (conservative)", () => {
+    const cs = run("你可以直接部署到生产环境");
+    expect(cs[0]).toMatchObject({ kind: "authorization", safeToAct: false, requiresConfirmation: true });
+  });
+
+  it("does NOT tag a bare imperative in reference/tutorial text (precision)", () => {
+    expect(run("Delete the old build artifacts and rerun the pipeline.")).toEqual([]);
+    expect(run("删除旧文件然后重新构建项目")).toEqual([]);
+    expect(run("今天温哥华天气不错，适合散步。")).toEqual([]);
+  });
+
+  it("derives authority from source: manual/session = user_direct, else inferred", () => {
+    expect(run("帮我发送这封邮件", "manual")[0]).toMatchObject({ authority: "user_direct" });
+    expect(run("帮我发送这封邮件", "session")[0]).toMatchObject({ authority: "user_direct" });
+    expect(run("帮我发送这封邮件", "dream")[0]).toMatchObject({ authority: "inferred" });
+  });
+
+  it("emits at most one commitment per chunk (highest action-sensitivity wins)", () => {
+    // Contains both a task verb (addressed) and a reminder cue; task dominates.
+    const cs = run("提醒我，另外请你帮我取消那个订单");
+    expect(cs).toHaveLength(1);
+    expect(cs[0].kind).toBe("task");
+  });
+});

--- a/src/structured/extractors.ts
+++ b/src/structured/extractors.ts
@@ -10,6 +10,7 @@
 
 import {
   emptyResult,
+  type CommitmentCandidate,
   type EntityCandidate,
   type EventCandidate,
   type ExtractorContext,
@@ -265,6 +266,47 @@ function extractRelations(ctx: ExtractorContext): RelationCandidate[] {
   return out;
 }
 
+/* ------------------------------- commitments ------------------------------ */
+
+// Action-sensitive directives. The patterns require the directive to be aimed
+// at the agent (帮我/请你 / please/can you / 提醒我 / remind me) so generic
+// imperatives in tutorial or reference text ("delete the file") don't get
+// tagged. Conservative defaults: anything side-effecting is safeToAct=false +
+// requiresConfirmation=true; only "set me a reminder" is safe to act on.
+
+// Task: an addressee marker followed (within a short span) by a side-effecting verb.
+const COMMIT_TASK =
+  /(?:帮我|请你?|麻烦你?|你能不能|\b(?:please|can you|could you|would you)\b)[\s\S]{0,40}?(?:取消|退订|预订|预定|发送|发邮件|删除|支付|转账|下单|部署|发布|\b(?:cancel|unsubscribe|book|send|email|delete|remove|pay|transfer|order|deploy|publish)\b)/i;
+const COMMIT_AUTH =
+  /(?:我?授权你?|你可以(?:直接)?去?|准许你?|\b(?:I authorize|you (?:can|may|are authorized)|go ahead and|feel free to)\b)/i;
+const COMMIT_APPT =
+  /(?:预约|约了|挂号|\b(?:appointment|booked|reservation|reschedule)\b)/i;
+const COMMIT_REMIND =
+  /(?:提醒我|别忘了|记得(?:要)?|\b(?:remind me|don'?t forget)\b)/i;
+
+function extractCommitments(ctx: ExtractorContext): CommitmentCandidate[] {
+  const t = ctx.text;
+  const authority: CommitmentCandidate["authority"] =
+    ctx.source === "manual" || ctx.source === "session" ? "user_direct" : "inferred";
+  const directive = t.replace(/\s+/g, " ").trim().slice(0, 240);
+
+  // Highest action-sensitivity wins → at most one commitment per chunk.
+  if (COMMIT_TASK.test(t)) {
+    return [{ directive, kind: "task", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+  }
+  if (COMMIT_AUTH.test(t)) {
+    return [{ directive, kind: "authorization", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+  }
+  if (COMMIT_APPT.test(t)) {
+    return [{ directive, kind: "appointment", safeToAct: false, requiresConfirmation: true, authority, confidence: 0.5 }];
+  }
+  if (COMMIT_REMIND.test(t)) {
+    // Setting a reminder is itself safe; the underlying task still isn't.
+    return [{ directive, kind: "reminder", safeToAct: true, requiresConfirmation: false, authority, confidence: 0.5 }];
+  }
+  return [];
+}
+
 /* --------------------------------- combine --------------------------------- */
 
 export function extractAll(ctx: ExtractorContext): ExtractorResult {
@@ -274,5 +316,6 @@ export function extractAll(ctx: ExtractorContext): ExtractorResult {
   result.events   = extractEvents(ctx);
   result.preferences = extractPreferences(ctx);
   result.relations   = extractRelations(ctx);
+  result.commitments = extractCommitments(ctx);
   return result;
 }

--- a/src/structured/reconcile.ts
+++ b/src/structured/reconcile.ts
@@ -17,6 +17,7 @@
 import { randomUUID } from "node:crypto";
 import type { Pool, PoolClient } from "pg";
 import type {
+  CommitmentCandidate,
   EntityCandidate,
   EventCandidate,
   ExtractorResult,
@@ -31,6 +32,8 @@ export type ReconcileInput = {
   result: ExtractorResult;
   /** Optional dream run id; null when ingesting outside a dream sweep. */
   dreamRunId?: string | null;
+  /** Owning agent — threaded onto commitments for hard isolation. Default 'main'. */
+  agentId?: string;
 };
 
 export type ReconcileOutcome = {
@@ -39,6 +42,7 @@ export type ReconcileOutcome = {
   eventIds: string[];
   preferenceIds: string[];
   metricIds: string[];
+  commitmentIds: string[];
   /** Number of dedup hits (rows that didn't need a new INSERT). */
   dedupCount: number;
 };
@@ -53,6 +57,7 @@ export async function reconcile(pool: Pool, input: ReconcileInput): Promise<Reco
       eventIds: [],
       preferenceIds: [],
       metricIds: [],
+      commitmentIds: [],
       dedupCount: 0,
     };
 
@@ -107,6 +112,13 @@ export async function reconcile(pool: Pool, input: ReconcileInput): Promise<Reco
       const { id, deduped } = await upsertMetric(client, m);
       if (deduped) {out.dedupCount += 1;}
       out.metricIds.push(id);
+    }
+
+    const agentId = input.agentId ?? "main";
+    for (const c of input.result.commitments) {
+      const { id, deduped } = await upsertCommitment(client, c, agentId, input.chunkId);
+      if (deduped) {out.dedupCount += 1;}
+      out.commitmentIds.push(id);
     }
 
     // Provenance — one row per *new* structured insertion (skip dedups).
@@ -313,6 +325,40 @@ async function upsertMetric(
   return { id, deduped: false };
 }
 
+/* ------------------------------- commitments ------------------------------- */
+
+async function upsertCommitment(
+  client: PoolClient,
+  c: CommitmentCandidate,
+  agentId: string,
+  chunkId: string,
+): Promise<{ id: string; deduped: boolean }> {
+  // Dedup an identical active directive for the same agent (e.g. the same rule
+  // re-stated). The supersede chain (invalidated_at + supersedes) is left for a
+  // later pass; v1 just avoids exact-duplicate rows.
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM structured.commitments
+       WHERE agent_id = $1 AND kind = $2 AND directive = $3 AND invalidated_at IS NULL
+       LIMIT 1`,
+    [agentId, c.kind, c.directive],
+  );
+  if (existing.rowCount && existing.rowCount > 0) {
+    return { id: existing.rows[0].id, deduped: true };
+  }
+  const id = randomUUID();
+  await client.query(
+    `INSERT INTO structured.commitments
+       (id, agent_id, chunk_id, directive, kind, safe_to_act, requires_confirmation,
+        authority, valid_from, expires_at, confidence)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+    [
+      id, agentId, chunkId, c.directive, c.kind, c.safeToAct, c.requiresConfirmation,
+      c.authority ?? null, c.validFrom ?? null, c.expiresAt ?? null, c.confidence,
+    ],
+  );
+  return { id, deduped: false };
+}
+
 /* ------------------------------- provenance -------------------------------- */
 
 async function writeProvenance(
@@ -326,6 +372,7 @@ async function writeProvenance(
   for (const id of out.eventIds)      {rows.push(["event", id, "events"]);}
   for (const id of out.preferenceIds) {rows.push(["preference", id, "preferences"]);}
   for (const id of out.metricIds)     {rows.push(["metric", id, "metrics"]);}
+  for (const id of out.commitmentIds) {rows.push(["commitment", id, "commitments"]);}
   if (rows.length === 0) {return;}
 
   // Insert one row per new structured item. Multi-row INSERT with explicit

--- a/src/structured/types.ts
+++ b/src/structured/types.ts
@@ -64,6 +64,30 @@ export type MetricCandidate = {
   confidence: number;
 };
 
+export type CommitmentKind =
+  | "task"           // a side-effecting directive aimed at the agent (cancel/send/delete/…)
+  | "authorization"  // the user granting the agent permission to act
+  | "appointment"    // a scheduled real-world commitment
+  | "reminder"       // a request to be reminded (setting it is safe)
+  | "other";
+
+/**
+ * An action-sensitive directive lifted out of a memory. The point is to tag
+ * memories the agent might *act* on so a stale or low-authority remark can't
+ * trigger a real-world side effect without a check. Conservative by default:
+ * side-effecting directives are safeToAct=false + requiresConfirmation=true.
+ */
+export type CommitmentCandidate = {
+  directive: string;
+  kind: CommitmentKind;
+  safeToAct: boolean;
+  requiresConfirmation: boolean;
+  authority?: "user_direct" | "overheard" | "inferred" | "system";
+  validFrom?: Date;
+  expiresAt?: Date;
+  confidence: number;
+};
+
 export type ExtractorContext = {
   /** Raw chunk text. */
   text: string;
@@ -81,6 +105,7 @@ export type ExtractorResult = {
   events: EventCandidate[];
   preferences: PreferenceCandidate[];
   metrics: MetricCandidate[];
+  commitments: CommitmentCandidate[];
   /**
    * Per-extractor module version. Stored in structured.provenance.extractor_version
    * so tuning / audit can replay specific extractor cohorts.
@@ -94,5 +119,6 @@ export const emptyResult = (extractorVersion: ExtractorVersion): ExtractorResult
   events: [],
   preferences: [],
   metrics: [],
+  commitments: [],
   extractorVersion,
 });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -13,6 +13,7 @@ import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
+import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
 import { getPool } from "./storage/pool.js";
 
@@ -275,6 +276,7 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
         userId: p.viewerUserId ?? inferredViewer.userId,
         chatId: p.viewerChatId ?? inferredViewer.chatId,
       };
+      const agentId = agentIdFromSessionKey(args.sessionKey);
       const result = await recall(
         { cfg, pool, embedding },
         {
@@ -287,7 +289,7 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
           },
           timeBucket: p.timeBucket,
           agentSessionId: args.sessionKey,
-          agentId: agentIdFromSessionKey(args.sessionKey),
+          agentId,
           // Only attach viewer when we actually have something to filter on;
           // an empty viewer object signals "no filtering" to the router.
           viewer: viewer.userId || viewer.chatId ? viewer : undefined,
@@ -306,12 +308,28 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
         };
       }
 
+      // Action-sensitive flags: a recalled directive the agent might ACT on is
+      // marked so it won't fire on a stray remark. Agent-scoped (isolation).
+      const commitmentList = await getActiveCommitmentsByChunk(
+        pool, result.results.map((c) => c.chunkId), agentId,
+      );
+      const commitmentByChunk = new Map<string, (typeof commitmentList)[number]>();
+      for (const cm of commitmentList) {
+        if (!commitmentByChunk.has(cm.chunkId)) {commitmentByChunk.set(cm.chunkId, cm);}
+      }
+
       const lines = result.results.map((c, i) => {
         const tier = c.hits.join("+");
+        const cm = commitmentByChunk.get(c.chunkId);
+        const flag = cm
+          ? cm.requiresConfirmation
+            ? ` ⚠ ${cm.kind}: confirm with the user before acting`
+            : ` ⚑ ${cm.kind}`
+          : "";
         // Inline citation (full chunkId) so the model can attribute a claim and
         // re-fetch the complete text via memory_get. Same handle as
         // details.results[].citation below.
-        return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
+        return `${i + 1}. [${tier}]${flag} ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
       });
       return {
         content: [
@@ -336,6 +354,7 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
             text: c.text,
             score: c.combinedScore,
             hits: c.hits,
+            commitment: commitmentByChunk.get(c.chunkId) ?? null,
           })),
         },
       };
@@ -415,14 +434,18 @@ export function buildGetTool(args: { config: OpenClawConfig; sessionKey?: string
         };
       }
       const c = outcome.chunk;
+      const cm = (await getActiveCommitmentsByChunk(pool, [c.chunkId], agentId))[0] ?? null;
+      const flag = cm?.requiresConfirmation
+        ? `\n⚠ action-sensitive (${cm.kind}) — confirm with the user before acting on this.`
+        : "";
       return {
         content: [
           {
             type: "text",
-            text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}`,
+            text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}${flag}`,
           },
         ],
-        details: { found: true, ...c },
+        details: { found: true, ...c, commitment: cm },
       };
     },
   };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,15 +1,16 @@
 /**
- * Agent tools exposed by memory-postgres: `memory_search` and `memory_store`.
+ * Agent tools exposed by memory-postgres: `memory_search`, `memory_get`,
+ * `memory_store`, `memory_update`, `memory_forget`.
  *
- * These are thin wrappers over the recall router and ingest pipeline so the
- * agent can read/write the long-term memory in turn.
+ * These are thin wrappers over the recall router, ingest pipeline, and
+ * single-chunk edit ops so the agent can read/write long-term memory in turn.
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveConfig, validateConfig } from "./config.js";
 import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
-import { forgetChunk, updateChunk } from "./edit/operations.js";
+import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
@@ -165,6 +166,19 @@ type ForgetParams = {
   reason?: string;
 };
 
+const GET_PARAMS = {
+  type: "object",
+  additionalProperties: false,
+  required: ["chunkId"],
+  properties: {
+    chunkId: { type: "string", description: "ID of the chunk to fetch in full (from a prior memory_search result)." },
+  },
+} as const;
+
+type GetParams = {
+  chunkId: string;
+};
+
 /**
  * Expected sessionKey shape: `agent:<agentId>:<sessionId>` (or longer with
  * trailing colons for channel-scoped keys). Pull out `<agentId>` so
@@ -294,7 +308,10 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
 
       const lines = result.results.map((c, i) => {
         const tier = c.hits.join("+");
-        return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}`;
+        // Inline citation (full chunkId) so the model can attribute a claim and
+        // re-fetch the complete text via memory_get. Same handle as
+        // details.results[].citation below.
+        return `${i + 1}. [${tier}] ${c.text.slice(0, 220)}\n   ↳ pg://${c.source}/${c.chunkId}`;
       });
       return {
         content: [
@@ -315,6 +332,7 @@ export function buildSearchTool(args: { config: OpenClawConfig; sessionKey?: str
           results: result.results.map((c) => ({
             chunkId: c.chunkId,
             source: c.source,
+            citation: `pg://${c.source}/${c.chunkId}`,
             text: c.text,
             score: c.combinedScore,
             hits: c.hits,
@@ -368,6 +386,43 @@ export function buildUpdateTool(args: { config: OpenClawConfig; sessionKey?: str
           },
         ],
         details: { decision: "updated", chunkId: outcome.chunkId, reEmbedded: outcome.reEmbedded },
+      };
+    },
+  };
+  return tool as unknown as AnyAgentTool;
+}
+
+export function buildGetTool(args: { config: OpenClawConfig; sessionKey?: string }): AnyAgentTool {
+  const tool = {
+    name: "memory_get",
+    label: "Memory Get",
+    description:
+      "Fetch one memory chunk in full by its id (the chunkId from a prior "
+      + "memory_search result). Use when a search snippet was truncated and you "
+      + "need the complete text plus provenance (source / citation). Read-only. "
+      + "Per-agent isolation enforced — a chunk owned by another agent reads as not found.",
+    parameters: GET_PARAMS as unknown as AnyAgentTool["parameters"],
+    async execute(this: void, _toolCallId: string, params: unknown): Promise<{ content: unknown; details: unknown }> {
+      const p = params as GetParams;
+      const { cfg, pool, embedding } = await setup(pluginConfigOf(args.config));
+      const agentId = agentIdFromSessionKey(args.sessionKey);
+      const outcome = await getChunk({ cfg, pool, embedding }, { chunkId: p.chunkId, agentId });
+
+      if (!outcome.ok) {
+        return {
+          content: [{ type: "text", text: `No memory chunk ${p.chunkId} (${outcome.reason}).` }],
+          details: { found: false, reason: outcome.reason },
+        };
+      }
+      const c = outcome.chunk;
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Memory chunk [${c.kind}, ${c.retentionClass}] — ${c.citation}\n${c.text}`,
+          },
+        ],
+        details: { found: true, ...c },
       };
     },
   };

--- a/src/workers/tuning.ts
+++ b/src/workers/tuning.ts
@@ -41,11 +41,25 @@ export type TuningProposal = {
   configPath?: string;
 };
 
+// One open proposal per (scope, proposal_type): the daily analyzer re-runs and
+// would otherwise pile up identical pending rows. ON CONFLICT against the
+// partial unique index (see storage/schema/61-tuning-dedup.sql) refreshes the
+// open proposal in place instead of duplicating it.
 const PROPOSAL_INSERT = `
   INSERT INTO audit.tuning_proposals
     (id, cadence, scope, proposal_type, current_value, proposed_value,
      evidence, risk_class, status, reason, config_path)
    VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8, 'pending', $9, $10)
+   ON CONFLICT (scope, proposal_type) WHERE status = 'pending'
+     DO UPDATE SET
+       ts             = now(),
+       cadence        = EXCLUDED.cadence,
+       current_value  = EXCLUDED.current_value,
+       proposed_value = EXCLUDED.proposed_value,
+       evidence       = EXCLUDED.evidence,
+       risk_class     = EXCLUDED.risk_class,
+       reason         = EXCLUDED.reason,
+       config_path    = EXCLUDED.config_path
    RETURNING id`;
 
 async function writeProposal(


### PR DESCRIPTION
## Summary

Memory-quality work on `feat/memory-0-1` (stacked on `fix/dedup-signal-and-tuning-dedup`): two recall-correctness fixes plus the SESSION-HANDOFF "0,1" feature scope. Migrations **60/61/62** apply automatically on gateway restart.

Already deployed + verified on the live gateway (2026-05-31); branches pushed for review.

## Recall correctness
- **Dedup no longer pollutes `last_recalled_at`** (migration 60) — the ingest dedup path bumped the recall signal (transcript-watcher re-ingests ~every 10s), so re-seen chunks looked perpetually "recalled" and the cold-gist compactor could never age them. Now bumps a separate `last_seen_at` / `dup_count`; `last_recalled_at` + `recall_count` are reserved for genuine recalls. De-polluted **422/500** live chunks.
- **Tuning proposal dedup** (migration 61) — partial unique index `(scope, proposal_type) WHERE status='pending'` + `ON CONFLICT … DO UPDATE`; collapsed **23 → 2** duplicate pending proposals.

## New tools / features
- **`memory_get(chunkId)`** — read-only single-chunk fetch when a search snippet was truncated; fail-closed per-agent isolation (another agent's chunk reads as not-found).
- **Cited recall** — `memory_search` surfaces inline `pg://<source>/<chunkId>` citations so the model can attribute a claim and re-fetch via `memory_get`.
- **Action-sensitive commitments** (migration 62) — directives the agent might *act* on are extracted into `structured.commitments` (agent-isolated) with `safe_to_act` / `requires_confirmation` / `authority` / validity, and surfaced with a ⚠ on recall. Conservative defaults: side-effecting directives require confirmation; only reminders are safe to act on.

## Hygiene
- Declare `memory_get` in `contracts.tools`.
- Remove the vestigial `contracts.memoryEmbeddingProviders` declaration (orphaned — nextclaw self-embeds and registers no adapter; only triggered the inspect deprecation advisory). nextclaw is an embedding *consumer*, not a host provider.

## Verification
- `tsc` clean; **146 unit tests pass** (+10: getChunk isolation, commitment extraction).
- Live transactional dry-runs (`BEGIN … ROLLBACK`) of all three migrations against real data.
- Deployed: gateway restarted, migrations applied, effects confirmed, `openclaw plugins inspect` clean (the embedding advisory clears on the next restart).

## Notes
- `package.json` version left at 0.2.1 — bump at release time.
- Deferred (not needed): migrating to the new embedding-provider contract; and the separate "recall is dormant / should it auto-prime?" question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
