### PR TITLE
docs: Simplified Chinese (zh-CN) translations for all docs — 中英双语

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # nextclaw — contributor guide
 
+**English** · [简体中文](AGENTS.zh-CN.md)
+
 Postgres + pgvector backed memory plugin for OpenClaw. Fills `plugins.slots.memory`.
 
 ## Scope

--- a/AGENTS.zh-CN.md
+++ b/AGENTS.zh-CN.md
@@ -1,0 +1,64 @@
+# nextclaw — 贡献指南
+
+[English](AGENTS.md) · **简体中文**
+
+基于 Postgres + pgvector 的 OpenClaw 记忆插件，用于填充 `plugins.slots.memory` 插槽（slot）。
+
+## 适用范围
+
+- 一旦接入该插槽，即替换 `memory-core`（内置的 SQLite 后端）
+- 4 层记忆：T0 进程内 / T1 PG UNLOGGED 热缓存 / T2 主存 / T3 冷存摘要（gist）
+- 多键索引（multi-key indexing，"新华字典"式）：每个记忆块（chunk）都按概念标签、实体引用、锚点（cwd/branch/PR/file）、时间桶、指标/偏好键，以及 6+1 分类体系进行索引
+- 摄入（ingest）流水线：确定性（deterministic）+ sidecar JSON + 缓存，LLM 仅作为兜底残差
+- 召回（recall）：逐层游走 T0→T1→T2→T3，多路并行（即便缺少高精度锚点也不跳过）
+- 对每个事件进行记忆操作打分（scoring）（ingest_score / recall_score）
+- 自调优循环（self-tuning loop）（每日 / 每周 / 每月生成提案）
+- 通过 PG LISTEN/NOTIFY 驱动仪表盘
+- 强制的按 agent 隔离（per-agent isolation）记忆命名空间（namespace）（`agent_id` 列贯穿每条召回路径）
+- 动作敏感型承诺：agent 可能据以采取行动的指令会被打上标记（`safe_to_act` / `requires_confirmation` / `authority` / 有效期），并在召回时以 ⚠ 标出，从而避免一句随口之言触发某个动作
+
+## 目录结构
+
+| Path | 职责 |
+|---|---|
+| `src/storage/` | pg.Pool、schema DDL、迁移（migration） |
+| `src/embedding/` | OpenAI 兼容的嵌入客户端 + chat 客户端（用于影子对比器） |
+| `src/ingest/` | Stage 0–6 流水线 + sidecar 提示词构建器 |
+| `src/recall/` | 逐层游走 + 多路并行实现 + 意图识别 + 合并 |
+| `src/workers/` | context-primer、spreading-activator、compactor、feedback、scoring、tuning、git-watcher、transcript-watcher、shadow-comparator |
+| `src/cache/` | CacheBackend 抽象 + PG UNLOGGED 实现 |
+| `src/structured/` | 实体 / 事件 / 指标 / 偏好 / 承诺抽取器 + 调和（reconcile）+ 分类器（另含 `commitments.ts` 召回侧读取器） |
+| `src/sdk/` | StructuredMemoryAPI 公开导出 |
+| `src/dashboard/` | HTTP 服务器 + SPA 资源 + bot-stats |
+| `src/cli/` | tail（router-explain、audit、stats 等位于 dashboard 中） |
+| `skills/` | 随插件一同发布的 OpenClaw 运维 skill（目前为 `openclaw-selfcare` —— 对 openclaw 及本插件进行安全的自升级） |
+
+## 规则
+
+- 所有 SQL 一律经由 `src/storage/pool.ts` 中的 `pg.Pool`。切勿内嵌连接字符串。
+- schema（表结构）变更归属于 `src/storage/schema/*.sql` + `src/storage/migrate.ts`。切勿通过临时 DDL 改动。
+- 每个审计行（audit row）都携带 `score`（摄入）或 `score + relevance_estimate`（召回）。
+- 打分计算位于 `src/scoring.ts`。不要把公式内联到路由代码中。
+- 优先采用确定性信号（Stage 0），其次 sidecar，最后才是 LLM。新功能必须契合这一层级顺序。
+- 嵌入适配器（embedding adapter）的替换必须可用；切勿在 config 之外硬编码 model id。
+- 缓存后端（cache backend）的替换必须可用；切勿绕过 `CacheBackend` 接口。
+- 仪表盘端点默认仅服务 **localhost**。任何超出 `127.0.0.1` 的访问都需通过 `dashboard.tokenEnv` 显式提供 token。
+- 调优的自动应用仅对 `safe_auto` 提案生效；其余一切均以 `status='pending'` 写入 `audit.tuning_proposals`。
+
+## 测试
+
+- 单元测试：各模块对应 `src/**/*.test.ts`
+- 在线（Live）测试：`test/*.live.test.ts` 需要 `OPENCLAW_LIVE_TEST=1` 以及可访问的 Postgres + 嵌入端点
+- 运行单元测试：`pnpm test`
+
+## 依赖
+
+- `pg`（node-postgres）—— 支持仪表盘所需的 LISTEN/NOTIFY
+- `pgvector` —— 面向 `pg` 的 pgvector 类型绑定
+- `undici` —— 用于面向 `api.telegram.org` 的 IPv4 优先 dispatcher 的 HTTP 客户端（`src/moderator/telegram-api.ts`）。直接声明依赖，而非依赖其传递引入，从而确保 OpenClaw 依赖树的变动不会令其凭空消失。
+
+## 跨扩展契约（cross-extension contract）
+
+- 自带嵌入能力：内部的 `EmbeddingClient`（manager-runtime → OpenAI 兼容 / Ollama 端点）自行完成嵌入。nextclaw 是嵌入的**消费方**，而非宿主提供方 —— 它**不**注册 `MemoryEmbeddingProviderAdapter`，也不声明任何 `contracts.embeddingProviders`
+- 实现来自 `openclaw/plugin-sdk/memory-core-host-engine-storage` 的 `MemorySearchManager`
+- 对外暴露 `StructuredMemoryAPI` 汇总入口，供希望以 SQL 形态访问的插件使用

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nextclaw
 
