### PR TITLE
feat: bundled openclaw-selfcare skill + declare undici dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Thumbs.db
 **/.dashboard.env
 **/auth-profiles.json
 **/auth-state.json
+**/config.env
+!**/config.env.example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memo
 | `src/sdk/` | StructuredMemoryAPI public exports |
 | `src/dashboard/` | HTTP server + SPA assets + bot-stats |
 | `src/cli/` | tail (router-explain, audit, stats, etc. live in dashboard) |
+| `skills/` | OpenClaw ops skills shipped with the plugin (currently `openclaw-selfcare` — safe self-upgrade of openclaw + this plugin) |
 
 ## Rules
 
@@ -52,6 +53,7 @@ Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memo
 
 - `pg` (node-postgres) — supports LISTEN/NOTIFY which the dashboard needs
 - `pgvector` — pgvector type binding for `pg`
+- `undici` — HTTP client for the IPv4-first dispatcher to `api.telegram.org` (`src/moderator/telegram-api.ts`). Declared directly, not relied on transitively, so an OpenClaw dependency-tree change can't make it vanish.
 
 ## Cross-extension contracts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`openclaw-selfcare` skill** (`skills/openclaw-selfcare/`) — a bundled OpenClaw
+  ops skill that safely keeps a host's OpenClaw core **and this plugin** up to date.
+  Before any upgrade it runs a **sandbox compatibility preflight**: it installs the
+  target openclaw into a throwaway prefix and checks that this plugin still satisfies
+  the new openclaw's declared range and that the plugin's runtime deps still resolve.
+  It auto-fixes the safely-fixable (bump the plugin to a compatible tag; install a
+  missing transitive dep such as `undici`), upgrades openclaw **only if preflight
+  passes**, then updates the plugin and verifies the gateway + memory probe recovered.
+  Refuses to upgrade onto an already-broken install or across a release flagged
+  breaking. Read-only `check`/`preflight`; `apply` performs the upgrade. Optional
+  daily cron and Telegram reporting. See `skills/openclaw-selfcare/SKILL.md`.
+
+### Fixed
+
+- **Declare `undici` as a direct dependency (`^8.3.0`).** `src/moderator/telegram-api.ts`
+  imports `undici` directly (`Agent` + an IPv4-first `fetch` dispatcher for
+  `api.telegram.org`), but it was only present transitively via OpenClaw's dependency
+  tree. A change to that tree — or installing the plugin without the same hoisting —
+  could make `undici` vanish at runtime and break the Telegram send path. It is now a
+  declared dependency so it can't disappear. (No behavior change; the resolved version
+  is unchanged.)
+
 ## 0.3.1 — Opt-in memory sidecar (stop the `<mem>` leak)
 
 Patch release on top of 0.3.0. One behavior change, no migrations.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 Standalone OpenClaw skills that compose well with nextclaw:
 
 - **[openclaw-skill-reminder](https://github.com/NextAgentBC/openclaw-skill-reminder)** — privacy-conscious time-based reminders. The cron config file only sees opaque `reminder:<short-id>` names; the actual detail (names, addresses, appointments) lives in a mode-600 file. Used by `/dashboard` users to schedule follow-ups without leaking PII into `jobs.json`.
+- **[openclaw-selfcare](skills/openclaw-selfcare/)** — *bundled in this repo* (`skills/openclaw-selfcare/`). Safely keeps a host's OpenClaw core **and this plugin** up to date: a sandbox compatibility preflight runs before any upgrade (does the new openclaw still load the plugin and resolve its deps?), it auto-fixes the safely-fixable (bump the plugin to a compatible tag, install a missing transitive dep such as `undici`), and it refuses to upgrade onto a broken or incompatible state. Read-only `check` by default; `apply` to actually upgrade. See [`skills/openclaw-selfcare/SKILL.md`](skills/openclaw-selfcare/SKILL.md).
 
 ## Quick start (~5 min on Neon, ~10 min on Docker)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "pg": "^8.13.0",
-        "pgvector": "^0.2.0"
+        "pgvector": "^0.2.0",
+        "undici": "^8.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "api.ts",
     "src/",
     "dist/",
+    "skills/",
     "openclaw.plugin.json",
     "AGENTS.md",
     "README.md",
@@ -39,7 +40,8 @@
   ],
   "dependencies": {
     "pg": "^8.13.0",
-    "pgvector": "^0.2.0"
+    "pgvector": "^0.2.0",
+    "undici": "^8.3.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.25"

--- a/skills/openclaw-selfcare/README.md
+++ b/skills/openclaw-selfcare/README.md
@@ -1,0 +1,56 @@
+# openclaw-selfcare
+
+A small OpenClaw **ops skill** that keeps one host's OpenClaw core and the nextclaw
+(`memory-postgres`) plugin up to date — *safely*.
+
+OpenClaw releases frequently. A core upgrade can occasionally ship an openclaw whose
+plugin API this memory plugin doesn't match yet, or one that prunes a transitive
+dependency the plugin needs (e.g. `undici`). Either way, the memory layer can go down
+mid-upgrade. This skill predicts that **in a sandbox before touching the live install**,
+auto-fixes the safely-fixable cases, and otherwise alerts instead of force-upgrading.
+
+## What it does
+
+```
+check latest openclaw
+   → sandbox preflight: does the new openclaw still load this plugin + resolve its deps?
+      → PASS         : upgrade openclaw, then update the plugin, then verify
+      → FIX-NEEDED   : bump plugin to a compatible tag / install the missing dep, re-check
+      → FAIL         : skip the upgrade, alert (never upgrade onto a broken/incompatible state)
+```
+
+## Quick start
+
+```bash
+# read-only status + compatibility verdict
+bash oc-selfcare.sh check
+
+# the real upgrade (preflight → upgrade → verify)
+bash oc-selfcare.sh apply
+```
+
+Install it as an OpenClaw skill so the agent can answer "is it safe to upgrade?":
+
+```bash
+openclaw skills install ./skills/openclaw-selfcare --force
+```
+
+See [`SKILL.md`](./SKILL.md) for the full command reference, the preflight verdict
+table, the new-host SOP (incl. an optional daily cron), and the built-in safety
+guarantees. Configuration is optional — see [`config.env.example`](./config.env.example).
+
+## Requirements
+
+`bash`, `node`, `npm`, `git`, `jq`, and `openclaw` on PATH. The plugin clone is located
+automatically via `openclaw plugins inspect memory-postgres`.
+
+## Safety
+
+- Read-only `check` / `preflight` never touch the live install.
+- `apply` refuses to upgrade unless the sandbox preflight passes, refuses to cross a
+  release flagged breaking, and refuses to stack an upgrade on an already-unhealthy
+  install.
+- A plugin clone with uncommitted changes (a dev box) is skipped, never bulldozed.
+- After upgrading it verifies the gateway version and memory probe actually recovered.
+
+Licensed under Apache-2.0, same as the rest of nextclaw.

--- a/skills/openclaw-selfcare/SKILL.md
+++ b/skills/openclaw-selfcare/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: openclaw-selfcare
+description: "Safely keep this host's OpenClaw core and the nextclaw (memory-postgres) plugin up to date. Flow: check the latest openclaw release → sandbox compatibility preflight (does the new openclaw still load this plugin and resolve its deps?) → auto-fix what's safely fixable (bump the plugin to a compatible tag, install a missing transitive dep) → upgrade openclaw ONLY if preflight passes → update the plugin → verify the gateway and memory came back. Never upgrades onto an already-broken state; never crosses a release flagged breaking. Use when the user asks: should this host upgrade openclaw / is there a new version / will upgrading break my memory plugin / safely upgrade openclaw / is the memory plugin compatible with the new openclaw / keep nextclaw current. Read-only by default (check); a real upgrade (apply) needs the user to explicitly ask."
+metadata:
+  version: 1.0.0
+  openclaw:
+    category: "ops"
+    requires:
+      bins:
+        - bash
+        - node
+        - npm
+        - git
+        - jq
+        - openclaw
+    cliHelp: "bash SKILL_DIR/oc-selfcare.sh check"
+---
+
+# openclaw-selfcare — single-host safe upgrade for OpenClaw + nextclaw
+
+OpenClaw ships often. A core upgrade can occasionally land an openclaw whose plugin
+API the installed memory plugin doesn't match yet, or one that prunes a transitive
+dependency the plugin relies on (a classic: `undici`) — and the memory layer goes
+down. This skill **predicts that in a sandbox before touching the live install**,
+fixes what's safely fixable, and otherwise **alerts instead of force-upgrading**.
+
+Everything is local to this one host — no ssh, no orchestration. A single
+self-contained script, `oc-selfcare.sh`, does the whole job. `SKILL_DIR` below means
+this skill's own directory.
+
+## ⚠️ Safety — read-only by default
+- `check` / `preflight` = **read-only**, sandbox only, never touches the live install. Run freely.
+- `apply` = **mutates production**: really upgrades openclaw, checks out a new plugin tag, restarts the gateway.
+
+**When invoked from chat: default to `check`.** Only run `apply` when the user
+explicitly asks to upgrade ("upgrade / apply / take it up to latest"). Don't apply on
+your own — the memory plugin is backed by the user's Postgres memory store; caution wins.
+
+## When to use
+User asks (any language): should this host upgrade / is there a new openclaw / is it
+safe to upgrade / will it break my memory plugin / is the plugin compatible with the
+new version / keep nextclaw current / safe upgrade.
+
+## Usage
+
+### 1. check — read-only overview (most common)
+```bash
+bash SKILL_DIR/oc-selfcare.sh check
+```
+Prints:
+- `openclaw: current=… latest=… (up-to-date | UPDATE AVAILABLE)`
+- `plugin memory-postgres: current=… latest=… (…) loaded=…`
+- a final `PREFLIGHT: <verdict>` line (table below)
+
+### 2. preflight — just the compatibility verdict
+```bash
+bash SKILL_DIR/oc-selfcare.sh preflight
+```
+
+### 3. apply — the real upgrade (needs explicit user go-ahead)
+```bash
+bash SKILL_DIR/oc-selfcare.sh apply
+```
+Order: breaking-release scan → preflight (+ one auto-fix retry) → upgrade openclaw
+only if compatible → update the plugin → verify gateway version + memory probe. Any
+failed verify exits non-zero and alerts; memory is never left half-upgraded.
+
+## Reading the preflight verdict
+| verdict | meaning | who handles it |
+|---|---|---|
+| `PASS` | compatible, safe to upgrade | apply proceeds |
+| `FIX-NEEDED:plugin-bump:<tag>` | a newer plugin tag is needed to match the new openclaw | apply auto-fixes |
+| `FIX-NEEDED:missing-dep:<pkg>` | plugin is missing a runtime dep (e.g. undici) | apply runs `npm install` |
+| `FAIL:peer-mismatch` | plugin declares incompatibility and no newer tag exists | **not auto-fixable** — wait for an upstream plugin release |
+| `FAIL:probe-current` | the install was **already unhealthy before** upgrading | **don't upgrade** — investigate the current state first |
+| `FAIL:sandbox-install` | couldn't fetch the target openclaw (network/registry) | retry / check connectivity |
+
+## How to report back
+Concise. Lead with the headline:
+- `✅ openclaw and memory plugin both current`, or
+- `⚠️ update available / preflight did not pass (reason)`.
+Quote the version numbers that matter; don't dump raw tables unless asked.
+
+## Deeper manual health check
+For a full memory-backend check (Postgres reachable, `vector`/`pg_trgm`/`btree_gin`
+extensions present, embedding endpoint live, plugin tools registered), run OpenClaw's
+own doctor:
+```bash
+openclaw doctor
+```
+A healthy plugin shows `memory-postgres: capability + tools registered (...)`.
+
+## Install on a new host (operator SOP — not something the agent runs unprompted)
+Prereq: this host already has openclaw + the nextclaw plugin (git clone, enabled).
+```bash
+# 1. install the skill from the plugin clone (or from ClawHub / git)
+openclaw skills install <nextclaw-clone>/skills/openclaw-selfcare --force
+
+# 2. self-check (read-only)
+bash ~/.openclaw/workspace/skills/openclaw-selfcare/oc-selfcare.sh check
+
+# 3. (optional) daily automatic safe upgrade at 06:00 local time
+( crontab -l 2>/dev/null | grep -v oc-selfcare.sh
+  echo "CRON_TZ=$(cat /etc/timezone 2>/dev/null || echo UTC)"
+  echo "0 6 * * * bash \$HOME/.openclaw/workspace/skills/openclaw-selfcare/oc-selfcare.sh apply >> /tmp/oc-selfcare.log 2>&1"
+) | crontab -
+
+# 4. (optional) Telegram reports: cp config.env.example config.env, set SELFCARE_TG_CHAT
+#    (bot token defaults to reusing openclaw's own channels.telegram.botToken)
+```
+
+## Configuration (all optional — see config.env.example)
+`SELFCARE_PLUGIN_ID` (default memory-postgres) · `SELFCARE_CHANNEL` (stable) ·
+`SELFCARE_PLUGIN_DIR` (default: ask openclaw) · `SELFCARE_TG_CHAT` / `SELFCARE_TG_TOKEN` ·
+`SELFCARE_SKIP_BREAKING_SCAN`.
+
+## Built-in safety guarantees (why this is a "safe" upgrade)
+- Won't upgrade unless a sandbox compatibility preflight passes.
+- Breaking release notes (regex on `breaking | migration required | incompatible | dropped support`)
+  → skip the core upgrade, alert only.
+- If the live gateway probe is already not ok before upgrading (`FAIL:probe-current`),
+  refuse to stack an upgrade on a broken state.
+- Plugin tag switch uses `git checkout -f` + per-file lockfile revert (avoids the
+  multi-pathspec "revert silently failed → checkout aborted" trap).
+- Plugin deps installed with a **full** `npm install` (no `--omit`, or transitive deps
+  like undici get pruned and the plugin fails to load).
+- A plugin clone with uncommitted code changes (a dev box) is **skipped** by both
+  auto-fix and the plugin update — never bulldozed.
+- After upgrading, it retries verification that the gateway version == target and the
+  memory probe == ok, else exits non-zero and alerts.

--- a/skills/openclaw-selfcare/config.env.example
+++ b/skills/openclaw-selfcare/config.env.example
@@ -1,0 +1,22 @@
+# oc-selfcare optional config. Copy to  config.env  (same dir) and edit.
+# Everything here is OPTIONAL — the script autodetects sensible defaults.
+
+# Plugin id to track (as shown by `openclaw plugins list`).
+#SELFCARE_PLUGIN_ID=memory-postgres
+
+# OpenClaw update channel: stable | beta | dev
+#SELFCARE_CHANNEL=stable
+
+# Override autodetection if needed:
+#SELFCARE_OPENCLAW=/home/youruser/.npm-global/bin/openclaw
+#SELFCARE_PLUGIN_DIR=~/nextclaw
+
+# Telegram report target. If SELFCARE_TG_CHAT is set, apply/preflight failures and the
+# final result get pushed to that chat. The bot TOKEN defaults to reusing openclaw's own
+# configured bot (channels.telegram.botToken in ~/.openclaw/openclaw.json), so you usually
+# only need the chat id. Set SELFCARE_TG_TOKEN only to use a different bot.
+#SELFCARE_TG_CHAT=123456789
+#SELFCARE_TG_TOKEN=
+
+# Set to 1 to skip the gh release-notes breaking-change scan (e.g. gh not installed).
+#SELFCARE_SKIP_BREAKING_SCAN=1

--- a/skills/openclaw-selfcare/oc-selfcare.sh
+++ b/skills/openclaw-selfcare/oc-selfcare.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# oc-selfcare — safe self-upgrade for OpenClaw + the nextclaw (memory-postgres) plugin
+# on a SINGLE host.
+#
+# One box that has `openclaw` and a git-cloned memory plugin (default id:
+# memory-postgres) installed. This keeps BOTH current, safely:
+#   check openclaw latest → compat preflight (sandbox) → auto-fix the fixable →
+#   upgrade openclaw only if preflight passes → update the plugin → verify the
+#   gateway + memory came back. It refuses to upgrade onto a broken state and
+#   refuses to cross a release flagged as breaking.
+#
+# Everything is local — no ssh, no multi-host orchestration. Self-contained:
+# copy this one file (and the optional config.env) onto any host and run it.
+#
+# Usage:
+#   oc-selfcare.sh check       # read-only: versions + preflight verdict + plugin diff
+#   oc-selfcare.sh preflight   # read-only: just the compat verdict
+#   oc-selfcare.sh apply       # do it: preflight (+auto-fix) → upgrade → verify
+#
+# Exit: 0 ok / 1 verify-failed / 2 usage / 10 fix-needed (check mode) / 20 blocked
+#
+# Config (env or config.env next to this script; all optional):
+#   SELFCARE_PLUGIN_ID    plugin id to track            (default: memory-postgres)
+#   SELFCARE_CHANNEL      openclaw update channel        (default: stable)
+#   SELFCARE_OPENCLAW     path to openclaw binary        (default: autodetect)
+#   SELFCARE_PLUGIN_DIR   plugin clone dir               (default: ask openclaw)
+#   SELFCARE_TG_CHAT      telegram chat id for reports   (default: none → stdout)
+#   SELFCARE_TG_TOKEN     telegram bot token             (default: reuse openclaw's)
+#   SELFCARE_SKIP_BREAKING_SCAN=1  skip the gh release-notes breaking scan
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$DIR/config.env" ] && { set -a; . "$DIR/config.env"; set +a; }
+
+MODE="${1:-check}"
+case "$MODE" in check|preflight|apply) ;; *) echo "usage: $0 {check|preflight|apply}"; exit 2 ;; esac
+
+PLUGIN_ID="${SELFCARE_PLUGIN_ID:-memory-postgres}"
+CHANNEL="${SELFCARE_CHANNEL:-stable}"
+OPENCLAW_JSON="${OPENCLAW_JSON:-$HOME/.openclaw/openclaw.json}"
+
+log()  { printf '%s\n' "$*"; }
+die()  { printf '%s\n' "$*" >&2; exit "${2:-1}"; }
+expand_tilde() { case "$1" in "~"*) printf '%s\n' "${1/#\~/$HOME}" ;; *) printf '%s\n' "$1" ;; esac; }
+
+# ---- locate openclaw ----
+OCP="${SELFCARE_OPENCLAW:-$(command -v openclaw 2>/dev/null)}"
+[ -n "$OCP" ] && [ -x "$OCP" ] || die "openclaw binary not found (set SELFCARE_OPENCLAW)" 2
+
+# ---- locate plugin clone (ask openclaw, then fall back to common spots) ----
+locate_plugin() {
+  if [ -n "${SELFCARE_PLUGIN_DIR:-}" ]; then expand_tilde "$SELFCARE_PLUGIN_DIR"; return; fi
+  local p
+  p="$("$OCP" plugins inspect "$PLUGIN_ID" 2>/dev/null \
+        | sed -n 's/^Install path:[[:space:]]*//p; s/^Source path:[[:space:]]*//p' | head -1)"
+  if [ -n "$p" ]; then expand_tilde "$p"; return; fi
+  for p in "$HOME/.openclaw/plugins/$PLUGIN_ID" "$HOME/.openclaw/extensions/$PLUGIN_ID" \
+           "$HOME/nextclaw" "$HOME/$PLUGIN_ID"; do
+    [ -d "$p/.git" ] && { printf '%s\n' "$p"; return; }
+  done
+}
+CLONE="$(locate_plugin)"
+
+# ---- versions ----
+oc_cur()    { "$OCP" --version 2>/dev/null | sed -n 's/^OpenClaw \([0-9][^ ]*\).*/\1/p' | head -1; }
+oc_latest() { npm view openclaw version 2>/dev/null \
+              || curl -fsSL https://registry.npmjs.org/openclaw/latest 2>/dev/null | jq -r .version 2>/dev/null; }
+plugin_ver() { "$OCP" plugins inspect "$PLUGIN_ID" 2>/dev/null | sed -n 's/^Version:[[:space:]]*//p' | head -1; }
+gw_probe()  { "$OCP" gateway status --deep 2>&1 | sed -n 's/^Connectivity probe:[[:space:]]*//p' | head -1; }
+gw_ver()    { "$OCP" gateway status --deep 2>&1 | sed -n 's/^Gateway version:[[:space:]]*\([0-9][^ ]*\).*/\1/p' | head -1; }
+
+CUR="$(oc_cur)";  LATEST="$(oc_latest)"
+[ -n "$CUR" ]    || die "cannot read current openclaw version — install already broken?" 20
+[ -n "$LATEST" ] || die "cannot reach npm registry for latest openclaw version" 20
+
+# =====================================================================
+# PREFLIGHT — sandbox compat check. Never touches the live install.
+# Echoes a final  PREFLIGHT: <PASS|FIX-NEEDED:reason|FAIL:reason>  line.
+# =====================================================================
+preflight() {
+  log "[selfcare] openclaw current=$CUR target=$LATEST plugin=$PLUGIN_ID clone=${CLONE:-<none>}"
+
+  # current install must be healthy first; don't blame the upgrade for a pre-existing break
+  local probe; probe="$(gw_probe)"
+  if [ -n "$probe" ] && ! printf '%s' "$probe" | grep -qi ok; then
+    log "[selfcare] live gateway probe currently NOT ok ($probe) — refuse to upgrade onto broken state"
+    echo "PREFLIGHT: FAIL:probe-current"; return 20
+  fi
+
+  if [ -z "$CLONE" ] || [ ! -f "$CLONE/package.json" ]; then
+    log "[selfcare] no plugin clone found — nothing memory-side to break"
+    echo "PREFLIGHT: PASS"; return 0
+  fi
+
+  local SBX; SBX="$(mktemp -d "${TMPDIR:-/tmp}/oc-selfcare.XXXXXX")" || { echo "PREFLIGHT: FAIL:sandbox-install"; return 20; }
+  trap 'rm -rf "$SBX"' RETURN
+  if ! ( cd "$SBX" && npm init -y >/dev/null 2>&1 \
+         && npm install --no-audit --no-fund --silent --prefix "$SBX" "openclaw@$LATEST" semver >"$SBX/i.log" 2>&1 ); then
+    log "[selfcare] sandbox install openclaw@$LATEST failed:"; tail -15 "$SBX/i.log" 2>/dev/null
+    echo "PREFLIGHT: FAIL:sandbox-install"; return 20
+  fi
+
+  semver_ok() { # $1=ver $2=range -> 1/0/?  (empty range = ok)
+    node -e "try{const s=require('$SBX/node_modules/semver');const r='$2'.trim();
+      console.log(!r?'1':(s.satisfies('$1',r)?'1':'0'))}catch(e){console.log('?')}" 2>/dev/null
+  }
+
+  # 1) declared openclaw range on the plugin (peerDependencies/engines/openclawCompat)
+  local peer; peer="$(jq -r '.peerDependencies.openclaw // .engines.openclaw // .openclawCompat // ""' "$CLONE/package.json" 2>/dev/null)"
+  peer="${peer//null/}"
+  if [ -n "$peer" ] && [ "$(semver_ok "$LATEST" "$peer")" = "0" ]; then
+    # is there a newer plugin tag whose range DOES cover the target?
+    local tag tp newer=""
+    ( cd "$CLONE" && git fetch --tags --quiet origin 2>/dev/null || true )
+    while IFS= read -r tag; do
+      [ -z "$tag" ] && continue
+      tp="$(cd "$CLONE" && git show "$tag:package.json" 2>/dev/null | jq -r '.peerDependencies.openclaw // .engines.openclaw // .openclawCompat // ""' 2>/dev/null)"
+      tp="${tp//null/}"
+      if [ -z "$tp" ] || [ "$(semver_ok "$LATEST" "$tp")" = "1" ]; then newer="$tag"; break; fi
+    done < <(cd "$CLONE" && git tag -l 'v*' --sort=-v:refname | head -10)
+    if [ -n "$newer" ]; then echo "PREFLIGHT: FIX-NEEDED:plugin-bump:$newer"; return 10; fi
+    log "[selfcare] plugin peer '$peer' excludes v$LATEST and no compatible newer tag exists"
+    echo "PREFLIGHT: FAIL:peer-mismatch"; return 20
+  fi
+
+  # 2) plugin runtime deps resolve? (catches undeclared/missing transitive deps, e.g. undici)
+  local miss=""
+  if [ -d "$CLONE/node_modules" ]; then
+    miss="$(cd "$CLONE" && npm ls --omit=dev --omit=peer --silent 2>&1 \
+            | sed -n 's/.*missing: \([^@ ]*\)@.*/\1/p; s/.*UNMET DEPENDENCY \([^ ]*\).*/\1/p' | head -1)"
+  fi
+  if [ -z "$miss" ]; then
+    # whatever the NEW openclaw asks the plugin to provide (its peerDeps) must resolve from the clone
+    local p
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+      ( cd "$CLONE" && node -e "require.resolve('$p')" 2>/dev/null ) || { miss="$p"; break; }
+    done < <(jq -r '.peerDependencies // {} | keys[]?' "$SBX/node_modules/openclaw/package.json" 2>/dev/null)
+  fi
+  if [ -n "$miss" ]; then echo "PREFLIGHT: FIX-NEEDED:missing-dep:$miss"; return 10; fi
+
+  echo "PREFLIGHT: PASS"; return 0
+}
+
+# =====================================================================
+# AUTO-FIX — only the two known-safe fixes. Refuses on dirty (dev) clones.
+# =====================================================================
+plugin_dirty() {
+  ( cd "$CLONE" && git status --porcelain --untracked-files=no -- . \
+      ':(exclude)package-lock.json' ':(exclude)pnpm-lock.yaml' ':(exclude)yarn.lock' 2>/dev/null | wc -l | tr -d ' ' )
+}
+revert_lockfiles() { local lf; for lf in package-lock.json pnpm-lock.yaml yarn.lock; do
+  [ -f "$CLONE/$lf" ] && ( cd "$CLONE" && git checkout -- "$lf" 2>/dev/null ); done; }
+
+auto_fix() { # $1 = reason  (plugin-bump:<tag> | missing-dep:<pkg>)
+  local kind="${1%%:*}" arg="${1#*:}"
+  [ -d "$CLONE/.git" ] || die "[selfcare] no clone to fix" 1
+  if [ "$(plugin_dirty)" -gt 0 ]; then
+    log "[selfcare] clone has uncommitted code changes — refuse auto-fix (protect dev work)"; return 1
+  fi
+  ( cd "$CLONE" && git config user.email >/dev/null 2>&1 || git config --local user.email selfcare@openclaw
+    git config user.name >/dev/null 2>&1 || git config --local user.name selfcare ) 2>/dev/null
+  case "$kind" in
+    plugin-bump)
+      log "[selfcare] auto-fix: checkout plugin $arg"
+      ( cd "$CLONE" && git fetch --tags --quiet origin 2>/dev/null || true )
+      revert_lockfiles
+      ( cd "$CLONE" && git checkout -f "$arg" 2>&1 | tail -2 ) || { log "[selfcare] checkout $arg failed"; return 1; }
+      ( cd "$CLONE" && npm install --no-audit --no-fund 2>&1 | tail -3 ) || { log "[selfcare] npm install failed"; return 1; }
+      revert_lockfiles ;;
+    missing-dep)
+      case "$arg" in *[!a-zA-Z0-9_./@-]*|"") log "[selfcare] bad pkg name: $arg"; return 1 ;; esac
+      log "[selfcare] auto-fix: npm install $arg (and commit so it survives)"
+      ( cd "$CLONE" && npm install --no-audit --no-fund --save "$arg" 2>&1 | tail -3 ) || { log "[selfcare] install $arg failed"; return 1; }
+      ( cd "$CLONE" && git add package.json package-lock.json pnpm-lock.yaml yarn.lock 2>/dev/null
+        git commit -m "selfcare: add $arg for openclaw compat" 2>&1 | tail -2 || true ) ;;
+    *) log "[selfcare] unfixable reason: $1"; return 1 ;;
+  esac
+  "$OCP" gateway restart 2>&1 | tail -2; sleep 5
+}
+
+# =====================================================================
+# UPGRADE openclaw core, then verify the live gateway came back on target.
+# =====================================================================
+upgrade_openclaw() {
+  log "[selfcare] upgrading openclaw $CUR → $LATEST (channel $CHANNEL)"
+  "$OCP" update --channel "$CHANNEL" --yes --json --timeout 1800 2>&1 | tail -20
+  local gv pr
+  for _ in 1 2 3 4 5; do
+    gv="$(gw_ver)"; pr="$(gw_probe)"
+    { [ "$gv" = "$LATEST" ] && printf '%s' "$pr" | grep -qi ok; } && break
+    sleep 6
+  done
+  log "[selfcare] openclaw after: gateway=$gv target=$LATEST probe=$pr"
+  [ "$gv" = "$LATEST" ] && printf '%s' "$pr" | grep -qi ok
+}
+
+# =====================================================================
+# UPDATE the memory plugin to its latest tag, then verify version + memory probe.
+# =====================================================================
+upgrade_plugin() {
+  [ -d "$CLONE/.git" ] || { log "[selfcare] no plugin clone — skip plugin update"; return 0; }
+  local cur latest want pv pr
+  ( cd "$CLONE" && git fetch --tags --quiet origin 2>/dev/null || true )
+  cur="$(cd "$CLONE" && git describe --tags --always 2>/dev/null)"
+  latest="$(cd "$CLONE" && git tag -l 'v*' --sort=-v:refname | head -1)"
+  [ -z "$latest" ] && { log "[selfcare] plugin: no tags — skip"; return 0; }
+  if [ "$(plugin_dirty)" -gt 0 ]; then log "[selfcare] plugin clone DIRTY — skip update (protect dev)"; return 0; fi
+  if [ "$cur" = "$latest" ]; then log "[selfcare] plugin already $cur"; return 0; fi
+  log "[selfcare] plugin $cur → $latest"
+  revert_lockfiles
+  ( cd "$CLONE" && git checkout -f "$latest" 2>&1 | tail -2 ) || { log "[selfcare] plugin checkout failed"; return 1; }
+  # Full install (NO --omit): the plugin can have transitive runtime deps (e.g. undici)
+  # that --omit=dev/--omit=peer would prune, breaking load.
+  ( cd "$CLONE" && npm install --no-audit --no-fund 2>&1 | tail -3 ) || { log "[selfcare] plugin npm install failed"; return 1; }
+  revert_lockfiles
+  "$OCP" gateway restart 2>&1 | tail -2; sleep 8
+  want="${latest#v}"
+  for _ in 1 2 3; do pv="$(plugin_ver)"; pr="$(gw_probe)"
+    { [ "$pv" = "$want" ] && printf '%s' "$pr" | grep -qi ok; } && break; sleep 5; done
+  log "[selfcare] plugin after: version=$pv target=$want probe=$pr"
+  [ "$pv" = "$want" ] && printf '%s' "$pr" | grep -qi ok
+}
+
+# =====================================================================
+# Telegram (optional). Reuses openclaw's own bot token if not overridden.
+# =====================================================================
+notify() {
+  local text="$1" tok="${SELFCARE_TG_TOKEN:-}" chat="${SELFCARE_TG_CHAT:-}"
+  [ -z "$tok" ] && [ -f "$OPENCLAW_JSON" ] && tok="$(jq -r '.channels.telegram.botToken // empty' "$OPENCLAW_JSON" 2>/dev/null)"
+  if [ -n "$tok" ] && [ -n "$chat" ]; then
+    curl -fsS -m 25 "https://api.telegram.org/bot${tok}/sendMessage" \
+      -d chat_id="$chat" -d parse_mode=HTML --data-urlencode "text=$text" >/dev/null 2>&1 \
+      && return 0 || { echo "[selfcare] tg send failed" >&2; return 1; }
+  fi
+  echo "[selfcare:notify] $text"
+}
+
+# =====================================================================
+# MAIN
+# =====================================================================
+case "$MODE" in
+  preflight)
+    preflight; exit $?
+    ;;
+
+  check)
+    log "openclaw: current=$CUR latest=$LATEST $([ "$CUR" = "$LATEST" ] && echo '(up-to-date)' || echo '(UPDATE AVAILABLE)')"
+    if [ -d "$CLONE/.git" ]; then
+      ( cd "$CLONE" && git fetch --tags --quiet origin 2>/dev/null || true )
+      pcur="$(cd "$CLONE" && git describe --tags --always 2>/dev/null)"
+      plat="$(cd "$CLONE" && git tag -l 'v*' --sort=-v:refname | head -1)"
+      log "plugin $PLUGIN_ID: current=$pcur latest=$plat $([ "$pcur" = "$plat" ] && echo '(up-to-date)' || echo '(UPDATE AVAILABLE)') loaded=$(plugin_ver)"
+    else
+      log "plugin $PLUGIN_ID: clone not found"
+    fi
+    v="$(preflight)"; rc=$?
+    log "$v"
+    exit $rc
+    ;;
+
+  apply)
+    # 1) breaking-release guard (best-effort; needs gh)
+    if [ "$CUR" != "$LATEST" ] && [ -z "${SELFCARE_SKIP_BREAKING_SCAN:-}" ] && command -v gh >/dev/null 2>&1; then
+      notes="$(gh release view "v$LATEST" --repo openclaw/openclaw 2>/dev/null || gh api "repos/openclaw/openclaw/releases/tags/v$LATEST" 2>/dev/null || true)"
+      if printf '%s' "$notes" | grep -qiE 'breaking[ -]?change|migration required|manual (data )?migration|incompatible|drop(ped|s) support'; then
+        notify "🛑 $(hostname): OpenClaw v$LATEST release notes look breaking — skipping auto-upgrade, please review manually"
+        log "[selfcare] breaking release detected — skipping openclaw upgrade, still refreshing plugin"
+        CUR="$LATEST"   # disable core upgrade below; still run plugin update
+      fi
+    fi
+
+    # 2) preflight (+ one auto-fix retry)
+    verdict="$(preflight | awk '/^PREFLIGHT:/{v=$0} END{sub(/^PREFLIGHT:[ \t]*/,"",v);print v}')"
+    log "[selfcare] preflight: $verdict"
+    case "$verdict" in
+      PASS) ;;
+      FIX-NEEDED:*)
+        if auto_fix "${verdict#FIX-NEEDED:}"; then
+          verdict="$(preflight | awk '/^PREFLIGHT:/{v=$0} END{sub(/^PREFLIGHT:[ \t]*/,"",v);print v}')"
+          log "[selfcare] post-fix preflight: $verdict"
+        fi ;;
+    esac
+    if [ "$verdict" != "PASS" ]; then
+      notify "🛑 $(hostname): openclaw pre-upgrade compat check did not pass ($verdict) — upgrade skipped, memory untouched"
+      exit 20
+    fi
+
+    # 3) upgrade openclaw core (only if behind)
+    oc_line="openclaw $CUR (already latest)"
+    if [ "$CUR" != "$LATEST" ]; then
+      if upgrade_openclaw; then oc_line="openclaw $CUR→$LATEST ✅"
+      else notify "⚠️ $(hostname): openclaw upgrade to v$LATEST failed verify (gateway/probe) — please check"; exit 1; fi
+    fi
+
+    # 4) update memory plugin
+    if upgrade_plugin; then plug_line="plugin $PLUGIN_ID → $(plugin_ver) ✅"
+    else notify "⚠️ $(hostname): memory plugin $PLUGIN_ID failed verify after update — please check"; exit 1; fi
+
+    notify "✅ $(hostname): $oc_line · $plug_line"
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a bundled OpenClaw ops skill, **`openclaw-selfcare`**, that safely keeps a host's
OpenClaw core **and this plugin** up to date — and fixes a latent dependency-declaration
bug (`undici`) that this exact skill is designed to guard against.

OpenClaw releases frequently. A core upgrade can occasionally ship an openclaw whose
plugin API this memory plugin doesn't match yet, or one that prunes a transitive
dependency the plugin needs — and the memory layer goes down mid-upgrade. This skill
**predicts that in a sandbox before touching the live install**, auto-fixes the
safely-fixable cases, and otherwise alerts instead of force-upgrading.

## What's in here

### `skills/openclaw-selfcare/` — the skill
A self-contained skill (one bash script + `SKILL.md` + `README.md` + `config.env.example`):

```
check latest openclaw
  → sandbox compatibility preflight (install target openclaw in a throwaway prefix;
    does this plugin still satisfy its declared range + do the plugin's runtime deps resolve?)
      → PASS        : upgrade openclaw, update the plugin, verify gateway + memory probe
      → FIX-NEEDED  : bump plugin to a compatible tag / install the missing dep, re-check
      → FAIL        : skip the upgrade & alert (never upgrade onto a broken/incompatible state)
```

- Read-only `check` / `preflight`; `apply` performs the real upgrade.
- Plugin clone located automatically via `openclaw plugins inspect memory-postgres`.
- Optional daily cron + Telegram reporting (reuses openclaw's own bot token; no second copy).
- Safety: refuses to upgrade across a release flagged breaking, refuses to stack onto an
  already-unhealthy install, skips dev clones with uncommitted changes, verifies recovery
  after every step.

### `fix`: declare `undici` as a direct dependency (`^8.3.0`)
`src/moderator/telegram-api.ts` imports `undici` directly (`Agent` + an IPv4-first `fetch`
dispatcher for `api.telegram.org` — Node's built-in fetch can't supply a custom dispatcher),
but it was only present **transitively** via OpenClaw's dependency tree. A change to that
tree — or installing without the same hoisting — could make `undici` vanish at runtime and
break the Telegram send path. Now declared directly so it can't disappear.

*No behavior change: the resolved version is unchanged (8.3.0, already in the lockfile).
The lockfile diff is a single added reference line.*

## Consistency / completeness checks done before pushing

- **Plugin id**: skill defaults to `memory-postgres` — matches `openclaw.plugin.json` `id`.
- **Compat field**: skill's preflight reads `peerDependencies.openclaw` — which this repo
  declares (`>=2026.4.25`), so the check is actually meaningful here.
- **Lockfile**: kept the change minimal — only `undici` added to root deps; the
  `node_modules/undici` entry already existed (no version churn, no unrelated reformatting).
- **`.gitignore`**: added `**/config.env` (keeps `config.env.example`) so a user's filled-in
  chat id / token can't be committed.
- **npm `files`**: added `skills/` so the skill ships with the npm package too.
- **Docs**: README *Companion skills*, `AGENTS.md` layout table + Dependencies, `CHANGELOG.md`
  Unreleased — all updated. Version bump intentionally left to the maintainer (Unreleased).

## Testing

- `bash -n` on the script; `package.json` validates; `package-lock` in sync
  (`npm install --package-lock-only` is a no-op).
- Ran the skill **read-only `check` against a real host** (openclaw + this plugin installed):
  it auto-located the clone, sandbox-installed the target openclaw, and returned
  `PREFLIGHT: PASS` — correctly reporting an available openclaw update with the plugin
  compatible.
- Installed via `openclaw skills install` → shows `✓ Ready, visible to model: yes`, all
  required binaries present.

## Notes for the maintainer

- This is the read-only-by-default posture: the `SKILL.md` instructs the agent to run `apply`
  only on explicit user request.
- Set a version + date on the `## Unreleased` heading when you cut the next release.