+**English** · [简体中文](README.zh-CN.md)
+
 > Postgres + pgvector long-term memory plugin for [OpenClaw](https://github.com/openclaw/openclaw).
 > 4-tier recall · multi-key Xinhua-dictionary indexing · deterministic-first ingest · hard per-agent isolation · real-time dashboard.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,321 @@
+# nextclaw
+
+[English](README.md) · **简体中文**
+
+> 为 [OpenClaw](https://github.com/openclaw/openclaw) 打造的 Postgres + pgvector 长期记忆插件。
+> 四层召回 · 多键索引（“新华字典”式）· 确定性优先摄入 · 硬性按 agent 隔离 · 实时仪表盘。
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+![Status: 0.3.0](https://img.shields.io/badge/status-0.3.0-blue)
+
+```
+   ┌────────────────────────────────────────────────────────────┐
+   │  OpenClaw agent (DM, Discord, Slack, WhatsApp, ...)         │
+   └─────────────┬──────────────────────────┬───────────────────┘
+                 │ memory_search             │ memory_store
+                 ▼                           ▼
+   ┌────────────────────────────────────────────────────────────┐
+   │ nextclaw                                                   │
+   │                                                            │
+   │  Recall tier-walk:  T0 → T1 → T2 → T3                      │
+   │  Ingest pipeline:   Stage 0 → 1 → 2 → 3 → 4 → 5 → 6        │
+   │  8-route hybrid:    semantic / fulltext / trgm /           │
+   │                     concept_tag / entity_ref /             │
+   │                     time_bucket / anchor / category        │
+   │                                                            │
+   │  Per-agent isolation:  WHERE c.agent_id = $X (every route) │
+   └─────────────┬──────────────────────────┬───────────────────┘
+                 │                          │
+                 ▼                          ▼
+   ┌─────────────────────┐       ┌───────────────────────────┐
+   │  Postgres + pgvector│       │  Embedding endpoint        │
+   │  semantic + struct  │       │  (Ollama / OpenAI-compat / │
+   │  + audit + cache    │       │   vLLM / TEI / ...)        │
+   │  + cold + LISTEN/   │       │                            │
+   │  NOTIFY → dashboard │       │                            │
+   └─────────────────────┘       └───────────────────────────┘
+```
+
+---
+
+## 功能简介
+
+- 作为 OpenClaw 内置 SQLite 记忆插件（`memory-core`）的**即插即用替代**
+- **四层召回**，让 75%+ 的重复查询在 <5ms 内返回，且**消耗 0 个 LLM token**、**0 次嵌入调用**
+- **多键索引**（“新华字典”式）：每个记忆块(chunk)都能从多个正交维度被检索到 —— 语义 / 全文 / trigram / 概念标签 / 实体引用 / 时间桶 / 锚点 / 类别
+- **确定性优先摄入**：热路径中没有 LLM；LLM 只作为残余阶段存在，仅当确定性抽取一无所获时才介入
+- **硬性的按 agent 记忆命名空间隔离**：在同一个数据库上同时运行一个私有 agent 和一个公开的 Discord agent —— 它们在物理上无法看到彼此的记忆（在 SQL 层强制隔离，而非应用层）
+- **语义问答缓存**（`cache.qa`）：重复的问题会命中亚毫秒级（L0 LRU）→ 约 5ms（L1 精确哈希）→ 约 50ms（L2 HNSW）。对重复问题完全跳过 LLM。
+- **Telegram 群组 Moderator(群消息编排器)**（可选，默认关闭）：采用 Anthropic《Building Effective Agents》中所述的编排器–worker 模式。把群组中的 `@-mentions` 路由给带工具（`memory_search`、通过 Tavily 的 `web_search`）的专家 worker，并持久化角色设计，让注册表随时间不断积累。
+- **实时仪表盘**（中英双语），包含类别分布、健康/医疗信息脱敏、bot 轮次遥测、模型并排对比
+- **自调优循环**（每日 / 每周 / 每月提案）
+- **通用 HTTP 摄入网关** —— 任何 cron / skill / 外部脚本都能通过同一条 Stage 0–6 流水线写入记忆
+- **精选、带引用的召回**：`memory_search` 的结果会附带 `pg://` 引用，让 agent 能为某个论断标注出处，并通过 `memory_get(chunkId)` 重新取回其完整内容；`memory_update` / `memory_forget` 让 agent 能主动精选记忆，而不只是一味追加
+- **动作敏感的记忆**：agent 可能会去*执行*的指令（取消、发送、授权、预约）会被标注 `safe_to_act` / `requires_confirmation` / `authority`，并在召回时以 ⚠ 标记呈现 —— 一句过时或无关的话，不经核实就无法触发真实世界的动作
+
+## 配套 skill
+
+可与 nextclaw 良好组合的独立 OpenClaw skill：
+
+- **[openclaw-skill-reminder](https://github.com/NextAgentBC/openclaw-skill-reminder)** —— 注重隐私的基于时间的提醒。cron 配置文件里只看得到不透明的 `reminder:<short-id>` 名称；真正的细节（姓名、地址、预约）存放在一个 mode-600 权限的文件中。`/dashboard` 用户用它来安排跟进事项，而不会把 PII 泄露进 `jobs.json`。
+- **[openclaw-selfcare](skills/openclaw-selfcare/)** —— *随本仓库一同提供*（`skills/openclaw-selfcare/`）。安全地让宿主的 OpenClaw 核心**以及本插件**保持更新：在任何升级之前都会先跑一遍沙箱兼容性预检（新版 openclaw 是否仍能加载本插件并解析其依赖？），它会自动修复可安全修复的问题（把插件升到兼容的 tag、安装缺失的传递依赖如 `undici`），并拒绝升级到一个已损坏或不兼容的状态。默认是只读的 `check`；`apply` 才会真正执行升级。参见 [`skills/openclaw-selfcare/SKILL.md`](skills/openclaw-selfcare/SKILL.md)。
+
+## 快速上手（Neon 约 5 分钟，Docker 约 10 分钟）
+
+你需要：一个 Postgres+pgvector 数据库（免费的 **Neon** 云端，或本地 **Docker**），以及一个免费的 **Jina** 嵌入(embedding) key（30 秒注册）。OpenClaw 自带 Node 22+，因此无需额外安装运行时。
+
+关于 Telegram Moderator、web_search 和反思升级，参见 [INSTALL.md](docs/INSTALL.zh-CN.md) 中的附加组件。**请先阅读 [SERVICES.md](docs/SERVICES.zh-CN.md)**，了解每项能力分别需要哪些外部服务。
+
+### 第 1 步 —— 安装 OpenClaw（宿主运行时，一行命令）
+
+```bash
+curl -fsSL https://openclaw.ai/install.sh | bash
+openclaw onboard --install-daemon
+# Windows PowerShell:  iwr -useb https://openclaw.ai/install.ps1 | iex
+```
+
+### 第 2 步 —— 准备一个带 pgvector 的 Postgres（二选一）
+
+<details open><summary><strong>方案 A —— Neon（推荐，零本地依赖，免费 0.5 GB）</strong></summary>
+
+1. 访问 <https://neon.tech> → **Sign up**（GitHub OAuth，无需信用卡）→ **Create project**
+2. 复制创建后显示的连接串，例如 `postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require`
+3. 在 Neon 的 **SQL Editor** 标签页里，粘贴并运行：
+
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS vector;
+   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+   CREATE EXTENSION IF NOT EXISTS btree_gin;
+   ```
+
+4. 导出连接串：
+
+   ```bash
+   export PG_URL="postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require"
+   ```
+
+</details>
+
+<details><summary><strong>方案 B —— Docker（本地，完全可控）</strong></summary>
+
+```bash
+docker run -d --name nextclaw-pg --restart unless-stopped \
+  -e POSTGRES_USER=nextclaw -e POSTGRES_PASSWORD=nextclaw -e POSTGRES_DB=nextclaw \
+  -p 127.0.0.1:55432:5432 -v nextclaw_pg:/var/lib/postgresql/data \
+  pgvector/pgvector:pg16
+until docker exec nextclaw-pg pg_isready -U nextclaw >/dev/null 2>&1; do sleep 1; done
+docker exec nextclaw-pg psql -U nextclaw -d nextclaw -c \
+  "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS btree_gin;"
+export PG_URL="postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw"
+```
+
+</details>
+
+### 第 3 步 —— 获取一个免费的 Jina 嵌入 key（30 秒，无需信用卡，100 万 token）
+
+<https://jina.ai/embeddings> → **Get API key for free** → 复制
+
+```bash
+export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+把 `PG_URL` 持久化以供日后的 shell 使用，把 `JINA_API_KEY` 同时持久化给 shell *和* OpenClaw 守护进程。守护进程由 launchd/systemd 启动，因此它**不会**读取你的 `~/.zshrc` —— 它读取的是 `~/.openclaw/service-env/ai.openclaw.gateway.env`：
+
+```bash
+# For interactive shells (future `configure-minimal.mjs` runs, ad-hoc psql, etc.)
+cat >> ~/.zshrc <<EOF   # or ~/.bashrc
+export PG_URL="$PG_URL"
+export JINA_API_KEY=$JINA_API_KEY
+EOF
+
+# For the gateway daemon (so memory_search / memory_store can call Jina)
+echo "export JINA_API_KEY=$JINA_API_KEY" >> ~/.openclaw/service-env/ai.openclaw.gateway.env
+```
+
+### 第 4 步 —— 把 nextclaw 安装进 OpenClaw
+
+```bash
+openclaw plugins install git:github.com/NextAgentBC/nextclaw
+```
+
+该插件的 id 是 **`memory-postgres`**（无论从哪个来源安装均如此）。其他来源 —— npm、ClawHub、本地开发 —— 列在[其他安装方式](#其他安装方式)一节中。
+
+### 第 5 步 —— 把它接入你的 `openclaw.json`（安全合并 —— 保留现有配置）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NextAgentBC/nextclaw/main/scripts/configure-minimal.mjs |
+  PG_URL="$PG_URL" node --input-type=module
+```
+
+这会向 `~/.openclaw/openclaw.json` 添加两个键，其余一切（`gateway`、`agents`、`auth`……）原封不动：
+
+- `plugins.slots.memory = "memory-postgres"`
+- `plugins.entries["memory-postgres"]`，包含 `postgres.url` + 仪表盘
+
+> 更想手动编辑？把下面这段粘贴进你现有的 `plugins.entries` —— 其中的 embedding 块是可选的，省略时默认使用 Jina 免费档。
+>
+> ```jsonc
+> "memory-postgres": {
+>   "enabled": true,
+>   "config": {
+>     "postgres": { "url": "<your PG_URL>" },
+>     "dashboard": { "enabled": true, "tokenEnv": "NEXTCLAW_DASH_TOKEN" }
+>   }
+> }
+> ```
+
+### 第 6 步 —— 设置仪表盘 token 并重启守护进程
+
+```bash
+export NEXTCLAW_DASH_TOKEN=$(openssl rand -hex 24)
+# Persist for the daemon (same env file as JINA_API_KEY above)
+echo "export NEXTCLAW_DASH_TOKEN=$NEXTCLAW_DASH_TOKEN" >> ~/.openclaw/service-env/ai.openclaw.gateway.env
+# Persist for this shell session too, for the smoke-test curls below
+echo "export NEXTCLAW_DASH_TOKEN=$NEXTCLAW_DASH_TOKEN" >> ~/.zshrc
+
+openclaw gateway restart
+```
+
+### 第 7 步 —— 冒烟测试：写入一条记忆，再把它召回
+
+仪表盘的 HTTP API 通过 **`X-Token`** 请求头（或 `?token=` 查询参数）来鉴权 —— 而不是 `Authorization: Bearer`。浏览器仪表盘会把 `?token=…` 捕获进 `sessionStorage`，随后在每次后续调用中以 `X-Token` 转发。
+
+```bash
+curl -sS -X POST http://127.0.0.1:8765/api/ingest \
+  -H "X-Token: $NEXTCLAW_DASH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"My favorite Postgres extension is pgvector.","source":"smoke","agentId":"main"}'
+
+curl -sS -X POST http://127.0.0.1:8765/api/recall \
+  -H "X-Token: $NEXTCLAW_DASH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What is my favorite Postgres extension?","agentId":"main"}'
+# → returns the chunk with hitTier: "t2_hybrid"
+```
+
+要在浏览器中打开实时仪表盘：
+
+```
+http://127.0.0.1:8765/?token=$NEXTCLAW_DASH_TOKEN
+```
+
+要查看带 persona 文件、故障排查、Discord/Telegram bot、web_search 以及多 agent 隔离的**完整 0 → 1 全流程**，参见 **[docs/INSTALL.md](docs/INSTALL.zh-CN.md)**。
+
+### 其他安装方式
+
+`openclaw plugins install` 接受多种来源 —— 选一个符合你工作流的：
+
+```bash
+# Git (recommended today — auto-builds during npm install via `prepare`)
+openclaw plugins install git:github.com/NextAgentBC/nextclaw
+openclaw plugins install git:github.com/NextAgentBC/nextclaw@v0.2.0   # pin a tag
+
+# npm (coming soon — the bare `nextclaw` npm name is taken by an unrelated
+# CLI, so this plugin will publish as a scoped name like @nextagentbc/nextclaw)
+# openclaw plugins install npm:@nextagentbc/nextclaw
+
+# ClawHub (coming soon — OpenClaw's official plugin hub)
+# openclaw plugins install clawhub:memory-postgres
+
+# Local dev (clone + live-reload symlink; runs from .ts source, no build needed)
+git clone https://github.com/NextAgentBC/nextclaw.git
+openclaw plugins install --link ./nextclaw
+```
+
+### 借助 AI agent 安装 nextclaw
+
+本套文档刻意写成既适合人类、也适合 LLM agent 阅读。如果你想让一个 agent 替你安装 nextclaw：
+
+1. 把 agent 指向 **[docs/SERVICES.md](docs/SERVICES.zh-CN.md)**，列举出你将需要哪些外部服务
+2. agent 会按顺序逐项走完依赖 —— Postgres → 嵌入 → （可选）LLM → （可选）Telegram → （可选）Tavily —— 使用每一节给出的注册链接、env-var 名称和验证用 curl
+3. 最后一步：agent 跑第 5 步的 `scripts/configure-minimal.mjs`，再跑第 7 步的冒烟测试
+
+SERVICES.md 末尾的 “For AI agents” 一节详述了推荐的对话流程。
+
+> **想自托管嵌入器而非使用 Jina？** 在本地运行 Ollama，
+> 并在 `memory-postgres` 条目中加上 `"embedding": { "format": "ollama" }`
+> —— embedding 块的其余字段会从各 format 的默认值自动补全。参见
+> [docs/CONFIG.md#embedding](docs/CONFIG.zh-CN.md#embedding)。
+>
+> ⚠️ **嵌入维度是单向的。** 它会在首次摄入时自动检测，并锁进 HNSW 索引。
+> 从 `jina-embeddings-v3`（1024d）切换到
+> `qwen3-embedding:4b`（4096d）需要执行 `TRUNCATE semantic.chunks`
+> 并重新摄入全部内容。请选一个你能用上一段时间的模型。
+
+## 文档
+
+| 文档 | 内容 |
+|---|---|
+| **[docs/SERVICES.md](docs/SERVICES.zh-CN.md)** | **请先阅读。** 每一项外部服务（Postgres、Jina、Gemini、Tavily、Telegram、OpenAI、credbroker）—— 注册链接、env var、配置片段、验证用 curl。为 AI agent 与人类双方而写。 |
+| **[docs/INSTALL.md](docs/INSTALL.zh-CN.md)** | 全新机器的 0 → 1 全流程 · Discord bot · Telegram Moderator · web_search · 多 agent 隔离 · 故障排查。提供 A → D 四个能力等级，可逐级进阶。 |
+| **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.zh-CN.md)** | 存储布局 · 四层召回 · 八路混合 · Stage 0–6 摄入 · 隔离保证 · 打分 · 自调优 · worker |
+| **[docs/CONFIG.md](docs/CONFIG.zh-CN.md)** | 每一个配置字段、默认值、调优建议 |
+| **[docs/LIVE_TESTS.md](docs/LIVE_TESTS.zh-CN.md)** | 如何对一个真实的 PG + 嵌入服务端点跑实时测试 |
+
+## 兼容性
+
+- **OpenClaw** `>= 2026.4.25`
+- **Node** `>= 22`
+- **Postgres** `>= 16`，需 **pgvector** `>= 0.7.0`（HNSW）
+- **嵌入**：Jina（默认，免费档），以及任意 OpenAI- 或 Ollama-兼容的服务端点。已测试 `jina-embeddings-v3`（1024d，默认）、`nomic-embed-text`（768d）、`qwen3-embedding:0.6b`（1024d）、`qwen3-embedding:4b`（4096d）。维度在首次嵌入时被检测并**锁进** HNSW 索引 —— 换模型就意味着重新摄入。
+- **反思 LLM**（可选）：任意 OpenAI-兼容的聊天服务端点，或原生 Gemini API（例如通过 Google 的免费档或一个 Tailscale 凭证 broker）。默认关闭。
+
+## 性能参考
+
+数据来自单机部署、约 280 个记忆块、单条 Discord 对话流：
+
+| 操作 | 路径 | LLM token | 嵌入调用 | 延迟 |
+|---|---|---|---|---|
+| 召回 —— 5 分钟内的重复查询 | T1 | 0 | 0 | ~ 1 ms |
+| 召回 —— 锚点（如查询中含 PR #） | T2 anchor | 0 | 0 | ~ 8 ms |
+| 召回 —— 一般性问题 | T2 hybrid | 0 | 1 | ~ 250 ms |
+| 摄入 —— 短文本（<200 字符），嵌入已预热 | deterministic | 0 | 0（缓存命中） | ~ 50 ms |
+| 摄入 —— 长文本（~2000 字符） | deterministic | 0 | 1 | ~ 600 ms |
+
+在典型负载下，摄入端到端**消耗 0 个 LLM token**。除非启用了可选的意图分类器，召回的 LLM token 也是 0。
+
+## 默认即隐私
+
+- `health` 和 `medical` 类的记忆块会在摄入时被自动置顶（`importance ≥ 0.7`，`retention_class='pinned'`），且是确定性的 —— 依据一份中英文关键词词典，而非 LLM 判断
+- 它们的 `text_excerpt` 在仪表盘的 `/api/recent` 响应中会被脱敏
+- 按 agent 隔离意味着一个面向公众的 agent **无法**取回它们，即便用对抗式提示也不行
+
+## 范围与限制
+
+我们把这个插件是什么、不是什么讲清楚，方便你在安装前判断它是否合适：
+
+### **记忆流水线**（召回、摄入、仪表盘、缓存、隔离）与渠道无关
+适用于任何 openclaw agent —— DM、Discord、Slack、WhatsApp 等。摄入通过 HTTP 网关接受来自任何来源的文本。**不与任何特定渠道或 bot 账号绑定。**
+
+### **Moderator**（Phase C / D，需主动开启）目前**仅限 Telegram 群组**
+当 `moderator.enabled=true` 时，插件会注册一个 `before_dispatch` hook，认领 **`telegram` 渠道上的群组 @-mentions** —— codex（或本来会回复的其他任何插件）对这些消息会被抑制；Moderator 通过 Telegram Bot API 带外回复。
+
+- **DM 不受影响** —— codex 一如既往地处理它们
+- **不含 @-mention 的群消息不受影响** —— codex 本来也不回复这些
+- **Slack / Discord / WhatsApp 的 `@-mentions` 不会被认领** —— 目前只有 `channelId === "telegram"` 才匹配
+
+如果你想让 Moderator 用在另一个渠道上，抑制规则（`index.ts` → `before_dispatch` hook）和 Telegram-Bot-API 回复路径（`src/moderator/telegram-api.ts`）都需要做适配。欢迎提 issue/PR。
+
+### 默认单租户；可显式多租户
+本插件写入的每一行都带有一个 `agent_id` 列。Moderator 使用 `cfg.moderator.agentId`（默认 `"main"`）。要在同一个 Postgres 上运行两个 openclaw 实例而互不冲突，给每个安装一个不同的 `agentId`：
+
+```jsonc
+"moderator": { "enabled": true, "agentId": "tutor-bot" }
+```
+
+`worker_roles`、`moderator.state`、`moderator.decisions` 以及 `cache.qa` 的行全部按命名空间隔离 —— 各 agent 看不到彼此的状态。
+
+### `web_search` 工具需要一个 Tavily 端点
+要么是 `credbroker.baseUrl`（一个代理 Tavily 的 Tailscale 凭证 broker —— 参见 [docs/CONFIG.md](docs/CONFIG.zh-CN.md)），要么是 env 中的 `TAVILY_API_KEY`。**两者都没有时，`web_search` 会向 LLM 返回一个诚实的错误**（LLM 随后会向用户解释这一限制）。绝不静默失败。
+
+### LLM 传输
+- Moderator 决策 LLM：**OpenAI-兼容** 或 **Gemini `:generateContent`**（带工具调用）。OpenAI 的工具调用格式目前只支持单轮；多轮工具调用需要 Gemini。
+- 嵌入：**Jina、OpenAI-兼容，或 Ollama**。默认是 Jina 免费档。
+
+## 状态
+
+`v0.2.x` —— 记忆流水线 + 仪表盘已稳定；Moderator + worker 工具层（Phase C/D）已经过实时测试，但相对更新。实时测试在参考配置上全部通过。并发模拟覆盖 8 个场景（缓存踩踏、跨 scope 并行、viewer 隔离、混合负载、worker 往返、角色自动注册、工具调用、web_search）。参见 [CHANGELOG.md](CHANGELOG.md)。
+
+## 许可证
+
+[Apache 2.0](LICENSE) · [NOTICE](NOTICE) 致谢 OpenClaw 上游项目。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # nextclaw architecture
 
+**English** · [简体中文](ARCHITECTURE.zh-CN.md)
+
 > Why a Postgres-backed memory plugin looks the way it does, and how the
 > pieces fit together.
 

--- a/docs/ARCHITECTURE.zh-CN.md
+++ b/docs/ARCHITECTURE.zh-CN.md
@@ -1,0 +1,242 @@
+# nextclaw 架构
+
+[English](ARCHITECTURE.md) · **简体中文**
+
+> 一个基于 Postgres 的记忆插件为何长成这个样子，以及各个部件是如何
+> 协同工作的。
+
+---
+
+## 存储布局
+
+Postgres 16 + pgvector + pg_trgm + btree_gin。共五个 schema：
+
+```
+semantic.*      — chunks (text, embedding, warmth, retention) + chunk_indexes
+                  (kind, value pairs for the multi-key router)
+structured.*    — entities, relations, events, preferences, metrics, provenance
+audit.*         — ingest_decisions, recall_decisions, model_comparisons,
+                  tuning_proposals, plugin_meta, schema_migrations
+cache.*         — UNLOGGED hot tables: hot_chunks, embeddings, intent,
+                  recall, entity_alias
+cold.*          — gists (compacted summaries with source_chunk_ids)
+```
+
+所有 DDL 都放在 `src/storage/schema/*.sql` 中，由迁移运行器（migration
+runner）在插件启动时按字典序依次执行。新的 schema 写入一个带下一个序号
+前缀的新文件（例如 `27-foo.sql`）。
+
+`semantic.chunks` 上的 `agent_id` 列是**记忆命名空间的边界**。所有召回
+路由都按 `WHERE c.agent_id = $X` 过滤；所有摄入都用写入者的 agent id
+打标。这一约束在 SQL 层强制执行，而非在应用层。
+
+---
+
+## 四层召回
+
+一次查询会按从最便宜到最昂贵的顺序逐层遍历，在第一个有用命中处即返回。
+写入 `audit.recall_decisions.hit_tier` 的层级标签会精确告诉你每次查询
+落在了哪一层。
+
+| Tier | Storage | Latency | LLM | Embed | Fires when |
+|---|---|---|---|---|---|
+| **T0** | In-process LRU per `(agent_id, session_id)` | < 0.1 ms | 0 | 0 | Recently-touched chunks in the live session |
+| **T1** | `cache.recall` (UNLOGGED), keyed on query+scope hash | ~ 1 ms | 0 | 0 | Same query repeats within 5 minutes |
+| **T2 anchor** | `chunk_indexes (kind=anchor_*)` JOIN chunks | ~ 5–15 ms | 0 | 0 | Caller passed (or query implied) `pr` / `file` / `branch` |
+| **T2 hybrid** | All 8 routes in parallel + MMR rerank | ~ 200–300 ms | 0 | 1 | Generic queries with no high-precision anchor |
+| **T3** | `cold.gists` HNSW + drill-down to source chunks | ~ 200 ms | varies | 1 | T2 returned nothing useful; query is historical |
+
+在真实使用中，T0 和 T1 覆盖了绝大多数重复查询（约 75%）。昂贵的 T2
+混合路径只有在问题确实是全新的时候才会运行。
+
+### 升级 / 降级
+
+- T2 命中 → 记忆块被升级到 T1（`cache.hot_chunks`，TTL 7 天）和
+  T0（进程内注册表，上限为 `tiers.t0SizeLimit`）
+- T1 命中 → 已经是热数据；只需触碰 `last_recalled_at` 并提升 warmth
+- 激活扩散 worker 在每次 T2 命中时异步触发：相邻记忆块（共享 entity /
+  concept_tag / 时间桶）的 warmth 会被提升，使得邻近召回更快
+- 90 天未被召回 + 未固定（non-pinned）+ 低重要性 → 成为冷 gist 整合的
+  候选（压缩器 worker）
+
+---
+
+## 8 路“新华字典”式召回
+
+“新华字典”的思路是：任何一个汉字都应当能从许多正交的路径触达（拼音 /
+部首 / 笔画 / 四角号码）。把同样的思路套用到记忆块上。每个记忆块都会在
+我们能确定性推导出的**每一个**信号上建立索引：
+
+| Route | What it matches | Index |
+|---|---|---|
+| `semantic` | Vector cosine | HNSW on `embedding` |
+| `fulltext` | Tokenized text match | GIN on `to_tsvector('simple', text)` |
+| `trgm` | Trigram similarity (typos, fuzzy CJK) | GIST `text gist_trgm_ops` |
+| `concept_tag` | Hyphenated / camelCase / CJK 2–6 char nouns | `chunk_indexes(kind='concept_tag')` |
+| `entity_ref` | Resolved entities from `structured.entities` | `chunk_indexes(kind='entity_ref')` |
+| `time_bucket` | Date bucket `YYYY-MM-DD` | `chunk_indexes(kind='time_bucket')` |
+| `anchor` | cwd / branch / pr / file / session | `chunk_indexes(kind='anchor_*')` |
+| `category` | health/medical/tech/life/work/finance/other | `chunk_indexes(kind='category')` |
+
+在一次 T2 混合查询中，这八路全部并行执行（`Promise.all`）。结果通过
+加权归一化合并，再经 MMR 重排以保证多样性。多路命中会叠加增益：一个
+同时命中 semantic + concept_tag + time_bucket 的记忆块，会胜过一个只
+弱命中单一路由的记忆块。
+
+路由器会直接从查询字符串本身推断锚点和概念标签（确定性正则），因此
+调用方无需事先抽取。
+
+---
+
+## Stage 0–6 摄入流水线
+
+```
+text in
+   ↓
+[Stage 1] trash filter — bilingual CN/EN boilerplate, length, noise regex
+   ↓ pass
+[Stage 0] deterministic extractors:
+            - entities (regex + alias dictionary)
+            - events (time + verb + actor)
+            - metrics (number + unit)
+            - preferences (rule-shaped)
+            - relations (subj-pred-obj)
+            - concept tags (camelCase split + CJK noun phrases)
+            - categories (CN+EN keyword dictionary, multi-label)
+[Stage 2] sidecar JSON parse (when present, with auto-disable on N consecutive bad JSON)
+   ↓ merge
+[Stage 3] embedding cache — text_hash lookup
+   ↓ if cache miss
+[Stage 4] LLM residual — only when Stage 0+2 produced nothing AND a
+            residual hook is configured. Default: skip.
+   ↓
+[Stage 5] write semantic.chunks + parallel multi-key index INSERTs
+[Stage 6] reconcile structured rows + provenance + audit + scoring
+```
+
+在正常运行下，**摄入不消耗任何 LLM token**。确定性的各个阶段处理掉了
+绝大部分工作；LLM 残余阶段的存在，是为了应对自动抽取没有产出任何东西、
+但内容仍值得摄入的情况。
+
+### 摄入时的隐私策略
+
+类别为 `health` 和 `medical` 的内容会自动：
+- 将 `retention_class` 提升为 `pinned`（永不衰减）
+- 将 `importance` 提升到 ≥ 0.7
+- 在仪表盘的 `/api/recent` 摘录中被脱敏
+
+这是确定性的——对 `(医院|hospital|...)` 的一次正则匹配即触发该策略。
+它**不**依赖某个 LLM 同意该内容属于敏感信息。
+
+---
+
+## 按 agent 隔离保证
+
+多个 agent 人格可以共享同一个 Postgres 实例而不共享记忆。这条边界在
+四个层面强制执行：
+
+1. **数据库行级** —— `semantic.chunks.agent_id`；每条召回路由的 SQL
+   都带有 `WHERE c.agent_id = $X`
+2. **进程内工作集（T0）** —— 以 `<agent_id>::<session_id>` 为键的
+   注册表
+3. **缓存作用域键（T1）** —— `cache.recall.scope_key` 包含
+   `agent:<id>` 前缀
+4. **工具** —— `memory_search` / `memory_store` 从调用会话的会话键中
+   解析出 agent id 并透传
+
+经对抗性探测验证：一个次级 agent 发起 6 次旨在浮现主 agent 记忆块的
+查询，召回结果为 **0**。
+
+---
+
+## 打分
+
+每一次摄入和每一次召回都会向 `audit.*.score` 写入一个 0–100 的综合
+分数。它让仪表盘能够显示“记忆操作健康”或“我们在召回上花费过多”。
+
+### 摄入分数
+
+```
+ingest_score = 100 × (
+    w_tok  × token_efficiency        ; default 0.30, ceiling 1000 tokens
+  + w_lat  × latency_efficiency      ; default 0.20, ceiling 500 ms
+  + w_qual × quality_signal          ; default 0.30
+  + w_path × ingest_path_efficiency  ; default 0.20
+)
+```
+
+`quality_signal` 反映抽取器的置信度；`ingest_path_efficiency` 偏好
+廉价路径（确定性 / 缓存 > LLM 残余）。
+
+### 召回分数
+
+```
+recall_score = 100 × (
+    w_tok  × token_efficiency
+  + w_lat  × latency_efficiency      ; ceiling 200 ms
+  + w_tier × tier_efficiency         ; T0=1.00, T1=0.90, T2_anchor=0.75, T2_hybrid=0.55, T3=0.20
+  + w_rel  × relevance_estimate      ; async-filled from follow-up signals
+)
+```
+
+默认权重可在 `scoring.{ingest,recall}.weights` 中配置。
+
+---
+
+## 自调优循环
+
+三种节奏，全部读取 `audit.*` SQL 视图，并将提案写入
+`audit.tuning_proposals`：
+
+| Cadence | Cost | Auto-apply | Examples |
+|---|---|---|---|
+| Daily (cron 04:00) | 0 LLM, pure SQL | `safe_auto` proposals only | dead trash regex pruning, frequent-reject pattern promotion, cache TTL adjustment |
+| Weekly | 0 LLM, A/B replay | `pending` (review required) | salience threshold calibration, tier capacity changes |
+| Monthly | optional LLM | `pending`, `high_risk` | new structured types emerging, embedding model refresh proposal |
+
+自动应用的变更会写入一行回滚记录；应用后 24 小时的监控会在关键指标
+偏差超过 20% 时回退。
+
+---
+
+## 实时可观测性
+
+PG 触发器在每一行审计记录插入时触发：
+
+```sql
+CREATE TRIGGER ingest_decisions_notify AFTER INSERT ON audit.ingest_decisions
+  FOR EACH ROW EXECUTE FUNCTION audit.notify_event();
+```
+
+仪表盘的 HTTP 服务器持有一个 `LISTEN audit_events` 连接，并向任意 SSE
+客户端重新广播。可以亚秒级地跟踪每一次记忆操作。
+
+---
+
+## Worker
+
+| Worker | Purpose | Trigger |
+|---|---|---|
+| `transcript-watcher` | Tails `<agent>/sessions/*.jsonl` and ingests every conversation turn | Polls every 10s; per-file byte offset persisted in `audit.plugin_meta` |
+| `git-watcher` | Polls a local repo and ingests new commits since `last_sha` | Polls every 1h; `last_sha` persisted |
+| `shadow-comparator` | Replays each turn against a challenger chat endpoint | Polls trajectory file every 30s |
+| `compactor` | 90-day rolling cold-gist consolidation | Runs in the dreaming cycle |
+| `spreading-activator` | Hebbian neighbor warmth bump | Fires async on every T2 recall |
+| `tuning` | Scheduled proposal analyzer | Cron-style (daily / weekly / monthly) |
+| `dashboard` | HTTP + SSE | Long-running |
+
+所有 worker 都通过插件的 `stop()` 钩子支持优雅关闭。
+
+---
+
+## 有意不做的部分
+
+- **不引入重排模型（reranker）**。MMR + 多路叠加已经能让我们达到不错的
+  精度，无需单独的 cross-encoder。如果你的领域需要，可以自行加上。
+- **不引入图遍历语言**。关系（relations）会被存储，但召回不会去遍历
+  它们。架构上已为此预留——可以作为第 9 路加入——但它不在 v0.1 的
+  路线上。
+- **不引入 Redis**。cache.* 各表使用 PG UNLOGGED。如果你做了埋点并
+  观察到缓存争用，替换 `CacheBackend` 实现即可；这一抽象已经就位。
+- **不引入自动 cross-encoder 重排器**。`mmrRerank` 复用自上游
+  OpenClaw，无需额外的模型调用即可提供多样性。

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,5 +1,7 @@
 # nextclaw — configuration reference
 
+**English** · [简体中文](CONFIG.zh-CN.md)
+
 Every config field, default, and tuning advice. Lives under
 `plugins.entries.memory-postgres.config` in your `~/.openclaw/openclaw.json`.
 

--- a/docs/CONFIG.zh-CN.md
+++ b/docs/CONFIG.zh-CN.md
@@ -1,0 +1,386 @@
+# nextclaw — 配置参考
+
+[English](CONFIG.md) · **简体中文**
+
+每一个配置字段、默认值与调优建议。配置位于
+`~/.openclaw/openclaw.json` 中的
+`plugins.entries.memory-postgres.config` 下。
+
+权威的 JSON Schema 定义在 `openclaw.plugin.json` 中；本文档
+与之保持一致，并附带说明。
+
+---
+
+## `postgres`
+
+```jsonc
+"postgres": {
+  "url": "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw",  // required
+  "poolMax": 8,                       // default 8
+  "statementTimeoutMs": 30000         // default 30s
+}
+```
+
+| Field | Default | 说明 |
+|---|---|---|
+| `url` | required | `postgres://user:pass@host:port/db` |
+| `poolMax` | 8 | node-postgres 连接池大小。如果同时运行多个并发摄入源，可调高到 16 以上 |
+| `statementTimeoutMs` | 30000 | 单条语句的耗时上限。对失控查询触发一次干净的中止 |
+
+---
+
+## `embedding`
+
+整个 `embedding` 配置块都是**可选的**。省略它（或传入 `{}`）
+即可使用 Jina 免费层的默认值。设置 `format` 可切换嵌入(embedding)家族；
+其余字段会按各 format 的默认值自动填充。
+
+```jsonc
+"embedding": {
+  "format":     "jina",                          // "jina" (default) | "openai" | "ollama"
+  "provider":   "jina",                          // informational tag, auto-filled from format
+  "model":      "jina-embeddings-v3",            // auto-filled from format
+  "baseUrl":    "https://api.jina.ai",           // auto-filled from format
+  "apiKeyEnv":  "JINA_API_KEY",                  // auto-filled from format
+  "path":       "/v1/embeddings",                // auto-filled from format
+  "dims":       1024,                            // optional; auto-detected on first call
+  "maxEmbedChars": 2000
+}
+```
+
+| Field | Default | 说明 |
+|---|---|---|
+| `format` | `"jina"` | 协议格式（wire format）。`jina` = Jina 的 `/v1/embeddings`，采用非对称的 `task=retrieval.passage\|.query`。`openai` = 标准 `/v1/embeddings`。`ollama` = 本地 `/api/embed` |
+| `provider` | from format | 仅作标签 —— 用于日志记录 |
+| `model` | from format | 随请求体发送。各 format 的默认值：`jina-embeddings-v3` / `text-embedding-3-small` / `qwen3-embedding:4b` |
+| `baseUrl` | from format | 服务端点主机，不含路径。各 format 的默认值：`https://api.jina.ai` / `https://api.openai.com` / `http://127.0.0.1:11434` |
+| `apiKeyEnv` | from format | 持有 Bearer token 的环境变量名（不是其值）。各 format 的默认值：`JINA_API_KEY` / `OPENAI_API_KEY` / （ollama 无） |
+| `path` | from format | 服务端点路径。各 format 的默认值：jina 与 openai 为 `/v1/embeddings`，ollama 为 `/api/embed` |
+| `dims` | 首次调用时自动检测 | 锁定 HNSW 索引的维度。**不重新摄入就无法更改。** |
+| `maxEmbedChars` | 2000 | 在嵌入(embedding)**之前**截断文本。完整文本仍存储在 `chunks.text` 中，可通过 tsvector / trgm 恢复。对长回复可将嵌入延迟降低 50–70%，且召回损失可忽略不计 |
+
+**⚠️ 维度锁定。** HNSW 索引在首次嵌入时记录维度。从
+`jina-embeddings-v3`（1024 维）切换到 `qwen3-embedding:4b`（4096 维）（或任何
+其他维度变更）需要执行：
+```sql
+TRUNCATE semantic.chunks RESTART IDENTITY CASCADE;
+TRUNCATE cache.embeddings;
+DROP INDEX IF EXISTS semantic.chunks_embedding_hnsw;
+```
+……然后重启 gateway。迁移运行器会按新维度重建 HNSW。请将此
+视为每个部署的一次性、不可逆决策。
+
+**零摩擦方案 —— Jina 免费层。** 在 jina.ai/embeddings 获取一个 key，
+执行 `export JINA_API_KEY=...`，然后整个 `embedding` 配置块都省略即可。
+
+**自托管方案 —— Ollama。** 在本地运行 `ollama serve`，然后：
+```jsonc
+"embedding": { "format": "ollama" }
+```
+`model` 默认为 `qwen3-embedding:4b`；可覆盖 `model` 改用更小的模型
+（`qwen3-embedding:0.6b` 提供快速的 1024 维，`nomic-embed-text`
+提供极小的 768 维、偏英文）。
+
+**多主机方案 —— 凭据代理。** 如果你运行了一个仅限 Tailscale、
+服务端注入 API key 的 OpenAI 兼容代理，把端点指向它即可：
+```jsonc
+"embedding": {
+  "format": "openai",
+  "baseUrl": "http://100.79.97.110:8800/v1/proxy/local-embed",
+  "model": "qwen3-embedding:0.6b"
+}
+```
+
+---
+
+## `tiers`
+
+```jsonc
+"tiers": {
+  "t0SizeLimit": 50,
+  "t1SizeLimit": 500,
+  "t1TtlDays": 7,
+  "warmthDecayHalflife": 14,
+  "promotionThreshold": 2,
+  "primeOnSessionStart": true
+}
+```
+
+| Field | Default | 说明 |
+|---|---|---|
+| `t0SizeLimit` | 50 | 每会话进程内 LRU 上限 |
+| `t1SizeLimit` | 500 | 每个 `user_scope` 在 `cache.hot_chunks` 中的软上限；写入时淘汰较旧的条目 |
+| `t1TtlDays` | 7 | 超过此天数的热记忆块(chunk)回落到 T2 |
+| `warmthDecayHalflife` | 14 days | 两次召回之间 warmth_score 衰减的半衰期 |
+| `promotionThreshold` | 2 | 晋升到 T1 前需达到的 T2 命中次数 |
+| `primeOnSessionStart` | true | 会话开始时用与锚点相关的记忆块(chunk)预热 T0 |
+
+**调优**：对于单次会话中浮现大量不同话题的长上下文对话，
+可将 `t0SizeLimit` 调高到 100 以上。
+
+---
+
+## `dashboard`
+
+```jsonc
+"dashboard": {
+  "enabled": true,
+  "host": "127.0.0.1",
+  "port": 8765,
+  "tokenEnv": "NEXTCLAW_DASH_TOKEN"
+}
+```
+
+| Field | Default | 说明 |
+|---|---|---|
+| `enabled` | false | 默认关闭，除非显式开启 |
+| `host` | `127.0.0.1` | 仅环回地址。设为其他值属于刻意为之 |
+| `port` | 8765 | |
+| `tokenEnv` | none | 持有仪表盘 token 的环境变量名。当 `host` 不是环回地址时**必填** |
+
+**安全**：在没有 token 的情况下，nextclaw 拒绝将仪表盘公开暴露。
+如需远程访问，请使用 Tailscale / Cloudflare Tunnel /
+SSH 隧道，并保持 `host: 127.0.0.1`，**切勿**使用 `0.0.0.0`。
+
+---
+
+## `transcriptWatchers[]`
+
+```jsonc
+"transcriptWatchers": [{
+  "id": "agent-main",                 // required, stable
+  "agentId": "main",                  // default "main"
+  "dir": "~/.openclaw/agents/main/sessions",  // required
+  "intervalMs": 10000,                // min 5000
+  "source": "session",                // label prefix
+  "maxBytesPerTick": 262144,          // 256 KiB cap per file per tick
+  "firstRunBackfillBytes": 65536,     // 64 KiB on first run
+  "defaultImportance": 0.35,
+  "dropPureQuestions": true,
+  "anchors": { "cwd": "...", "branch": "..." }  // static anchors merged into every ingest
+}]
+```
+
+`agentId` 控制记忆命名空间的隔离 —— 由该 watcher 摄入的记忆块(chunk)
+会将 `agent_id` 设为此值。查询时按相同的 agent id 过滤即可检索到它们；
+跨 agent 的查询在物理上无法访问。
+
+`firstRunBackfillBytes`：在首次轮询某个会话文件时（没有持久化的偏移量），
+向前回溯读取多少字节。可避免 watcher 首次启动时把整段历史记录
+灌入记忆。设为 `0` 可完全禁用回填(backfill)。
+
+`dropPureQuestions`：跳过整条内容都是问句的用户消息
+（以 `?` 或 吗/呢/嘛 结尾）。这很有用，因为纯问句
+很少包含可长期保留的事实。
+
+---
+
+## `gitWatchers[]`
+
+```jsonc
+"gitWatchers": [{
+  "id": "openclaw-main",
+  "path": "/home/me/openclaw",
+  "branch": "main",
+  "remote": "origin",
+  "intervalMs": 3600000,              // 1h
+  "source": "git",
+  "anchors": { "cwd": "/home/me/openclaw", "branch": "main" }
+}]
+```
+
+每隔 `intervalMs` 轮询本地仓库，摄入自 `last_sha`（持久化在
+`audit.plugin_meta` 中）以来的新提交。会先执行 `git fetch`；
+请确保守护进程的运行用户对该仓库及其远程拥有读取权限。
+
+---
+
+## `shadowComparators[]`
+
+```jsonc
+"shadowComparators": [{
+  "id": "qwen-vs-gpt",
+  "trajectoryDir": "~/.openclaw/agents/main/sessions",
+  "baseUrl": "http://127.0.0.1:8000",
+  "model": "Qwen3-32B-Instruct",
+  "apiKeyEnv": "QWEN_API_KEY",        // optional
+  "intervalMs": 30000,                // min 10s
+  "backfillWindowMs": 86400000,       // 24h
+  "maxOutputTokens": 400,
+  "requestTimeoutMs": 90000,
+  "minUserMessageChars": 4
+}]
+```
+
+对于在 `<agent>/sessions/*.trajectory.jsonl` 中观察到的每一个 gpt 回合，
+将同一条 prompt 重放到这个挑战者端点，并把双方结果存入
+`audit.model_comparisons`。为仪表盘的 “Model
+Comparison”（模型对比）面板提供数据。
+
+---
+
+## `sidecar`
+
+```jsonc
+"sidecar": {
+  "enabled": true,
+  "triggers": {
+    "minUserMessageChars": 50,
+    "onWriteTools": true,
+    "onNumericMention": true,
+    "onExplicitRemember": true
+  },
+  "consecutiveBadJsonDisableCount": 5
+}
+```
+
+sidecar(旁路) 的 prompt 构建器会要求 agent 在回合结束时输出一个结构化的
+`<mem>{entities, events, preferences, metrics}</mem>` 块。插件随后解析它
+（第 2 阶段）并将结构化的数据行直接喂给抽取环节 ——
+在结构化这一遍上零 LLM 成本。
+
+当连续出现 `consecutiveBadJsonDisableCount` 个格式错误的 JSON 时，
+自动停用 7 天。
+
+---
+
+## `gates`
+
+```jsonc
+"gates": {
+  "salience": { "minImportance": 0.35, "model": "qwen3-instruct:7b" },
+  "extractor": { "minConfidence": 0.7, "quarantineBelow": true },
+  "perSourceOverrides": {
+    "manual":  { "skipGates": true },
+    "session": { "minImportance": 0.6 },
+    "dream":   { "minImportance": 0.4 }
+  },
+  "trashRegexes": ["^\\s*$", "^(I'll|Let me)..."]
+}
+```
+
+第 4 阶段的 LLM 残差路径。几乎所有人都会把它关掉（不做
+残差 LLM 调用）。如果你想启用，可将 `salience.model` 设为一个廉价的本地模型。
+
+---
+
+## `recall`
+
+```jsonc
+"recall": {
+  "intentModel": "qwen3-instruct:7b",  // optional, used only if intent classification is on
+  "totalK": 24,
+  "cacheRecallTtlSec": 300,
+  "cacheIntentTtlSec": 3600
+}
+```
+
+| Field | Default | 说明 |
+|---|---|---|
+| `totalK` | 24 | MMR 重排后的 Top-k |
+| `cacheRecallTtlSec` | 300 | T1 cache.recall 的 TTL（5 分钟）。如果你的数据更新频繁，可调低 |
+| `cacheIntentTtlSec` | 3600 | 意图分类缓存的 TTL |
+
+---
+
+## `compaction`
+
+```jsonc
+"compaction": {
+  "enabled": true,
+  "minAgeDays": 90,
+  "minClusterSize": 5,
+  "runDuringDeepDream": true
+}
+```
+
+冷数据要点（cold-gist）合并。将满足以下条件的记忆块(chunk)聚为一类：
+存在 90 天以上、共享 concept_tags / entities、且未被固定（pin）。
+用 `cold.gists` 中的单条要点摘要替换它们；原始记忆块(chunk)被标记为
+`retention='ephemeral'`，但为保留来源（`provenance`）会再留存 30 天。
+
+---
+
+## `retention`
+
+```jsonc
+"retention": {
+  "ephemeralAfterDays": 90,
+  "neverDecayPinned": true
+}
+```
+
+冷数据要点（cold-gist）合并运行后，ephemeral 记忆块(chunk)在此窗口
+之后成为真正删除的候选。被固定（pin）的记忆块(chunk)（含所有
+健康/医疗类）永远不会被自动删除。
+
+---
+
+## `scoring`
+
+```jsonc
+"scoring": {
+  "ingest": {
+    "weights": { "token": 0.30, "latency": 0.20, "quality": 0.30, "path": 0.20 },
+    "tokenBudgetCeiling": 1000,
+    "latencyBudgetMs": 500
+  },
+  "recall": {
+    "weights": { "token": 0.25, "latency": 0.25, "tier": 0.25, "relevance": 0.25 },
+    "tokenBudgetCeiling": 500,
+    "latencyBudgetMs": 200,
+    "relevanceFollowupWindowMs": 3600000
+  }
+}
+```
+
+0–100 综合评分公式。默认权重是针对
+“摄入大多廉价、召回应当快速” 这类工作负载调优的。如果你的
+优先级不同，可自行调整（例如，若想对低置信度的抽取施加更重的
+惩罚，可调高 `quality` 的权重）。
+
+---
+
+## `tuning`
+
+```jsonc
+"tuning": {
+  "autoApplyEnabled": false,
+  "scopes": {
+    "trash_regex": "auto",       // safe_auto: dead regex pruning, etc.
+    "salience_threshold": "review",
+    "tier_capacity": "review",
+    "embedding_model": "manual"
+  }
+}
+```
+
+自调优循环针对每个 scope 的应用策略。默认值偏
+保守；在你设置 `autoApplyEnabled: true` 之前，不会有任何项被
+自动应用。
+
+---
+
+## 顶层结构
+
+```jsonc
+{
+  "postgres": { ... },        // required
+  "embedding": { ... },       // required
+  "tiers": { ... },           // optional
+  "dashboard": { ... },       // optional
+  "transcriptWatchers": [],   // optional
+  "gitWatchers": [],          // optional
+  "shadowComparators": [],    // optional
+  "sidecar": { ... },         // optional
+  "gates": { ... },           // optional
+  "recall": { ... },          // optional
+  "compaction": { ... },      // optional
+  "retention": { ... },       // optional
+  "scoring": { ... },         // optional
+  "tuning": { ... }           // optional
+}
+```
+
+凡是不在此列表中的项，都会在配置加载时被
+`openclaw.plugin.json` 中的 JSON Schema 拒绝。

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,7 @@
 # nextclaw — 0 → 1 installation walkthrough
 
+**English** · [简体中文](INSTALL.zh-CN.md)
+
 This is the **fresh-machine** guide. If you already have OpenClaw + an
 embedding endpoint running, jump to step ④.
 

--- a/docs/INSTALL.zh-CN.md
+++ b/docs/INSTALL.zh-CN.md
@@ -1,0 +1,644 @@
+# nextclaw —— 从 0 到 1 安装实战
+
+[English](INSTALL.md) · **简体中文**
+
+这是一份**全新机器**上的安装指南。如果你已经跑起了 OpenClaw 和一个嵌入服务端点（embedding endpoint），可以直接跳到步骤 ④。
+
+已在 Ubuntu 24.04 和 macOS 14 上测试通过。理论上凡是 OpenClaw 安装脚本能跑起来的主机都适用（Linux、macOS、Windows-WSL）。Postgres 既可以用云端（Neon —— 零本地依赖），也可以用本地（Docker）。预计耗时：走 Neon 的「纯记忆」路线约 **15 分钟**；如果还想加上 Telegram Moderator 和 `web_search`，再多花 **15 分钟**。
+
+> 📦 **动手之前：请先看 [SERVICES.zh-CN.md](SERVICES.zh-CN.md)** —— 那里列出了 nextclaw 可以接入的全部外部服务（Postgres、Jina、Gemini、Tavily、Telegram、OpenAI、credbroker），附带注册链接和每个服务对应的验证命令。本文假设你已经想清楚自己要用哪些服务。
+
+### 能力等级（开始前先选一个）
+
+| 等级 | 能用什么 | 需要的外部服务 | 预计耗时 |
+|---|---|---|---|
+| **A. 纯记忆** | 召回、摄入、仪表盘、隔离 | Postgres + Jina | 10 分钟 |
+| **B. + 反思（Reflection）** | 在 A 的基础上加每晚记忆整合 | Postgres + Jina + Gemini | 15 分钟 |
+| **C. + Telegram Moderator** | 在上面基础上加群内 `@bot` 应答 | Postgres + Jina + Gemini + Telegram bot | 30 分钟 |
+| **D. + 网页搜索** | 在上面基础上加 worker 的 `web_search`，用于获取实时信息 | Postgres + Jina + Gemini + Telegram + Tavily | 35 分钟 |
+
+本文**先把等级 A 搭起来**，B/C/D 则做成可选附加（bolt-on）的章节，你可以之后再做。
+
+---
+
+## ① 安装 OpenClaw
+
+nextclaw 是 [OpenClaw](https://github.com/openclaw/openclaw) 的一个*插件*，而不是独立程序。先装好 OpenClaw；它自带 Node 运行时，所以没有额外的前置依赖。
+
+```bash
+# macOS / Linux — one-line installer
+curl -fsSL https://openclaw.ai/install.sh | bash
+
+# Windows (PowerShell):
+#   iwr -useb https://openclaw.ai/install.ps1 | iex
+
+# Run the onboarding wizard (installs the gateway as a launchd/systemd user service)
+openclaw onboard --install-daemon
+```
+
+验证：
+
+```bash
+openclaw --version    # should print 2026.x.x
+openclaw doctor       # should mostly pass; warnings about disabled bundled plugins are fine
+```
+
+> 引导向导会生成 `~/.openclaw/openclaw.json`，里面带有一套合理的默认配置（网关 gateway、认证 profile、agent 工作区）。我们会在步骤 ⑤ 里把 nextclaw 的插件条目**追加**进这个文件 —— 切勿覆盖它。
+
+---
+
+## ② 启动 Postgres + pgvector
+
+二选一：**选项 A（Neon，云端，零本地依赖）** 或 **选项 B（Docker，本地）**。两条路都会产出一个 `PG_URL` 环境变量，本指南后续都会用到它。
+
+### 选项 A —— Neon（推荐，免费 0.5 GB，无需信用卡）
+
+1. 打开 <https://neon.tech> → 用 GitHub **Sign up** → **Create project**
+2. 复制创建完成后显示的连接串，例如 `postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require`
+3. 在 Neon 的 **SQL Editor** 标签页里粘贴并运行：
+
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS vector;
+   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+   CREATE EXTENSION IF NOT EXISTS btree_gin;
+   ```
+
+4. 导出它：
+
+   ```bash
+   export PG_URL="postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require"
+   ```
+
+> Neon 会自动挂起（suspend）空闲的数据库。长时间空闲后的第一次召回可能要等 ~1–2 秒，等计算实例唤醒；之后的召回又会恢复到正常速度。
+
+### 选项 B —— Docker（本地，完全可控）
+
+```bash
+docker run -d --name nextclaw-pg --restart unless-stopped \
+  -e POSTGRES_USER=nextclaw -e POSTGRES_PASSWORD=nextclaw -e POSTGRES_DB=nextclaw \
+  -p 127.0.0.1:55432:5432 -v nextclaw_pg:/var/lib/postgresql/data \
+  pgvector/pgvector:pg16
+
+# Wait for PG, then install the three extensions
+until docker exec nextclaw-pg pg_isready -U nextclaw >/dev/null 2>&1; do sleep 1; done
+docker exec nextclaw-pg psql -U nextclaw -d nextclaw -c \
+  "CREATE EXTENSION IF NOT EXISTS vector;
+   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+   CREATE EXTENSION IF NOT EXISTS btree_gin;"
+
+export PG_URL="postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw"
+```
+
+两条路都用下面这条命令验证：
+
+```bash
+psql "$PG_URL" -c "SELECT extname FROM pg_extension WHERE extname IN ('vector','pg_trgm','btree_gin');"
+# Should list all three. (Install psql via `brew install libpq` or `apt-get install postgresql-client` if missing.)
+```
+
+> Docker 容器只绑定在宿主机的 **127.0.0.1:55432** 上，绝不会暴露到公网接口。数据卷 `nextclaw_pg` 会在容器重启后持久保留。想清空重来：`docker rm -f nextclaw-pg && docker volume rm nextclaw_pg`。
+
+---
+
+## ③ 准备一个嵌入服务端点
+
+**默认方案：Jina 免费档 —— 30 秒搞定，无需信用卡、无需 GPU。**
+
+1. 打开 [jina.ai/embeddings](https://jina.ai/embeddings/)，点击 "Get API key for free"
+2. 复制密钥并导出：
+
+```bash
+export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+就这么简单。验证：
+
+```bash
+curl -sS https://api.jina.ai/v1/embeddings \
+  -H "Authorization: Bearer $JINA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"jina-embeddings-v3","input":["hello"]}' | head -c 200
+# Should return JSON with a "data": [{ "embedding": [...] }] array
+```
+
+`jina-embeddings-v3` 是 1024 维、多语言的（中文支持很好），免费档每个密钥覆盖 100 万 token（按典型聊天用量算约等于 500 天）。当配置里省略 `embedding` 块时，插件默认就用它。
+
+> ⚠️ **嵌入维度是单向的，无法回头。** 它会在首次摄入时被自动检测，并锁进 HNSW 索引。要从 `jina-embeddings-v3`（1024 维）切换到 `qwen3-embedding:4b`（4096 维），就必须执行 `TRUNCATE semantic.chunks RESTART IDENTITY CASCADE` 并把所有内容重新摄入一遍。所以请挑一个你未来几个月都能接受的模型。
+
+### 备选方案：用 Ollama 自托管（无需 API，完全可控）
+
+如果你更想把嵌入模型跑在本地 —— 隐私更好、没有速率限制，但需要 ~1–4 GB 的内存/显存：
+
+```bash
+# Linux (one-liner installer)
+curl -fsSL https://ollama.com/install.sh | sh
+# macOS: download from https://ollama.com (or: brew install ollama)
+
+ollama serve &                          # background, listens on 127.0.0.1:11434
+ollama pull qwen3-embedding:0.6b        # ~1 GB, multilingual, recommended
+# or:  ollama pull nomic-embed-text     # ~274 MB, English-leaning
+```
+
+然后在 embedding 块里写上 `"format": "ollama"`（其余字段都会从该格式的默认值里自动补齐）。详见 [`docs/CONFIG.md#embedding`](CONFIG.zh-CN.md#embedding)。
+
+### 备选方案：Tailscale 凭据中转（私有集群、多主机）
+
+如果你在一个 Tailscale tailnet 上跑多个 agent，并且希望调用方主机上一个 API 密钥都不存，那就把端点指向你信任的 mainserver 上的一个 OpenAI 兼容代理。示例（把 IP / 端口换成你自己的）：
+
+```jsonc
+"embedding": {
+  "format": "openai",
+  "baseUrl": "http://100.79.97.110:8800/v1/proxy/local-embed",
+  "model": "qwen3-embedding:0.6b"
+  // apiKeyEnv omitted — broker authenticates via tailnet identity
+}
+```
+
+---
+
+## ④ 把 nextclaw 装进 OpenClaw
+
+OpenClaw 的插件加载器可以直接从本仓库拉取插件。`package.json` 里的 `prepare` 脚本会在 `npm install` 期间自动构建，所以等安装完成时，编译产物已经就绪。
+
+```bash
+openclaw plugins install git:github.com/NextAgentBC/nextclaw
+
+# Optional: pin to a specific tag for reproducibility
+# openclaw plugins install git:github.com/NextAgentBC/nextclaw@v0.2.0
+```
+
+验证：
+
+```bash
+openclaw plugins list | grep memory-postgres
+# Should show:  memory-postgres  enabled  global:memory-postgres/dist/index.js  0.2.0
+```
+
+> 无论你从哪里安装，插件的 id 永远是 **`memory-postgres`** —— 这正是你在 `openclaw.json` 的 `plugins.slots.memory` 和 `plugins.entries` 里要引用的那个键。npm 包名和仓库名（"nextclaw"）都跟 manifest 里的 id 无关。
+
+> **其他安装来源**（都会产出同一个 `memory-postgres` id）：
+>
+> | 来源 | 命令 | 何时使用 |
+> |---|---|---|
+> | npm（即将上线） | `openclaw plugins install npm:@nextagentbc/nextclaw` | 一旦以带作用域的名字发布到 npm 后 |
+> | ClawHub（即将上线） | `openclaw plugins install clawhub:memory-postgres` | 在 OpenClaw 官方 hub 上架之后 |
+> | 本地 checkout | `git clone … && openclaw plugins install --link ./nextclaw` | 想改插件本身时 —— 软链接方式，直接从 `.ts` 源码运行 |
+> | 本地 tarball | `openclaw plugins install npm-pack:./nextclaw-0.2.0.tgz` | 隔离网络 / 离线安装 |
+
+---
+
+## ⑤ 配置 `~/.openclaw/openclaw.json`
+
+步骤 ① 里的 `openclaw onboard` 已经写好了这个文件，里面有 `gateway`、`agents`、`auth` 等等。你需要做的是把 nextclaw 的插件条目**合并**进去，同时不打扰其他任何内容。
+
+### 最快：用自带的辅助脚本（安全合并）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NextAgentBC/nextclaw/main/scripts/configure-minimal.mjs |
+  PG_URL="$PG_URL" node --input-type=module
+```
+
+它只会精确地加两个键：
+
+- `plugins.slots.memory = "memory-postgres"`
+- `plugins.entries["memory-postgres"]`，包含你的 `postgres.url` 和一个默认的 dashboard 块
+
+文件里的其他每一个键都会逐字节原样保留。
+
+### 手动：自己编辑
+
+用编辑器打开 `~/.openclaw/openclaw.json`。在已有的 `plugins.entries` 对象下，加入：
+
+```jsonc
+"memory-postgres": {
+  "enabled": true,
+  "config": {
+    "postgres": { "url": "<your PG_URL>" },
+    "dashboard": { "enabled": true, "tokenEnv": "NEXTCLAW_DASH_TOKEN" }
+  }
+}
+```
+
+再在 `plugins.slots` 下加上（或设置）`"memory": "memory-postgres"`。embedding 块是可选的 —— 省略时默认使用 Jina 免费档，并从环境变量里读取 `JINA_API_KEY`。
+
+### 更贴近实战的配置 —— 开启仪表盘、对话记录监听器、每晚反思
+
+如果想要一套更接近生产环境的配置，完整的 `memory-postgres.config` 长这样（把 `configure-minimal.mjs` 生成的那个值粘贴替换掉）：
+
+```jsonc
+"memory-postgres": {
+  "enabled": true,
+  "config": {
+    "postgres": { "url": "<your PG_URL>" },
+
+    // Embedding block is OPTIONAL — defaults to Jina free-tier.
+    // Uncomment + edit to swap to ollama / openai / proxy:
+    // "embedding": { "format": "ollama" },
+
+    "tiers": {
+      "t0SizeLimit": 50,
+      "t1SizeLimit": 500,
+      "t1TtlDays": 7,
+      "primeOnSessionStart": true
+    },
+    "dashboard": {
+      "enabled": true,
+      "host": "127.0.0.1",
+      "port": 8765,
+      "tokenEnv": "NEXTCLAW_DASH_TOKEN"
+    },
+    "transcriptWatchers": [{
+      "id": "agent-main",
+      "agentId": "main",
+      "dir": "~/.openclaw/agents/main/sessions",
+      "intervalMs": 10000,
+      "defaultImportance": 0.35
+    }]
+    // For nightly reflection see the bolt-on section below.
+  }
+}
+```
+
+> 如果你的 OpenClaw 构建不会自动展开 `~`，请把它换成你的绝对 home 路径（Linux 上是 `/home/<you>`，macOS 上是 `/Users/<you>`）。
+
+---
+
+## ⑥ 配置工作区人格文件（可选但推荐）
+
+OpenClaw 会把 agent 工作区里的 markdown 加载进系统提示词。没有这些文件，agent 就没有人格。
+
+```bash
+mkdir -p ~/.openclaw/workspace
+cat > ~/.openclaw/workspace/SOUL.md <<'EOF'
+You are a long-memory AI assistant.
+- Direct answers; skip pleasantries
+- Be honest about uncertainty
+- Use memory_search before answering questions about past conversations
+EOF
+
+cat > ~/.openclaw/workspace/IDENTITY.md <<'EOF'
+- Name: <pick one>
+- Vibe: helpful, precise, long-termist
+EOF
+
+cat > ~/.openclaw/workspace/USER.md <<'EOF'
+- Name: <your name>
+- Email: <your email>
+- Preferences: <how you want to be addressed, language, etc>
+EOF
+```
+
+> AGENTS.md 随 OpenClaw 一起提供，告诉 agent 总体上该怎么表现。SOUL.md / IDENTITY.md / USER.md 则是每个用户自己的定制。如果你跳过这一步，bot 仍然能用，只是人格比较通用。
+
+---
+
+## ⑦ 启动，然后用冒烟测试验证
+
+```bash
+# Generate a dashboard token (any random string)
+export NEXTCLAW_DASH_TOKEN=$(openssl rand -hex 24)
+
+# Persist for the daemon (launchd/systemd does NOT read ~/.zshrc — it sources
+# ~/.openclaw/service-env/ai.openclaw.gateway.env on each start).
+# Same file should also hold JINA_API_KEY so the embedding client can run.
+ENV_FILE=~/.openclaw/service-env/ai.openclaw.gateway.env
+grep -q '^export JINA_API_KEY=' "$ENV_FILE" 2>/dev/null \
+  || echo "export JINA_API_KEY=$JINA_API_KEY" >> "$ENV_FILE"
+echo "export NEXTCLAW_DASH_TOKEN=$NEXTCLAW_DASH_TOKEN" >> "$ENV_FILE"
+
+# Persist for this shell too (for the smoke-test curls below)
+echo "export NEXTCLAW_DASH_TOKEN=$NEXTCLAW_DASH_TOKEN" >> ~/.zshrc
+
+# Restart the gateway daemon so it picks up the new plugin + config
+openclaw gateway restart
+```
+
+首次启动时，迁移执行器会应用插件自带的所有 DDL 文件（位于 `<install-path>/dist/src/storage/schema/*.sql`；确切的安装路径因环境而异 —— 运行 `openclaw plugins list | grep memory-postgres` 即可看到）。留意这几行：
+
+```
+memory-postgres: capability + tools registered (memory_search, memory_store, dashboard, ...)
+memory-postgres: transcript-watcher started — id=agent-main ...
+http server listening
+```
+
+### 冒烟测试 1 —— 通过通用 HTTP 网关写入 + 召回
+
+仪表盘 API 通过 **`X-Token`** 请求头（或 `?token=` 查询参数）来鉴权。浏览器仪表盘会把 `?token=…` 捕获进 `sessionStorage`，并在之后每次请求里以 `X-Token` 的形式带上。
+
+```bash
+# Write
+curl -sS -X POST http://127.0.0.1:8765/api/ingest \
+  -H "X-Token: $NEXTCLAW_DASH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"My favorite Postgres extension is pgvector.","source":"smoke","agentId":"main"}' \
+  | python3 -m json.tool
+
+# Recall
+curl -sS -X POST http://127.0.0.1:8765/api/recall \
+  -H "X-Token: $NEXTCLAW_DASH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"What is my favorite Postgres extension?","agentId":"main"}' \
+  | python3 -m json.tool
+```
+
+召回应当返回带 `hitTier: "t2_hybrid"` 的那个记忆块（chunk）。5 分钟内再次发起完全相同的召回会命中 `t1` 缓存（~1ms）。
+
+### 冒烟测试 2 —— 打开仪表盘
+
+```
+http://127.0.0.1:8765/?token=$NEXTCLAW_DASH_TOKEN
+```
+
+token 会被捕获到 `sessionStorage`，并在后续 fetch 里以 `X-Token` 形式转发。你应该会看到：
+
+- KPI：过去 24 小时内 1 次摄入、1 次召回
+- 实时事件流：2 条事件（1 次摄入、1 次召回）
+- 最近摄入表：你刚刚写入的那个 chunk
+- 最近召回表：你刚刚发起的那个查询
+
+如果有任何面板是空的，看文末的**故障排查**。
+
+---
+
+## ⑧ 加一个 Discord bot（可选）
+
+如果你想要一个聊天 bot 前端，而不只是 HTTP API：
+
+### 8.1 创建 Discord 应用
+
+1. 打开 https://discord.com/developers/applications → **New Application**
+2. Bot 标签页 → **Reset Token** → 保存 token（只显示这一次）
+3. Privileged Gateway Intents → 启用 **Message Content Intent**
+4. OAuth2 → URL Generator → 勾选 `bot` scope；权限勾选 View Channel、Send Messages、Read Message History → 把 bot 邀请到你的服务器
+
+### 8.2 拿到你需要的几个 ID
+
+在 Discord 客户端里 → User Settings → Advanced → **Developer Mode: ON**。然后右键 → **Copy ID**，分别复制：
+
+- 你把 bot 邀请进去的那个服务器（guild）
+- 你想让它应答的那个频道
+
+### 8.3 接入 `openclaw.json`
+
+```jsonc
+{
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "token": "<your bot token>",
+      "groupPolicy": "allowlist",
+      "allowFrom": ["*"],
+      "allowBots": "mentions",
+      "guilds": {
+        "<your guild id>": {
+          "slug": "my-server",
+          "requireMention": true,
+          "ignoreOtherMentions": true,
+          "channels": {
+            "<your channel id>": { "enabled": true }
+          }
+        }
+      }
+    }
+  },
+  "bindings": [
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "discord",
+        "guildId": "<your guild id>",
+        "peer": { "kind": "channel", "id": "<your channel id>" }
+      }
+    }
+  ]
+}
+```
+
+> `groupPolicy: "allowlist"` 加 `allowFrom: ["*"]` 的意思是：在列出的 guild 里，**任何用户**都能跟 bot 对话。想收紧，就把 `"*"` 换成具体的 Discord 用户 ID。
+
+> `requireMention: true` 意味着只有被显式 @ 提及时 bot 才会应答。如果你想让**其他** bot（比如一个 Linux IRC 桥接 bot）也能 @ 它，就配合 `allowBots: "mentions"` 一起用。
+
+重启网关，进你的 Discord 频道，**@你的-bot hi**，然后看着仪表盘亮起来。
+
+---
+
+## ⑨ 多 agent 硬隔离（可选）
+
+如果你想要一个面向公众的 agent（比如一个社区 Discord），并且让它**物理上无法**看到你的私有记忆：
+
+```jsonc
+{
+  "agents": {
+    "list": [
+      { "id": "main", "default": true, "workspace": "~/.openclaw/workspace" },
+      { "id": "club", "workspace": "~/.openclaw/workspace-club" }
+    ]
+  },
+  "bindings": [
+    {
+      "agentId": "club",
+      "match": {
+        "channel": "discord",
+        "guildId": "<public-guild-id>",
+        "peer": { "kind": "channel", "id": "<public-channel-id>" }
+      }
+    }
+  ],
+  "plugins": {
+    "entries": {
+      "memory-postgres": {
+        "config": {
+          "transcriptWatchers": [
+            { "id": "agent-main", "agentId": "main", "dir": "~/.openclaw/agents/main/sessions" },
+            { "id": "agent-club", "agentId": "club", "dir": "~/.openclaw/agents/club/sessions" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+再建一个独立的工作区目录 + 人格文件：
+
+```bash
+mkdir -p ~/.openclaw/workspace-club ~/.openclaw/agents/club/sessions
+# Create SOUL.md / IDENTITY.md (no USER.md — public agent shouldn't know your private info)
+```
+
+验证 —— club agent 的 `agent_id='club'` 记忆块在每一条召回路径上都会被 SQL 层过滤。一句 `WHERE c.agent_id = $X` 条件能挡住跨 agent 的读取，哪怕提示词是恶意构造的也一样。完整的隔离模型见 [ARCHITECTURE.zh-CN.md](ARCHITECTURE.zh-CN.md)。
+
+---
+
+## 可选附加：每晚反思（等级 B）
+
+反思守护进程会读取最近 24 小时的对话记忆块，写出一个蒸馏后的 `kind='reflection'` 汇总块，外加一组 `kind='profile'`，后者会在每次召回时被预热（prime）进 T0（模型的工作记忆）。效果是：长时间运行的上下文能跨天存活，而不必把历史一遍遍重新喂进提示词。
+
+**前置条件：** 一个 LLM 端点。免费推荐：**Gemini 2.5 Flash** —— 见 [SERVICES.zh-CN.md §3](SERVICES.zh-CN.md#3-gemini-google-ai-studio--free-llm-for-moderator--reflection)。
+
+```bash
+# Get a Gemini key from https://aistudio.google.com/apikey
+export GEMINI_API_KEY=AIza...
+```
+
+在 `openclaw.json` 的 `memory-postgres.config` 下加入：
+
+```jsonc
+"reflection": {
+  "enabled": true,
+  "intervalMs": 86400000,
+  "lookbackHours": 24,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+重启 OpenClaw。在日志里验证：
+
+```
+memory-postgres: reflection daemon started — format=gemini model=gemini-2.5-flash intervalMs=86400000
+```
+
+第一次反思会在启动约 24 小时后运行。想提前强制跑一次，手动调用仪表盘端点（需要 token）：
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8765/api/reflection/run-now" \
+  -H "X-Token: $NEXTCLAW_DASH_TOKEN"
+```
+
+---
+
+## 可选附加：Telegram Moderator（等级 C）
+
+Moderator（群消息编排器）是一个有自己一套主张的 orchestrator-worker（编排器-worker）：它会把 Telegram 群里的 `@-提及` 从 codex（或其他本来会应答的东西）那里**抢过来**，然后跑一套多步决策循环：
+
+1. 缓存预检（L0/L1/L2）—— 重复问题在 <50ms 内应答，且 0 LLM token 消耗
+2. Moderator 决策 —— gpt-5.5 / gemini-flash 选出 `answer-direct` / `clarify` / `escalate` 等动作
+3. worker 派发 —— 专职角色 + memory_search +（可选）web_search
+4. 通过 Telegram Bot API 回复 —— 先发一个占位的 ⏳，答案就绪后再编辑成正式内容
+5. 把答案写回 cache.qa，这样下一个类似问题就能命中预检
+
+私聊（DM）**不会**被抢 —— 仍由 codex 像以前一样处理。
+
+**前置条件：**
+1. **Telegram bot token** —— 从 [@BotFather](https://t.me/BotFather) 获取，见 [SERVICES.zh-CN.md §4](SERVICES.zh-CN.md#4-telegram-bot--required-for-moderator)
+2. **你的 Telegram 用户 ID** —— 从 [@userinfobot](https://t.me/userinfobot) 获取
+3. **LLM 端点**（推荐 Gemini，跟反思用同一个密钥就行）
+
+```bash
+# Already have these from Level B; just adding the Telegram pieces:
+export GEMINI_API_KEY=AIza...
+TELEGRAM_BOT_TOKEN=1234567890:AAH...   # not exported — goes inline in config
+TELEGRAM_OWNER_ID=8064984663            # YOUR Telegram user id from @userinfobot
+```
+
+在 `openclaw.json` 里加入（顶层，与 `plugins` 平级）：
+
+```jsonc
+"channels": {
+  "telegram": {
+    "enabled": true,
+    "botToken": "1234567890:AAH...",
+    "polling": { "enabled": true }
+  }
+},
+"commands": {
+  "ownerAllowFrom": ["telegram:8064984663"]
+}
+```
+
+再在 `memory-postgres.config` 下加入：
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "agentId": "main",
+  "debounceMs": 1500,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+**在 Oracle Cloud / IPv6 有问题的主机上，设置 IPv6 兜底开关**：见 [docs/CONFIG.zh-CN.md](CONFIG.zh-CN.md#telegram-on-ipv6-broken-hosts) —— 在 systemd drop-in 里加上 `OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY=1`。
+
+重启 OpenClaw。把你的 bot 加进一个 Telegram 群。发送 `@my_tutor_bot hello`。观察：
+
+```bash
+journalctl --user -u openclaw-gateway --since "1 min ago" | grep -E "moderator|before_dispatch"
+```
+
+你应该会看到 `[moderator/hook] before_dispatch CLAIMED`，紧接着是 `moderator: scope=tg:chat:... action=answer-direct`。bot 会先回一个占位的 ⏳，然后是真正的答案。
+
+**常见坑：** 群里的 Telegram bot 默认只能看到**@ 它**或**回复它消息**的那些消息（默认隐私模式）。这恰好就是 Moderator 想要的。除非你想让 Moderator 处理群里的每一条消息，否则**不要**去用 `/setprivacy` → Disable。
+
+---
+
+## 可选附加：web_search worker 工具（等级 D）
+
+没有它，worker 只能靠记忆 + LLM 训练数据来回答，并会表示自己无法上网查实时信息（新闻、最新版本号，以及任何时效性内容）。接入 Tavily 后，worker 的工具调用循环里就解锁了实时网页搜索。
+
+**已经配好了 OpenClaw 的 tavily 插件？**（判断方法：`openclaw doctor` 里提到了 tavily，或者你在启动日志里看到 `tavily web search provider selected`）那就**完事了**。nextclaw 的 Moderator worker 会自动复用 `plugins.entries.tavily.config.webSearch.apiKey` 里那把同样的 Tavily 密钥。不用环境变量，也不用额外配置。
+
+**第一次接 Tavily？** 见 [SERVICES.zh-CN.md §5](SERVICES.zh-CN.md#5-tavily--web-search-for-the-moderators-web_search-tool) —— 免费每月 1,000 次搜索。推荐做法：把密钥放进 `plugins.entries.tavily.config.webSearch.apiKey`，这样 codex 和 Moderator worker 就能共用同一份凭据。
+
+**重启后验证：** 问 bot 一些实时的东西，比如 "@my_tutor_bot 今天有什么 AI 新闻"。日志里应该出现：
+
+```
+worker[tN]: model invoked 1 tool(s): web_search
+```
+
+如果看到这一行却没有答案：说明 Tavily 调用失败了（查 `journalctl ... | grep web_search`）。如果压根看不到这一行：说明 worker 判断光靠记忆就够了 —— 这是模型自己的决定。
+
+---
+
+## ⑩ 故障排查
+
+**首次启动时迁移报错**
+```
+ERROR: extension "vector" is not available
+```
+→ pgvector 扩展没装上。
+- **Neon**：在 Neon 的 SQL Editor 里把步骤 ②A 的那三条 `CREATE EXTENSION` 语句再跑一遍。
+- **Docker**：确认你用的是 `pgvector/pgvector:pg16` 镜像（而不是原版 `postgres:16`）。清空重建：`docker rm -f nextclaw-pg && docker volume rm nextclaw_pg`，然后重新执行步骤 ②B 里的 docker run。
+
+**`openclaw plugins install git:` 报错 "requires compiled runtime output"**
+→ 你是从一个缺了 `prepare` 脚本的 fork 安装的。检查源码里的 `package.json`，确认 `scripts` 中有 `"prepare": "npm run build"`，且 `devDependencies` 里有 `typescript`。上游的 `NextAgentBC/nextclaw` 仓库自 v0.2.0 起两者都有。
+
+**仪表盘提示 "unauthorized" 或 401**
+→ token 没传进去。用 `?token=$NEXTCLAW_DASH_TOKEN` 打开一次 URL；之后它会存进浏览器的 `sessionStorage`，并在后续加载时以 `X-Token` 转发。关掉标签页就会清空。
+
+**bot 在 Discord 上不应答**
+→ 按顺序检查：
+1. `openclaw doctor` —— 有没有任何 "channel allowlist drops" 的警告？
+2. 你 @ 的是不是**用户** id，而不是**身份组（role）** id？有些客户端会自动补全成一个跟 bot 同名的身份组。临时关掉 `requireMention` 来测试。
+3. `tail -f /tmp/openclaw/openclaw-*.log | grep discord` —— 找 `skipping guild message` 的原因。
+4. bot 在那个频道上有没有 **View Channel + Send Messages** 权限？
+
+**写入之后召回却始终返回 0 条结果**
+→ 嵌入服务端点不可达。直接 `curl /v1/embeddings` 测一下。检查 `/api/recent`，看摄入事件是否有 `decision: "accepted"` 且 `latency_ms` 非零 —— 如果写入进得去但召回什么都找不到，那多半是 HNSW 索引没建起来（它在首次嵌入时才惰性创建）。重启网关，再重新写一个 chunk。
+
+**`<mem>{...}</mem>` 文本泄漏进了 bot 在 Discord 上的回复里**
+→ 你的 OpenClaw 比 2026 年 5 月还旧。用 `openclaw update` 更新，或者在 memory-postgres 配置里设 `prompting.sidecar: "off"`。
+
+**仪表盘面板是空的 / 事件不推流**
+→ PG 的 `LISTEN/NOTIFY` 可能被挡了。检查直接执行 `SELECT pg_notify('test', 'hello')` 是否能成功。（Neon 自 2023 年起支持 LISTEN/NOTIFY；如果它失效了，去看 Neon 的状态页。）SSE 给每个客户端保持一条连接；重新加载仪表盘标签页即可。
+
+**插件安装成功，但网关日志报 "memory-postgres config validation failed"**
+→ 你在配置 `postgres.url` 之前就运行了 `openclaw plugins install`。安装这一步同时还会试图*激活*插件，而激活需要一份有效的配置。先完成步骤 ⑤（或重新跑一遍 `configure-minimal.mjs`），然后 `openclaw gateway restart`。
+
+---
+
+## 接下来去哪儿
+
+- [ARCHITECTURE.zh-CN.md](ARCHITECTURE.zh-CN.md) —— 四层召回模型、Stage 0–6 流水线、多键索引、隔离保证
+- [CONFIG.zh-CN.md](CONFIG.zh-CN.md) —— 每一个配置字段、默认值和调优建议
+- [LIVE_TESTS.zh-CN.md](LIVE_TESTS.zh-CN.md) —— 如何针对真实的 PG + 嵌入服务端点运行实时测试套件
+- 如果本指南里有任何步骤对你不管用，欢迎提 issue：https://github.com/NextAgentBC/nextclaw/issues

--- a/docs/KB_TAXONOMY.md
+++ b/docs/KB_TAXONOMY.md
@@ -1,5 +1,7 @@
 # KB filesystem taxonomy
 
+**English** · [简体中文](KB_TAXONOMY.zh-CN.md)
+
 > Every file the bot ever sees — whether uploaded via Telegram, dropped
 > in by the teacher with `scp`, or fed in by a future web upload UI —
 > lives under one root directory with one set of rules. The rules are

--- a/docs/KB_TAXONOMY.zh-CN.md
+++ b/docs/KB_TAXONOMY.zh-CN.md
@@ -1,0 +1,190 @@
+# 知识库（KB）文件系统式分类
+
+[English](KB_TAXONOMY.md) · **简体中文**
+
+> bot 见到的每一个文件——无论是通过 Telegram 上传、由老师用 `scp`
+> 放进来，还是将来由某个 Web 上传界面送入——都存放在同一个根目录下，
+> 遵循同一套规则。这些规则是机械式的，而非由 LLM 决定，因此 bot 的存储
+> 始终保持整洁，我们无需指望 agent 去“自觉守规矩”。
+
+## 根目录
+
+```
+/home/ubuntu/.openclaw/kb/         ← OPENCLAW_KB_ROOT env var (default)
+```
+
+整棵树都位于同一个用户拥有的目录下。备份非常简单（`pg_dump` 加上对该
+目录做一次 `tar`，即可得到 agent 记忆 + 原始素材的完整快照）。
+
+## 顶层布局
+
+```
+kb/
+├── _meta/                         meta / index files (NOT ingested)
+│   ├── upload-log.jsonl           append-only audit log of every intake
+│   ├── aliases.json               numeric-id → human-name map
+│   │                              (e.g. tg-1001234567890 → "5年级数学群")
+│   ├── versions.json              { "<doc-id>": { "current": "v3", "history": [...] } }
+│   └── purgatory/                 files quarantined for review
+│
+├── inbox/                         freshly-received, not yet classified
+│   └── 2026-05-16/                date-bucketed, auto-rotated
+│       └── <original-filename>
+│
+├── courses/                       teacher-uploaded curriculum (global scope)
+│   └── <course-id>/
+│       ├── _info.md               course description (manually written)
+│       └── <topic>/               e.g. "week1", "fractions", "essay-writing"
+│           ├── <file>
+│           └── ...
+│
+├── groups/                        per-Telegram-group shared materials
+│   └── tg-<chat_id>/              (chat-id is numeric, negative for groups)
+│       ├── _info.md               who's in this group, what's the focus
+│       ├── shared/                visible to everyone in the group
+│       │   └── <file>
+│       └── teacher-only/          visible only to the teacher viewer
+│           └── <file>
+│
+└── students/                      per-student private files
+    └── tg-<user_id>/              (telegram user_id)
+        ├── homework/
+        │   └── YYYY-MM-DD__<title>.<ext>
+        ├── notes/
+        └── shared-with-teacher/   student opts to share with teacher only
+```
+
+## 命名约定
+
+### 文件名
+
+```
+<base-name>__<doc-id>__v<N>.<ext>
+```
+
+- **base-name**：原始文件名（经过 slug 化处理：转小写、空格 → `-`、
+  去掉中日韩标点、保留 ASCII 与中日韩字符）。
+- **doc-id**：跨版本保持稳定的标识符。默认取 base-name 的 slug，
+  可通过 `--doc-id` 参数覆盖。用作 `anchor_kb_doc` 的取值。
+- **vN**：版本号。摄入工具通过统计同一文件夹中具有相同 `doc-id` 的
+  现有文件数量来计算它；首次上传为 `v1`。
+
+示例：
+```
+courses/ai-course/week1/00-overview__ai-course-week1-00__v1.md
+courses/ai-course/week1/00-overview__ai-course-week1-00__v2.md   ← later upload
+```
+
+旧版本会保留在磁盘上以备审计；它们在 `semantic.chunks` 中的记忆块
+（chunk）会带上 `superseded_by`，指向更新的记忆块，因此召回时永远
+不会返回它们。
+
+### 目录名
+
+- 群组 / 用户 / 学生文件夹：一律为 `tg-<numeric-id>`。这个数字 id
+  是稳定的；人类可读的别名存放在 `_meta/aliases.json` 中，这样在
+  Telegram 里重命名群组不会破坏路径。
+- 课程文件夹：课程名称的 `<slug>`（转小写、空格 → `-`、保留中日韩字符）。
+- 主题文件夹：同样的 slug 规则。
+
+## 路由规则（机械式）
+
+给定一次上传 `(file, sender_user_id, chat_id, chat_type, caption)`：
+
+1. **若 `chat_type` 为私聊（DM）：**
+   - 若发送者是 bot 拥有者（与 `commands.ownerAllowFrom` 匹配）：
+     - 若 caption 含 `#course <course-id>` → `courses/<course-id>/inbox/`
+     - 否则 → `inbox/<date>/`（老师稍后审阅）
+   - 若发送者是已知学生：
+     - 若 caption 含 `#share` → `students/tg-<user_id>/shared-with-teacher/`
+     - 否则 → `students/tg-<user_id>/inbox/`
+   - 其他情况（未知发送者）：`_meta/purgatory/<date>/`（需审阅）
+
+2. **若 `chat_type` 为群组 / 超级群组：**
+   - 若发送者是 bot 拥有者：
+     - 若 caption 含 `#teacher-only` → `groups/tg-<chat_id>/teacher-only/`
+     - 否则 → `groups/tg-<chat_id>/shared/`
+   - 若发送者是学生：
+     - 若 caption 含 `#share` → `groups/tg-<chat_id>/shared/`
+     - 默认 → `students/tg-<user_id>/inbox/`（即便是在群组里上传，
+       也视为个人作业；分享需主动选择加入）
+
+3. **Caption 提示（在上述基础上叠加）：**
+   - `#week<N>` → 放入 `week<N>` 子文件夹
+   - `#homework` → 放入 `homework/` 子文件夹
+   - `#topic <slug>` → 放入 `<slug>/` 子文件夹
+   - `#doc-id <slug>` → 覆盖自动推导出的 doc-id
+   - `#version <N>` → 手动覆盖版本号（否则自动递增）
+
+## 摄入资格
+
+并非每个上传的文件都会变成记忆块（chunk）。由摄入工具决定：
+
+| 格式 | 行为 |
+|---|---|
+| `.md / .markdown` | 解析 + 切块 + 嵌入 + 插入 |
+| `.txt` | 按 markdown 处理，但不做标题切分 |
+| `.pdf` | （Phase B++.2）pdf-parse → 切块 + 嵌入 + 插入 |
+| `.docx` | （Phase B++.2）mammoth → markdown → 切块 + 插入 |
+| `.csv`（含 Q、A 两列） | （Phase B++.2）按行 → cache.qa 预填充 + 切块 |
+| `.html / .htm` | （Phase B++.2）html-to-text → 切块 + 插入 |
+| `.png / .jpg / .heic` | 仅存储；不摄入（直到支持多模态） |
+| `.mp3 / .ogg / .wav / .m4a` | （后续）credbroker ASR → 切块 |
+| `.mp4 / .mov` | 仅存储 |
+| 其他任何类型 | 仅存储；在 `_meta/upload-log.jsonl` 中标记为 “unsupported” |
+
+## 锚点映射
+
+每个由 KB 文件写入的记忆块（chunk）都携带以下锚点（来自
+`semantic.chunk_indexes` 中的 `anchor_kind=value`）：
+
+| 锚点种类 | 取值 |
+|---|---|
+| `anchor_kb_doc` | doc-id（跨版本稳定） |
+| `anchor_kb_version` | `v<N>` |
+| `anchor_kb_path` | 在 `kb/` 下的相对路径，用于可追溯性 |
+| `anchor_sender_id` | `tg-<uploader_user_id>`（仅用于学生上传；老师上传保持发送者匿名，以便全局可发现） |
+| `anchor_chat_id` | 若上传为群组范围，则为 `tg-<chat_id>` |
+| `anchor_visibility` | 按路由结果取 `public` / `private` / `teacher-only` |
+| `anchor_topic` | 来自 caption 提示，或文件的首个标题 |
+| `anchor_category` | 由 Stage 0 分类器推导 |
+
+这意味着 Phase B 构建的同一个 `viewer-scope` 过滤器可以零成本地作用于
+KB 内容：即便某个学生摄入了同一棵 `kb/students/tg-X/homework/` 树，
+他也看不到另一个学生的作业。
+
+## 审计日志
+
+每次摄入都会向 `_meta/upload-log.jsonl` 追加一行 JSON：
+
+```json
+{
+  "ts": "2026-05-16T19:36:00Z",
+  "source": "telegram",
+  "sender_user_id": "8064984663",
+  "chat_id": "-1001234567890",
+  "chat_type": "supergroup",
+  "caption": "#share #week3 homework explanation",
+  "original_filename": "homework-week3.pdf",
+  "saved_path": "groups/tg-1001234567890/shared/homework-week3__week3-homework__v1.pdf",
+  "format": "pdf",
+  "doc_id": "week3-homework",
+  "version": "v1",
+  "chunks_written": 0,
+  "chunks_status": "pending-pdf-support",
+  "errors": []
+}
+```
+
+这份日志是“哪些文件在哪里”以及“谁在何时上传了什么”的唯一可信来源。
+仪表盘的 `/kb` 视图就从它读取数据。
+
+## 垃圾清理 / 轮转策略
+
+- `inbox/` 中超过 30 天的条目移入 `_meta/purgatory/`
+- `_meta/purgatory/` 中超过 90 天的条目会被删除（PG 中的记忆块
+  保留 `superseded_by` 链——磁盘空间释放，记忆完好无损）
+- `courses/*/` 与 `groups/*/shared/` 永不自动删除；仅可通过
+  `nextclaw kb remove <doc-id>` 手动删除
+- `students/*/inbox/` 按学生维度、需主动选择加入的清理（学生的数据，
+  由学生自己决定）

--- a/docs/LIVE_TESTS.md
+++ b/docs/LIVE_TESTS.md
@@ -1,5 +1,7 @@
 # Live tests
 
+**English** · [简体中文](LIVE_TESTS.zh-CN.md)
+
 Most files under `test/` are gated by `OPENCLAW_LIVE_TEST=1` because
 they require a running Postgres + embedding endpoint and we don't want
 CI failures in environments without those.

--- a/docs/LIVE_TESTS.zh-CN.md
+++ b/docs/LIVE_TESTS.zh-CN.md
@@ -1,0 +1,80 @@
+# 实测（Live tests）
+
+[English](LIVE_TESTS.md) · **简体中文**
+
+`test/` 目录下的大多数文件都通过 `OPENCLAW_LIVE_TEST=1` 进行门控，因为
+它们需要一个正在运行的 Postgres + 嵌入服务端点，而我们不希望在缺少这些
+依赖的环境中导致 CI 失败。
+
+## 前置条件
+
+```bash
+cd dev/ && docker compose up -d            # Postgres on 127.0.0.1:55432
+ollama serve & ollama pull nomic-embed-text   # Embedding endpoint
+```
+
+## 运行
+
+在 OpenClaw 仓库根目录下运行（如果扩展目录自带测试运行器，也可在该目录内运行）：
+
+```bash
+export OPENCLAW_LIVE_TEST=1
+export NEXTCLAW_DB_URL='postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw'
+export NEXTCLAW_EMBED_URL='http://127.0.0.1:11434'
+export NEXTCLAW_EMBED_MODEL='nomic-embed-text'
+
+# All live tests
+pnpm test extensions/memory-postgres/test/
+
+# Or a specific file
+pnpm test extensions/memory-postgres/test/recall.live.test.ts
+```
+
+若未设置 `OPENCLAW_LIVE_TEST=1`，所有 `*.live.test.ts` 文件都会静默跳过。
+
+## 各项实测的覆盖范围
+
+| 文件 | 断言内容 |
+|---|---|
+| `e2e.live.test.ts` | 完整的摄入 → 召回往返流程；`agent_id` 隔离；多键索引派生 |
+| `pipeline.live.test.ts` | Stage 0–6 摄入流水线行为：垃圾过滤、去重、sidecar、多键写入 |
+| `recall.live.test.ts` | 全部 8 条路由正确触发；MMR 重排多样性；cache.recall TTL |
+| `structured.live.test.ts` | 提取器对账（实体、事件、指标、偏好） |
+| `compactor.live.test.ts` | 90 天冷数据 gist 合并 |
+| `tuning.live.test.ts` | 自调优分析器按计划周期触发 |
+| `dashboard.live.test.ts` | HTTP 端点返回预期结构；SSE 投递审计事件 |
+| `qwen3.live.test.ts` | 嵌入服务端点可达性 + 响应结构 |
+
+## 测试隔离
+
+每个测试都会创建唯一的 `source` 前缀，并在该前缀下植入数据块（chunks）。
+清理工作在 `afterEach` 中通过 `DELETE FROM semantic.chunks WHERE
+source LIKE '<prefix>:%'` 执行，并级联清理 `cache.*` 和 `audit.*` 行。
+
+如果某个测试中途失败并残留了状态，请运行：
+
+```bash
+docker exec -e PGPASSWORD=nextclaw nextclaw-pg psql -U nextclaw -d nextclaw -c "
+DELETE FROM semantic.chunks WHERE source LIKE 'test-%';
+DELETE FROM cache.recall;
+DELETE FROM cache.intent;
+"
+```
+
+## 新增一项实测
+
+1. 将其命名为 `*.live.test.ts`，以便在未设置环境变量标志时自动跳过
+2. 为每个测试使用唯一的 `source` 前缀（类似 `secrets.token_hex(4)` 的风格）
+3. 在 `afterEach` 中清理
+4. 不要在测试文件之间共享状态；每个文件各自拥有其数据
+
+## CI 注意事项
+
+标准 CI 流水线**不会**运行这些测试——它们所需的基础设施在每次运行时
+启动的成本很高。在提交涉及以下内容的 PR 之前，请先在本地运行它们：
+
+- `src/storage/schema/*.sql`（任何 schema 变更）
+- `src/recall/router.ts` 或 `src/recall/routes.ts`
+- `src/ingest/pipeline.ts`
+- `transcript-watcher` / `git-watcher` / `shadow-comparator` worker
+- `src/dashboard/server.ts` 中任何影响 API 端点的内容

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -1,5 +1,7 @@
 # External services nextclaw uses
 
+**English** · [简体中文](SERVICES.zh-CN.md)
+
 This doc lists every external service nextclaw can talk to, **why** you'd want it, **where to sign up**, and the **exact env var / config snippet** to wire it in.
 
 Written so both an AI agent (looking for `bash` blocks + JSON paths to act on) and a human (looking for the "why") can use it.

--- a/docs/SERVICES.zh-CN.md
+++ b/docs/SERVICES.zh-CN.md
@@ -1,0 +1,517 @@
+# nextclaw 使用的外部服务
+
+[English](SERVICES.md) · **简体中文**
+
+本文档列出了 nextclaw 可以对接的每一项外部服务（external service），说明**为什么**你会需要它、**在哪里注册**，以及把它接入所需的**具体环境变量 / 配置片段**。
+
+文档的写法兼顾 AI 智能体（查找可执行的 `bash` 代码块与 JSON 路径）和人类用户（查找"为什么要用"），双方都能使用。
+
+---
+
+## TL;DR —— 能力矩阵
+
+| 你想要…… | 至少需要 |
+|---|---|
+| 长期记忆 + 召回（核心功能） | **Postgres + pgvector** + 一个**嵌入服务端点**（Jina 免费额度即可） |
+| 实时仪表盘 + HTTP 数据摄入 | 仅需核心（再加一个随机的 `NEXTCLAW_DASH_TOKEN`） |
+| 夜间反思（记忆整合） | 核心 + 一个 **LLM 端点**（Gemini 免费版或 OpenAI） |
+| Telegram 群组**主持人（Moderator）**（编排者-工作者模式，认领 `@提及`） | 核心 + 一个 **Telegram bot token** + **Gemini**（或 OpenAI） |
+| 工作者的 `web_search` 工具 | 上述内容 + **Tavily API 密钥** 或一个 credbroker |
+| 工作者的 `memory_search` 工具 | 核心（无需额外服务） |
+| 在同一个 Postgres 上实现多智能体隔离 | 核心；只需为每个安装实例设置 `cfg.moderator.agentId` |
+
+第一行以外的一切都是可选的。仅靠核心，插件即可运行；接入更多服务可解锁更多行为。
+
+---
+
+## 1. Postgres + pgvector（必需）
+
+**为什么：** 存储所有分块（chunk）、嵌入、审计与缓存。nextclaw 只是数据库之上的一层薄封装——没有它，任何内存中的状态都无法在重启后存活。
+
+**获取方式：** 选择最适合你环境的一种。
+
+### 方案 A —— Neon（云端，免费 0.5 GB，零本地依赖）
+
+1. 访问 <https://neon.tech> → 用 GitHub 注册（无需信用卡）→ **Create project**
+2. 复制连接字符串（形如 `postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require`）
+3. 在 Neon 的 **SQL Editor** 标签页中运行：
+
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS vector;
+   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+   CREATE EXTENSION IF NOT EXISTS btree_gin;
+   ```
+
+4. 导出：
+   ```bash
+   export PG_URL="postgresql://user:pwd@ep-xxx.neon.tech/neondb?sslmode=require"
+   ```
+
+> Neon 会自动挂起空闲的数据库。长时间空闲后的第一次查询会将其唤醒（约 1–2 秒）；之后的查询又会恢复快速。
+
+### 方案 B —— Docker（本地，完全可控）
+
+```bash
+docker run -d --name nextclaw-pg --restart unless-stopped \
+  -e POSTGRES_USER=nextclaw -e POSTGRES_PASSWORD=nextclaw -e POSTGRES_DB=nextclaw \
+  -p 127.0.0.1:55432:5432 -v nextclaw_pg:/var/lib/postgresql/data \
+  pgvector/pgvector:pg16
+until docker exec nextclaw-pg pg_isready -U nextclaw >/dev/null 2>&1; do sleep 1; done
+docker exec nextclaw-pg psql -U nextclaw -d nextclaw -c \
+  "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS btree_gin;"
+export PG_URL="postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw"
+```
+
+仅绑定到 `127.0.0.1:55432`，绝不暴露在公网接口上。数据卷 `nextclaw_pg` 会在重启之间持久保存数据。
+
+### 验证（两种方案通用）
+
+```bash
+psql "$PG_URL" -c "SELECT extname FROM pg_extension WHERE extname IN ('vector','pg_trgm','btree_gin');"
+# Must list all three. Install psql via `brew install libpq` or `apt-get install postgresql-client` if missing.
+```
+
+**配置（位于 `~/.openclaw/openclaw.json` → `plugins.entries.memory-postgres.config`）：**
+
+```jsonc
+"postgres": { "url": "<your $PG_URL>" }
+```
+
+**已经在别处有 Postgres 了？** 那就跳过以上两种方案；只需给插件一个已安装 `vector`、`pg_trgm` 和 `btree_gin` 扩展的 URL 即可。插件会在首次启动时运行自己的数据库 schema 迁移（`dist/src/storage/schema/*.sql`）。
+
+---
+
+## 2. Jina 嵌入 —— 推荐的默认选项（免费）
+
+**为什么：** 把文本转换成 1024 维向量，从而让语义召回得以工作。Jina 的免费额度（free tier）每个密钥约覆盖 100 万 token（约等于典型聊天场景下 500 天的用量）。对中英文都表现良好。
+
+**获取密钥：**
+
+1. 打开 [https://jina.ai/embeddings](https://jina.ai/embeddings/)
+2. 点击 **"Get API key for free"** —— 无需信用卡
+3. 复制密钥（形如 `jina_xxxxxxxxxxxxxxxxxx`）
+
+**设置环境变量：**
+
+```bash
+export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Persist it:
+echo 'export JINA_API_KEY=jina_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' >> ~/.bashrc
+```
+
+**验证：**
+
+```bash
+curl -sS https://api.jina.ai/v1/embeddings \
+  -H "Authorization: Bearer $JINA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"jina-embeddings-v3","input":["hello"]}' | head -c 200
+# Must return JSON with a data[].embedding array
+```
+
+**配置：** *无需任何配置块* —— 当 openclaw.json 中省略 `embedding` 时，插件默认使用 Jina（`format=jina`、`baseUrl=https://api.jina.ai`、`apiKeyEnv=JINA_API_KEY`）。
+
+---
+
+## 2b. 备选方案：Ollama（自托管，无需 API 密钥）
+
+**为什么：** 没有速率限制、完全私密、可离线运行。需要约 1–4 GB 内存/显存。
+
+**获取方式：**
+
+```bash
+# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+# macOS
+brew install ollama   # or download from https://ollama.com
+
+ollama serve &                              # listens on 127.0.0.1:11434
+ollama pull qwen3-embedding:0.6b            # ~1 GB, multilingual, recommended
+# OR
+ollama pull nomic-embed-text                # ~274 MB, English-leaning
+```
+
+**验证：**
+
+```bash
+curl -sS http://127.0.0.1:11434/api/embed \
+  -d '{"model":"qwen3-embedding:0.6b","input":"hello"}' | head -c 200
+```
+
+**配置：**
+
+```jsonc
+"embedding": {
+  "format": "ollama",
+  "model": "qwen3-embedding:0.6b"
+}
+```
+
+`baseUrl` 默认为 `http://127.0.0.1:11434`；若 Ollama 运行在其他主机上，请覆盖此值。
+
+---
+
+## 2c. 备选方案：OpenAI 兼容接口（任意提供方、vLLM、TEI 等）
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+```jsonc
+"embedding": {
+  "format": "openai",
+  "baseUrl": "https://api.openai.com",
+  "model": "text-embedding-3-small",
+  "apiKeyEnv": "OPENAI_API_KEY"
+}
+```
+
+> ⚠️ **嵌入维度是单向的。** 它会在首次摄入时被自动检测，并锁定进 HNSW 索引。从 `jina-embeddings-v3`（1024 维）切换到 `qwen3-embedding:4b`（4096 维）需要执行 `TRUNCATE semantic.chunks RESTART IDENTITY CASCADE` 并重新摄入所有数据。请挑选一个你能用上几个月的模型。
+
+---
+
+## 3. Gemini（Google AI Studio）—— 供主持人与反思使用的免费 LLM
+
+**为什么：** 主持人（Moderator）的决策循环和夜间反思守护进程都需要一个对话 LLM。Gemini 2.5 Flash 拥有慷慨的免费额度（每个密钥约 250 RPD）。
+
+**获取密钥：**
+
+1. 打开 [https://aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+2. 用 Google 账号登录
+3. **Create API key** → 复制（形如 `AIza...`）
+
+**设置环境变量：**
+
+```bash
+export GEMINI_API_KEY=AIza...
+echo 'export GEMINI_API_KEY=AIza...' >> ~/.bashrc
+```
+
+**验证：**
+
+```bash
+curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GEMINI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"say hi"}]}]}' | head -c 200
+```
+
+**配置 —— 主持人：**
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+**配置 —— 反思（可选，夜间摘要）：**
+
+```jsonc
+"reflection": {
+  "enabled": true,
+  "model": {
+    "format": "gemini",
+    "baseUrl": "https://generativelanguage.googleapis.com",
+    "model": "gemini-2.5-flash",
+    "apiKeyEnv": "GEMINI_API_KEY"
+  }
+}
+```
+
+---
+
+## 3b. 备选 LLM：OpenAI / OpenAI 兼容接口
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+```jsonc
+"moderator": {
+  "enabled": true,
+  "model": {
+    "format": "openai",
+    "baseUrl": "https://api.openai.com",
+    "model": "gpt-5.5",
+    "apiKeyEnv": "OPENAI_API_KEY"
+  }
+}
+```
+
+> ⚠️ **工具调用（Tool-calling）**：目前工作者的工具调用路径（`web_search`、`memory_search`）只完整支持 Gemini 的 `:generateContent` API。使用 `format=openai` 时，工作者会以单次（single-shot）模式运行——回答仍然有效，但不会在回答中途进行工具调用。OpenAI 的工具格式是一个待办项（TODO）。如果你现在就想要联网搜索，请使用 Gemini。
+
+---
+
+## 4. Telegram bot —— 主持人必需
+
+**为什么：** 主持人活动在 Telegram 群组中。没有 bot 账号，主持人就没有任何可认领或可回复的对象。
+
+**获取 token：**
+
+1. 打开 Telegram，搜索 **`@BotFather`**，开始一段对话
+2. 发送 `/newbot`
+3. 按提示操作——挑选一个显示名称（例如 `My Tutor Bot`）和一个用户名（必须以 `bot` 结尾，例如 `my_tutor_bot`）
+4. BotFather 会回复一个形如 `1234567890:AAH...long-string...` 的 token。**把它复制下来。**
+
+**获取你自己的用户 id（用于仅限所有者的命令）：**
+
+1. 在 Telegram 中与 **`@userinfobot`** 对话
+2. 它会回复你的数字用户 id（例如 `8064984663`）
+
+**把 bot 加入你的群组：**
+
+1. 打开群组 → 添加成员 → 搜索 bot 的用户名 → 添加
+2. 确保 bot 能读取消息：默认情况下，群组中的 Telegram bot **只能看到 @提及它的消息**或对它消息的回复。这恰恰是主持人想要的——群内闲聊保持私密，只有明确的提及才会被处理。
+3. 如果你希望 bot 看到群里的所有消息（对主持人而言**不推荐**），可使用 BotFather → `/setprivacy` → Disable。
+
+**配置：**
+
+```jsonc
+"channels": {
+  "telegram": {
+    "enabled": true,
+    "botToken": "1234567890:AAH...",
+    "polling": { "enabled": true }
+  }
+},
+"commands": {
+  "ownerAllowFrom": ["telegram:8064984663"]
+}
+```
+
+**验证 bot 是否存活：**
+
+```bash
+curl -sS "https://api.telegram.org/bot<YOUR_TOKEN>/getMe"
+# Should return {"ok":true,"result":{"id":...,"username":"my_tutor_bot",...}}
+```
+
+在 OpenClaw 携带此配置重启后，前往你的群组并发送 `@my_tutor_bot hello`。观察 `tail -f /tmp/openclaw/openclaw-*.log`，留意 `[moderator/hook] before_dispatch CLAIMED` 这一行。
+
+---
+
+## 5. Tavily —— 供主持人 `web_search` 工具使用的联网搜索
+
+**为什么：** 工作者的 `web_search` 工具封装了 Tavily。没有它，主持人只能凭记忆 + LLM 训练数据作答，无法获取当前信息（新闻、最新版本号等）。工作者会如实说明这一点。
+
+### 已经配置好 OpenClaw 的 tavily 插件了？那就大功告成。
+
+如果你的 `openclaw.json` 中已经有：
+```jsonc
+"plugins": { "entries": { "tavily": { "enabled": true, "config": { "webSearch": { "apiKey": "tvly-..." } } } } }
+```
+（这是 OpenClaw 存放 codex 侧 tavily 密钥的标准位置——其设置向导会把它放在这里）
+
+**那么 nextclaw 的工作者会自动复用同一个密钥。** 无需 `TAVILY_API_KEY` 环境变量，也无需额外配置。在插件启动时，我们会读取 `plugins.entries.tavily.config.webSearch.apiKey` 并将其传给工作者的工具运行时。这样 codex 和我们的主持人工作者都能用同一份已配置的凭据访问 Tavily。
+
+工作者的解析优先级（先匹配者胜出）：
+1. `cfg.credbroker.tavilyUrl`（如果你有一个 Tailscale 凭据代理（credbroker））
+2. OpenClaw 的 `plugins.entries.tavily.config.webSearch.apiKey` ← **大多数用户落在这里**
+3. `NEXTCLAW_WEB_SEARCH_URL` 环境变量
+4. `TAVILY_API_KEY` 环境变量
+5. 什么都没配置 → `web_search` 向 LLM 返回一个如实的错误；LLM 会告诉用户它无法搜索。
+
+### 还没有 Tavily 密钥？
+
+1. 打开 [https://app.tavily.com/](https://app.tavily.com/)
+2. 用 Google / GitHub / 邮箱登录
+3. 侧边栏中的 **API Keys** → **Create new key**（免费额度：1,000 次搜索 / 月）
+4. 复制（形如 `tvly-...`）
+
+**配置方式（方案 A —— 推荐，同时也给 codex 提供联网搜索）：**
+
+把以下内容加入 `openclaw.json`，让 codex 和主持人工作者复用同一个密钥：
+
+```jsonc
+"plugins": {
+  "entries": {
+    "tavily": {
+      "enabled": true,
+      "config": {
+        "webSearch": { "apiKey": "tvly-..." }
+      }
+    }
+  }
+}
+```
+
+**配置方式（方案 B —— 仅主持人，不为 codex 提供联网搜索）：**
+
+```bash
+export TAVILY_API_KEY=tvly-...
+echo 'export TAVILY_API_KEY=tvly-...' >> ~/.bashrc
+```
+
+**验证：**
+
+```bash
+curl -sS https://api.tavily.com/search \
+  -H "Content-Type: application/json" \
+  -d "{\"api_key\":\"tvly-...\",\"query\":\"openclaw github\",\"max_results\":2}" | head -c 200
+# Returns JSON with results[]
+```
+
+### 为什么存在两条路径
+
+OpenClaw 的 tavily 插件为 **codex 智能体循环** 注册了一个搜索工具——codex 通过 `WebSearchProviderPlugin.createTool()` 拾取它。而我们的主持人工作者是 codex 循环之外的**一次独立 LLM 调用**（它是调度专家的编排者，而非 codex 本身）。所以严格来说，我们运行的是自己的 Tavily 请求。我们只是复用了 codex 已配置的密钥，免得运维人员要操心两遍。
+
+---
+
+## 5b. Cloudflare Tunnel（可选 —— 为 Telegram WebApp 提供公网仪表盘 URL）
+
+**为什么：** 要从 **Telegram WebApp 按钮**（`/dashboard` bot 命令）打开记忆仪表盘，仪表盘需要一个公网 HTTPS URL。Cloudflare Tunnel 免费提供一个，无需端口转发，也不需要公网 IP。Telegram 的 WebApp SDK 要求使用 HTTPS——`http://` URL 会被静默拒绝。
+
+### 快速路径（5 分钟，临时 URL）
+
+```bash
+mkdir -p ~/bin
+curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o ~/bin/cloudflared
+chmod +x ~/bin/cloudflared
+~/bin/cloudflared tunnel --url http://localhost:8765 --no-autoupdate
+# Outputs: Your quick Tunnel has been created! Visit it at:
+#   https://random-words-here.trycloudflare.com
+```
+
+把该 URL 粘贴进 `openclaw.json`：
+
+```jsonc
+"dashboard": {
+  "enabled": true, "host": "127.0.0.1", "port": 8765,
+  "tokenEnv": "NEXTCLAW_DASH_TOKEN",
+  "publicUrl": "https://random-words-here.trycloudflare.com"
+}
+```
+
+重启 OpenClaw。向你的 bot 发送 `/dashboard`。点击那个按钮。
+
+> ⚠️ 快速隧道（quick-tunnel）的 URL **每次 cloudflared 重启时都会改变**。用于测试没问题；生产环境请使用具名隧道（named tunnel，见下文）。
+
+### 稳定路径（具名隧道 —— 一次性设置，约 15 分钟）
+
+需要：一个 Cloudflare 账号（免费）+ 一个托管在 Cloudflare DNS 上的域名。
+
+```bash
+~/bin/cloudflared tunnel login                            # browser auth
+~/bin/cloudflared tunnel create memory-dashboard          # creates UUID
+~/bin/cloudflared tunnel route dns memory-dashboard memory.yourdomain.com
+# Create ~/.cloudflared/config.yml:
+cat > ~/.cloudflared/config.yml <<'EOF'
+tunnel: memory-dashboard
+credentials-file: /home/youruser/.cloudflared/<UUID>.json
+ingress:
+  - hostname: memory.yourdomain.com
+    service: http://localhost:8765
+  - service: http_status:404
+EOF
+# Run as systemd --user service:
+~/bin/cloudflared service install
+sudo systemctl start cloudflared
+```
+
+现在 `https://memory.yourdomain.com` 在重启之间保持稳定。更新 openclaw.json 中的 `publicUrl`，然后就别再去动它了。
+
+### 鉴权机制（不泄露 token）
+
+- 仪表盘的 `/api/*` 端点会拒绝任何不带有效 token（`X-Token` 请求头 / `?token=` 查询参数）的请求。
+- 当 Telegram 打开 WebApp 时，它会注入 `window.Telegram.WebApp.initData`——一个经过签名的载荷，包含用户的 Telegram id + auth_date + HMAC。
+- 仪表盘的 JS 会把该 initData POST 到 `/api/auth/telegram`。服务端用 bot token 进行 HMAC 校验，确认 `user.id` 在 `commands.ownerAllowFrom` 中，并签发一个**按用户隔离的会话 token**（保存在内存中，TTL 为 1 小时）。
+- 会话 token 会作为 `X-Token` 随后续所有调用一起发送。URL 中没有全局 token，意味着**转发该链接不会泄露访问权限**。
+
+---
+
+## 6. Credbroker（可选 —— 仅适用于多主机部署）
+
+**为什么：** 如果你在一个 Tailscale tailnet 上有多台机器，并且希望**调用方主机上零 API 密钥**，那就在一台可信的 "mainserver" 上运行一个凭据代理（credential broker），让所有机器都指向它。代理会基于 Tailscale 身份从其保险库中注入凭据。
+
+这是一种高级用户的配置。如果你还没有这样的设置，可以跳过。
+
+**配置：**
+
+```jsonc
+"credbroker": {
+  "baseUrl": "http://<mainserver-tailscale-ip>:8800",
+  "services": {
+    "embedding": "local-embed",
+    "gemini":    "gemini",
+    "tavily":    "tavily"
+  }
+}
+```
+
+设置后，任何**被省略**的单服务 `baseUrl` 都会自动推导为 `${baseUrl}/v1/proxy/${service}`。显式指定的 URL 始终优先。`services` 块是可选的——其默认值与常见的 credbroker 设置相匹配。
+
+**使用 credbroker 时**，所有单服务的 `baseUrl` + `apiKeyEnv` 字段都可以省去：
+
+```jsonc
+"credbroker": { "baseUrl": "http://100.x.y.z:8800" },
+"embedding":  { "format": "openai", "model": "qwen3-embedding:0.6b" },
+"moderator":  { "enabled": true, "model": { "format": "gemini", "model": "gemini-2.5-flash" } },
+"reflection": { "enabled": true, "model": { "format": "gemini", "model": "gemini-2.5-flash" } }
+```
+
+搭建 credbroker 本身超出了本文档的范围——请参阅你所在 tailnet 的文档。
+
+---
+
+## 7. OpenClaw（宿主运行时 —— 必需）
+
+nextclaw 是 [OpenClaw](https://github.com/openclaw/openclaw) 的一个插件，并非独立程序。OpenClaw 提供了智能体运行时、通道入口（channel ingress）、钩子系统（hook system）和 CLI。它自带了 Node 运行时，因此没有额外的前置依赖。
+
+**安装：**
+
+```bash
+# macOS / Linux
+curl -fsSL https://openclaw.ai/install.sh | bash
+# Windows PowerShell
+#   iwr -useb https://openclaw.ai/install.ps1 | iex
+
+# Install the gateway daemon (launchd/systemd user service)
+openclaw onboard --install-daemon
+```
+
+**验证：**
+
+```bash
+openclaw --version    # 2026.x.x
+openclaw doctor
+```
+
+**在其之上安装 nextclaw：**
+
+```bash
+openclaw plugins install git:github.com/NextAgentBC/nextclaw
+openclaw plugins list | grep memory-postgres   # confirm it's discovered
+```
+
+---
+
+## 快速参考 —— 环境变量
+
+| 环境变量 | 服务 | 是否可选？ |
+|---|---|---|
+| `JINA_API_KEY` | Jina 嵌入 | 若使用 Ollama/OpenAI 则可选 |
+| `GEMINI_API_KEY` | Gemini LLM（主持人 + 反思） | 若禁用主持人或改用 OpenAI 则可选 |
+| `OPENAI_API_KEY` | OpenAI（LLM 或嵌入） | 可选，作为 Gemini/Jina 的替代 |
+| `TAVILY_API_KEY` | 联网搜索工具 | 可选——没有它则该功能降级为"无联网访问" |
+| `NEXTCLAW_DASH_TOKEN` | 仪表盘鉴权 | 若启用仪表盘则必需 |
+| `NEXTCLAW_WEB_SEARCH_URL` | 覆盖 Tavily 端点 | 仅限高级用户 |
+
+---
+
+## 致代为用户安装 nextclaw 的 AI 智能体
+
+如果你是一个正在帮用户安装 nextclaw 的 LLM 智能体，以下是推荐的对话流程：
+
+1. **询问用户想要什么** —— 只要记忆？还是也要一个 Telegram 主持人？或者还要联网搜索？参考本文档顶部的能力矩阵。
+2. **了解用户已经有什么** —— Docker？Node？现成的 Postgres？一个 Telegram bot？现有的 API 密钥？
+3. **按依赖顺序逐项走查服务：** Postgres → 嵌入 →（若需主持人）LLM →（若需主持人）Telegram bot →（若需联网搜索）Tavily。
+4. **对每一项服务：** 大声读出"为什么"那一句（让用户清楚自己正在同意什么），然后要么从用户那里获取密钥，要么用本文档中给出的链接 URL 引导其完成注册。
+5. **用 `curl` 片段验证每一步**，再进行下一步。尽早发现错误的 API 密钥能省下日后的调试时间。
+6. **最终配置：** 把所有接好的配置块汇集到 `~/.openclaw/openclaw.json` 中。启动 OpenClaw。运行 [INSTALL.zh-CN.md ⑦](INSTALL.zh-CN.md#-start-then-verify-with-a-smoke-test) 中的冒烟测试 1。
+
+冒烟测试必须通过，才能宣告成功。如果召回返回 0 条结果，那很可能是嵌入服务没接对——请先检查 `/api/recent` 是否有摄入错误。

--- a/skills/openclaw-selfcare/README.md
+++ b/skills/openclaw-selfcare/README.md
@@ -1,5 +1,7 @@
 # openclaw-selfcare
 
+**English** · [简体中文](README.zh-CN.md)
+
 A small OpenClaw **ops skill** that keeps one host's OpenClaw core and the nextclaw
 (`memory-postgres`) plugin up to date — *safely*.
 

--- a/skills/openclaw-selfcare/README.zh-CN.md
+++ b/skills/openclaw-selfcare/README.zh-CN.md
@@ -1,0 +1,55 @@
+# openclaw-selfcare
+
+[English](README.md) · **简体中文**
+
+一个轻量的 OpenClaw **运维 skill**，负责将单台主机上的 OpenClaw core 与 nextclaw
+（`memory-postgres`）插件保持在最新版本——而且是*安全地*升级。
+
+OpenClaw 发布频繁。core 升级偶尔会带来一个本记忆插件尚未适配其插件 API 的 openclaw
+版本，或者一个裁剪掉了插件所依赖的某个传递依赖（transitive dependency，例如 `undici`）的版本。
+无论哪种情况，记忆层（memory layer）都可能在升级中途宕机。本 skill 会**在沙箱中、于触碰线上安装之前**
+预测这一风险，对可安全修复的情况执行自动修复（auto-fix），其余情况则发出告警而非强行升级。
+
+## 功能说明
+
+```
+check latest openclaw
+   → sandbox preflight: does the new openclaw still load this plugin + resolve its deps?
+      → PASS         : upgrade openclaw, then update the plugin, then verify
+      → FIX-NEEDED   : bump plugin to a compatible tag / install the missing dep, re-check
+      → FAIL         : skip the upgrade, alert (never upgrade onto a broken/incompatible state)
+```
+
+## 快速上手
+
+```bash
+# read-only status + compatibility verdict
+bash oc-selfcare.sh check
+
+# the real upgrade (preflight → upgrade → verify)
+bash oc-selfcare.sh apply
+```
+
+将其作为 OpenClaw skill 安装，agent 便能回答"现在升级安全吗？"：
+
+```bash
+openclaw skills install ./skills/openclaw-selfcare --force
+```
+
+完整的命令参考、预检（preflight）裁决表、新主机 SOP（含可选的每日 cron）以及内置的安全保证，
+详见 [`SKILL.md`](./SKILL.md)（该文档保持英文）。配置为可选项——参见 [`config.env.example`](./config.env.example)。
+
+## 依赖要求
+
+PATH 中需具备 `bash`、`node`、`npm`、`git`、`jq` 以及 `openclaw`。插件的克隆目录会通过
+`openclaw plugins inspect memory-postgres` 自动定位。
+
+## 安全性
+
+- 只读（read-only）的 `check` / `preflight` 绝不触碰线上安装。
+- `apply` 在以下情况下会拒绝升级：沙箱预检未通过；需要跨越被标记为破坏性（breaking）的发布；
+  以及在一个本就不健康的安装之上叠加升级。
+- 含有未提交改动的插件克隆（即开发机，dev box）会被跳过，绝不强行覆盖。
+- 升级完成后，会验证（verify）网关（gateway）版本与记忆探针确实已恢复。
+
+本项目采用 Apache-2.0 许可，与 nextclaw 其余部分一致。


### PR DESCRIPTION
## Summary

Adds **Simplified Chinese (zh-CN) translations for every doc in the repo**, side by side
with the English originals, each with a language-switch link at the top
(`English · 简体中文`).

The dashboard was already bilingual CN/EN; this brings the written docs to parity so a
Chinese-speaking operator can install, configure, and run nextclaw entirely in Chinese.

## What's translated

| English | 简体中文 |
|---|---|
| `README.md` | `README.zh-CN.md` |
| `AGENTS.md` (contributor guide) | `AGENTS.zh-CN.md` |
| `docs/ARCHITECTURE.md` | `docs/ARCHITECTURE.zh-CN.md` |
| `docs/CONFIG.md` | `docs/CONFIG.zh-CN.md` |
| `docs/INSTALL.md` | `docs/INSTALL.zh-CN.md` |
| `docs/KB_TAXONOMY.md` | `docs/KB_TAXONOMY.zh-CN.md` |
| `docs/LIVE_TESTS.md` | `docs/LIVE_TESTS.zh-CN.md` |
| `docs/SERVICES.md` | `docs/SERVICES.zh-CN.md` |
| `skills/openclaw-selfcare/README.md` | `skills/openclaw-selfcare/README.zh-CN.md` |

(`CHANGELOG.md` intentionally left English; `SKILL.md` stays English as it's the file
OpenClaw loads — its Chinese companion is the skill's `README.zh-CN.md`.)

## How it was kept faithful

- **Code is untouched.** All code blocks, shell commands, config/JSON/SQL, file paths,
  env-var and field names, badges and ASCII diagrams are byte-identical to the English.
  Verified the fenced-code-block count matches EN↔ZH for every single doc.
- **Links rewired.** Repo-internal doc links in the zh-CN files point to their zh-CN
  counterparts; external URLs untouched.
- **One glossary.** A single term glossary was applied across all files so vocabulary is
  consistent (四层召回 / 按 agent 隔离 / 仪表盘 / 沙箱预检 / 传递依赖 /
  Moderator(群消息编排器) / 确定性优先摄入 …). Product/tech names (OpenClaw, Postgres,
  pgvector, undici, …) stay in English.
- The `openclaw-selfcare` skill and the `undici` dependency note flow through into the
  Chinese README / AGENTS automatically.

## Notes for the maintainer

- 2,517 insertions, all additive — the only change to English files is a one-line
  language-switch link under each title.
- If you later edit an English doc, update its `.zh-CN.md` sibling to match.
