### PR TITLE
v0.4 correctness + pgvectorscale (DiskANN) + LLM residual extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Thumbs.db
 /tmp/
 *.swp
 *.bak
+test/golden/last-run.json
 
 # Personal config that should never be committed
 **/openclaw.json

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -4,12 +4,13 @@
 #   docker compose up -d
 #   # PG ready at postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw
 #
-# Image: pgvector/pgvector pins both Postgres and pgvector versions.
+# Image: nextclaw-pg:pg16-vectorscale = pgvector/pgvector:pg16 + pgvectorscale
+# (DiskANN, for >2000-dim embeddings). Build recipe: dev/vectorscale.Dockerfile.
 # The init.d/ script installs pg_trgm + btree_gin alongside pgvector.
 
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: nextclaw-pg:pg16-vectorscale
     container_name: nextclaw-pg
     restart: unless-stopped
     environment:

--- a/dev/vectorscale.Dockerfile
+++ b/dev/vectorscale.Dockerfile
@@ -1,0 +1,28 @@
+# nextclaw memory Postgres image: pgvector + pgvectorscale (DiskANN).
+#
+# Why: pgvector's HNSW index is capped at 2000 dimensions (8 KB index-tuple
+# page limit); the deployment's embedder (Qwen3-Embedding-8B) is 4096-d.
+# pgvectorscale's StreamingDiskANN (SBQ-compressed layout) indexes high-dim
+# vectors, so semantic recall stays index-accelerated without truncating the
+# embedding. src/storage/migrate.ts builds a `diskann` index when the
+# `vectorscale` extension is present, falling back to `hnsw` otherwise.
+#
+# The package is the official, PostgreSQL-licensed release from
+# timescale/pgvectorscale. Pin both version and arch.
+#
+# Build (this host is arm64; pass --build-arg VS_ARCH=amd64 on x86):
+#   docker build -f dev/vectorscale.Dockerfile -t nextclaw-pg:pg16-vectorscale dev
+FROM pgvector/pgvector:pg16
+
+ARG VS_VERSION=0.9.0
+ARG VS_ARCH=arm64
+
+ADD https://github.com/timescale/pgvectorscale/releases/download/${VS_VERSION}/pgvectorscale-${VS_VERSION}-pg16-${VS_ARCH}.zip /tmp/vs.zip
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends unzip ca-certificates \
+ && unzip /tmp/vs.zip -d /tmp/vs \
+ && apt-get install -y --no-install-recommends "/tmp/vs/pgvectorscale-postgresql-16_${VS_VERSION}-Linux_${VS_ARCH}.deb" \
+ && rm -rf /tmp/vs /tmp/vs.zip \
+ && apt-get purge -y unzip \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/dist/index.js
+++ b/dist/index.js
@@ -92,6 +92,7 @@ async function handleDashboardCommand(api, ctxObj) {
     return true;
 }
 import { startTranscriptWatcherDaemon } from "./src/workers/transcript-watcher.js";
+import { buildResidualExtractor } from "./src/ingest/residual.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
 import { ingestCompactionSummary } from "./src/workers/compaction-ingest.js";
@@ -464,6 +465,7 @@ export default definePluginEntry({
                             cfg,
                             pool,
                             embedding,
+                            llmResidual: buildResidualExtractor(cfg),
                             watcher,
                             logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
                         });

--- a/dist/src/cache/qa.js
+++ b/dist/src/cache/qa.js
@@ -196,6 +196,18 @@ export async function recordCacheHit(pool, id) {
 export async function invalidateCachedAnswer(pool, id, reason) {
     await pool.query(`UPDATE cache.qa SET invalidated = true, invalidated_reason = $2 WHERE id = $1`, [id, reason]);
 }
+/**
+ * Invalidate every cached answer derived from a given source chunk/doc. Called
+ * from the chunk-invalidation path so a forgotten/rewritten chunk stops serving
+ * a stale answer — without this the QA cache's 90-day TTL outlives the fact.
+ * Matches on `source_doc_id`, the direct provenance link. Returns the count
+ * invalidated.
+ */
+export async function invalidateCachedAnswersByDoc(pool, sourceDocId, reason) {
+    const r = await pool.query(`UPDATE cache.qa SET invalidated = true, invalidated_reason = $2
+       WHERE source_doc_id = $1 AND NOT invalidated`, [sourceDocId, reason]);
+    return r.rowCount ?? 0;
+}
 export async function recordCacheFeedback(pool, id, vote) {
     await pool.query(vote === "up"
         ? `UPDATE cache.qa SET upvotes = upvotes + 1 WHERE id = $1`

--- a/dist/src/config.js
+++ b/dist/src/config.js
@@ -97,6 +97,7 @@ export function resolveConfig(raw) {
         transcriptWatchers: (raw.transcriptWatchers ?? []).map(resolveTranscriptWatcher),
         shadowComparators: (raw.shadowComparators ?? []).map(resolveShadowComparator),
         reflection: resolveReflectionConfig(raw.reflection, credbroker),
+        residual: resolveResidualConfig(raw.residual, credbroker),
         moderator: resolveModeratorConfig(raw.moderator, credbroker),
     };
 }
@@ -161,6 +162,24 @@ function resolveModeratorConfig(raw, credbroker) {
             apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
         },
         publishSkillsDir,
+    };
+}
+function resolveResidualConfig(raw, credbroker) {
+    const block = raw ?? {};
+    const modelBlock = block.model ?? {};
+    // Default to gemini (the credbroker only proxies gemini); honour an explicit openai.
+    const format = modelBlock.format === "openai" ? "openai" : "gemini";
+    const credbrokerFallback = format === "gemini" ? credbroker.geminiUrl : null;
+    return {
+        enabled: bool(block.enabled, false),
+        maxRpm: Math.max(1, num(block.maxRpm, 8)),
+        dailyTokenBudget: Math.max(0, num(block.dailyTokenBudget, 50_000)),
+        model: {
+            format,
+            baseUrl: isString(modelBlock.baseUrl) ? modelBlock.baseUrl : (credbrokerFallback ?? ""),
+            model: isString(modelBlock.model) ? modelBlock.model : "gemini-2.5-flash",
+            apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
+        },
     };
 }
 function resolveReflectionConfig(raw, credbroker) {

--- a/dist/src/edit/invalidate.js
+++ b/dist/src/edit/invalidate.js
@@ -1,0 +1,33 @@
+/**
+ * Unified chunk invalidation — the single fan-out run after any memory edit
+ * (update / forget; future supersede hangs off the same entry point). Keeps the
+ * four cache tiers from serving a fact that just changed:
+ *
+ *   T0  in-process working sets  → evict the chunk from every session
+ *   T1  cache.hot_chunks         → drop the chunk's hot entry
+ *   T2  cache.recall             → broad bust (UNLOGGED, cheap)
+ *   QA  cache.qa                 → invalidate answers derived from the chunk
+ *
+ * Before this, update/forget busted recall + hot_chunks but left T0 stale (its
+ * evict() had no caller) and never touched the QA cache — the most dangerous
+ * gap: same question, stale answer, for up to the cache's 90-day TTL.
+ *
+ * Every step is fail-soft: an invalidation hiccup must not break the edit that
+ * triggered it (the data write already committed).
+ */
+import { evictFromAllWorkingSets } from "../recall/working-set.js";
+import { invalidateCachedAnswersByDoc } from "../cache/qa.js";
+export async function invalidateChunk(pool, chunkId, reason) {
+    // T0 — in-process, synchronous.
+    evictFromAllWorkingSets(chunkId);
+    // T1 — drop the chunk's hot-cache entry.
+    await pool
+        .query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [chunkId])
+        .catch(() => undefined);
+    // T2 — broad bust of the query-result cache (UNLOGGED, ephemeral).
+    await pool
+        .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
+        .catch(() => undefined);
+    // QA — answers derived from this chunk.
+    await invalidateCachedAnswersByDoc(pool, chunkId, reason).catch(() => undefined);
+}

--- a/dist/src/edit/operations.js
+++ b/dist/src/edit/operations.js
@@ -19,6 +19,7 @@
  */
 import { randomUUID } from "node:crypto";
 import pgvector from "pgvector/pg";
+import { invalidateChunk } from "./invalidate.js";
 export async function updateChunk(deps, params) {
     const existing = await deps.pool.query(`SELECT agent_id, text FROM semantic.chunks WHERE id = $1`, [params.chunkId]);
     if (existing.rowCount === 0) {
@@ -74,15 +75,9 @@ export async function updateChunk(deps, params) {
        VALUES ($1, 'edit', null, $2, 'updated', 'edit_update',
                100, '', $3, $4, now())`, [randomUUID(), params.agentId, params.chunkId, params.reason ?? null])
         .catch(() => { });
-    // Invalidate cache.recall entries that might have surfaced this chunk
-    // with stale text. Cheap broad invalidation; cache.recall is UNLOGGED.
-    await deps.pool
-        .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
-        .catch(() => undefined);
-    // Drop hot_chunks for this chunk so T1 doesn't keep the old warmth.
-    await deps.pool
-        .query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-        .catch(() => undefined);
+    // Invalidate every cache tier (T0 working sets, hot_chunks, recall, QA) that
+    // might still serve the now-stale text.
+    await invalidateChunk(deps.pool, params.chunkId, "edit_update");
     return { ok: true, chunkId: params.chunkId, reEmbedded };
 }
 export async function forgetChunk(deps, params) {
@@ -100,21 +95,15 @@ export async function forgetChunk(deps, params) {
         ]);
         await deps.pool.query(`DELETE FROM semantic.chunk_indexes WHERE chunk_id = $1`, [params.chunkId])
             .catch(() => undefined);
-        await deps.pool.query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-            .catch(() => undefined);
     }
     else {
         await deps.pool.query(`UPDATE semantic.chunks
           SET retention_class = 'trash',
               updated_at = now()
         WHERE id = $1 AND agent_id = $2`, [params.chunkId, params.agentId]);
-        await deps.pool.query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-            .catch(() => undefined);
     }
-    // Bust cache.recall broadly — cheap, UNLOGGED.
-    await deps.pool
-        .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
-        .catch(() => undefined);
+    // Invalidate every cache tier (T0 working sets, hot_chunks, recall, QA).
+    await invalidateChunk(deps.pool, params.chunkId, mode === "tombstone" ? "forget_tombstone" : "forget_trash");
     await deps.pool
         .query(`INSERT INTO audit.ingest_decisions
          (id, source, agent_session_id, agent_id, decision, ingest_path,

--- a/dist/src/ingest/pipeline.js
+++ b/dist/src/ingest/pipeline.js
@@ -24,6 +24,13 @@ import { hashTextForCache, MemoryEmbeddingCache, } from "../cache/embeddings.js"
 import { mergeExtractorResults, parseSidecar, } from "./sidecar.js";
 import { trashFilter } from "./trash.js";
 const DEFAULT_KIND = "fact";
+/* ----------------------------- residual gating ---------------------------- */
+// Stage 4 LLM residual fires when deterministic extraction is weak by COMBINED
+// CONFIDENCE (this subsumes the old empty-only gate). Two guards bound the cost
+// of deep extraction. Tunable; promote to config if the residual gets wired.
+const RESIDUAL_CONFIDENCE_THRESHOLD = 0.7;
+const RESIDUAL_MAX_CHARS = 4000;
+const RESIDUAL_DAILY_TOKEN_BUDGET = 50_000;
 /* ------------------------- concept_tag derivation ------------------------- */
 /**
  * Stage 0 deterministic concept_tag derivation. No LLM, no embeddings.
@@ -87,6 +94,29 @@ function deriveConceptTags(text) {
         .map(([tag]) => tag);
 }
 export const _conceptTagInternal = { deriveConceptTags };
+/** Average confidence across all extracted candidates; 0 when nothing fired. */
+function combinedConfidence(r) {
+    const confs = [
+        ...r.entities.map((e) => e.confidence),
+        ...r.events.map((e) => e.confidence),
+        ...r.preferences.map((p) => p.confidence),
+        ...r.metrics.map((m) => m.confidence),
+        ...r.relations.map((x) => x.confidence),
+    ];
+    if (confs.length === 0) {
+        return 0;
+    }
+    return confs.reduce((a, b) => a + b, 0) / confs.length;
+}
+export const _residualInternal = { combinedConfidence };
+/** Residual LLM tokens already spent today (UTC day) — the daily-budget guard. */
+async function residualTokensSpentToday(pool) {
+    const r = await pool.query(`SELECT coalesce(sum(llm_tokens_used), 0)::text AS sum
+       FROM audit.ingest_decisions
+      WHERE ingest_path = 'llm_residual'
+        AND scored_at >= date_trunc('day', now())`);
+    return Number(r.rows[0]?.sum ?? 0);
+}
 /* ----------------------------- multi-key idx ------------------------------ */
 async function writeMultiKeyIndexes(pool, chunkId, input, result, categories, now) {
     const inserts = [];
@@ -201,21 +231,24 @@ export async function ingestOne(deps, input) {
             path = "deterministic";
         }
     }
-    // ---------- Stage 4 LLM residual (only when both stages produced little) ----
-    const detWeak = det.metrics.length === 0
-        && det.events.length === 0
-        && det.preferences.length === 0
-        && det.relations.length === 0;
-    const sideWeak = !sidecar?.ok
-        || (sidecar.result.metrics.length === 0
-            && sidecar.result.events.length === 0
-            && sidecar.result.preferences.length === 0
-            && sidecar.result.relations.length === 0);
-    if (detWeak && sideWeak && deps.llmResidual) {
-        const r = await deps.llmResidual(text, input.signals ?? {});
-        llmTokensUsed += r.tokensUsed;
-        extractor = mergeExtractorResults(r.result, extractor);
-        path = "llm_residual";
+    // ---------- Stage 4 LLM residual ----------
+    // Fire on LOW CONFIDENCE, not just emptiness: a chunk where the regex
+    // extractors caught only a little, weakly, is exactly where the long tail
+    // (coreference, implicit preferences, cross-turn facts) hides. Two guards
+    // keep deep extraction from running away on cost — a per-chunk char cap and
+    // a daily token budget. (Inert until a residual model is bound to
+    // deps.llmResidual; the gate is ready for when it is.)
+    const detConf = combinedConfidence(det);
+    const sideConf = sidecar?.ok ? combinedConfidence(sidecar.result) : 0;
+    const weak = detConf < RESIDUAL_CONFIDENCE_THRESHOLD && sideConf < RESIDUAL_CONFIDENCE_THRESHOLD;
+    if (weak && deps.llmResidual && text.length <= RESIDUAL_MAX_CHARS) {
+        const spentToday = await residualTokensSpentToday(deps.pool).catch(() => 0);
+        if (spentToday < RESIDUAL_DAILY_TOKEN_BUDGET) {
+            const r = await deps.llmResidual(text, input.signals ?? {});
+            llmTokensUsed += r.tokensUsed;
+            extractor = mergeExtractorResults(r.result, extractor);
+            path = "llm_residual";
+        }
     }
     // ---------- Stage 3 cache + write semantic.chunks ----------
     const textHash = hashTextForCache(text);

--- a/dist/src/ingest/pipeline.js
+++ b/dist/src/ingest/pipeline.js
@@ -30,7 +30,6 @@ const DEFAULT_KIND = "fact";
 // of deep extraction. Tunable; promote to config if the residual gets wired.
 const RESIDUAL_CONFIDENCE_THRESHOLD = 0.7;
 const RESIDUAL_MAX_CHARS = 4000;
-const RESIDUAL_DAILY_TOKEN_BUDGET = 50_000;
 /* ------------------------- concept_tag derivation ------------------------- */
 /**
  * Stage 0 deterministic concept_tag derivation. No LLM, no embeddings.
@@ -243,7 +242,7 @@ export async function ingestOne(deps, input) {
     const weak = detConf < RESIDUAL_CONFIDENCE_THRESHOLD && sideConf < RESIDUAL_CONFIDENCE_THRESHOLD;
     if (weak && deps.llmResidual && text.length <= RESIDUAL_MAX_CHARS) {
         const spentToday = await residualTokensSpentToday(deps.pool).catch(() => 0);
-        if (spentToday < RESIDUAL_DAILY_TOKEN_BUDGET) {
+        if (spentToday < deps.cfg.residual.dailyTokenBudget) {
             const r = await deps.llmResidual(text, input.signals ?? {});
             llmTokensUsed += r.tokensUsed;
             extractor = mergeExtractorResults(r.result, extractor);

--- a/dist/src/ingest/residual.js
+++ b/dist/src/ingest/residual.js
@@ -1,0 +1,81 @@
+import { ReflectionClient } from "../embedding/reflection-client.js";
+function emptyResult() {
+    return { entities: [], events: [], preferences: [], metrics: [], relations: [], commitments: [], extractorVersion: "vresidual-1" };
+}
+const SYSTEM_PROMPT = `You extract durable PREFERENCES from a single chat message into JSON.
+A preference is a lasting like, dislike, choice, or rule the user expressed or clearly implied
+("switched to dark mode", "can't stand meetings before noon", "always books aisle seats").
+Do NOT extract one-off facts, events, questions, or anything you have to guess at.
+
+Output ONLY this JSON object, no prose, no code fences:
+{"preferences":[{"key":"<short snake_case topic>","value":"<the preference, concise>","confidence":<0..1>}]}
+Use an empty array when nothing qualifies. confidence reflects how clearly it was stated.`;
+/** Parse the model's JSON into PreferenceCandidates, tolerating fences/prose. */
+export function parseResidualPreferences(text) {
+    let obj;
+    try {
+        const m = text.match(/\{[\s\S]*\}/); // first {...} block
+        if (!m) {
+            return [];
+        }
+        obj = JSON.parse(m[0]);
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const p of obj.preferences ?? []) {
+        if (typeof p?.key !== "string" || !p.key.trim()) {
+            continue;
+        }
+        const v = p.value;
+        if (v == null || (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean")) {
+            continue;
+        }
+        const conf = typeof p.confidence === "number" ? Math.max(0, Math.min(1, p.confidence)) : 0.6;
+        out.push({ scope: "global", key: p.key.trim().toLowerCase().slice(0, 64), value: v, confidence: conf });
+    }
+    return out.slice(0, 8);
+}
+// In-process requests-per-minute guard (free-tier RPM safety).
+let rpmWindowStart = 0;
+let rpmCount = 0;
+function withinRpm(maxRpm, nowMs) {
+    if (nowMs - rpmWindowStart >= 60_000) {
+        rpmWindowStart = nowMs;
+        rpmCount = 0;
+    }
+    if (rpmCount >= maxRpm) {
+        return false;
+    }
+    rpmCount += 1;
+    return true;
+}
+/**
+ * Build the residual extractor, or `undefined` when disabled/unconfigured (the
+ * pipeline then runs deterministic-only, unchanged). `clientOverride` is for
+ * tests. Wire the result into `IngestDeps.llmResidual`.
+ */
+export function buildResidualExtractor(cfg, clientOverride) {
+    const r = cfg.residual;
+    if (!r.enabled || !r.model.baseUrl) {
+        return undefined;
+    }
+    const client = clientOverride ?? new ReflectionClient({
+        baseUrl: r.model.baseUrl,
+        model: r.model.model,
+        format: r.model.format,
+        apiKey: r.model.apiKeyEnv ? process.env[r.model.apiKeyEnv] : undefined,
+    });
+    return async (text) => {
+        if (!withinRpm(r.maxRpm, Date.now())) {
+            return { result: emptyResult(), tokensUsed: 0 };
+        }
+        const resp = await client.chat({ systemPrompt: SYSTEM_PROMPT, userPrompt: text, maxOutputTokens: 400, temperature: 0.1 });
+        if (!resp.ok) {
+            return { result: emptyResult(), tokensUsed: 0 };
+        } // fail-soft: 429 / timeout / error
+        const preferences = parseResidualPreferences(resp.text);
+        return { result: { ...emptyResult(), preferences }, tokensUsed: resp.inputTokens + resp.outputTokens };
+    };
+}

--- a/dist/src/recall/relevance.js
+++ b/dist/src/recall/relevance.js
@@ -1,0 +1,15 @@
+export async function recordCitationFollowup(pool, agentId, chunkId, windowMs) {
+    if (windowMs <= 0) {
+        return;
+    }
+    await pool.query(`UPDATE audit.recall_decisions SET relevance_estimate = 1.0
+       WHERE id = (
+         SELECT id FROM audit.recall_decisions
+          WHERE agent_id = $1
+            AND relevance_estimate IS NULL
+            AND ts > now() - make_interval(secs => $2)
+            AND $3 = ANY(returned_chunk_ids)
+          ORDER BY ts DESC
+          LIMIT 1
+       )`, [agentId, windowMs / 1000, chunkId]);
+}

--- a/dist/src/recall/router.js
+++ b/dist/src/recall/router.js
@@ -203,6 +203,7 @@ export async function recall(deps, input) {
             llmTokensUsed: 0,
             score,
             latencyMs: Date.now() - start,
+            returnedChunkIds: t0Hits.map((c) => c.chunkId),
         });
         return {
             results: t0Hits,
@@ -231,6 +232,7 @@ export async function recall(deps, input) {
             llmTokensUsed: 0,
             score,
             latencyMs: Date.now() - start,
+            returnedChunkIds: filtered.map((c) => c.chunkId),
         });
         return {
             results: filtered,
@@ -413,6 +415,7 @@ export async function recall(deps, input) {
         llmTokensUsed: 0,
         score,
         latencyMs: Date.now() - start,
+        returnedChunkIds: filtered.map((c) => c.chunkId),
     });
     return {
         results: filtered,
@@ -434,8 +437,8 @@ async function auditRecall(deps, input, partial) {
         .query(`INSERT INTO audit.recall_decisions
         (id, query_text, hit_tier, candidates, returned,
          agent_session_id, agent_id, llm_tokens_used, embed_calls, latency_ms,
-         score, scored_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())`, [
+         score, returned_chunk_ids, scored_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::uuid[], now())`, [
         id,
         input.query,
         partial.hitTier,
@@ -447,6 +450,7 @@ async function auditRecall(deps, input, partial) {
         partial.embedCalls,
         partial.latencyMs,
         partial.score,
+        partial.returnedChunkIds,
     ])
         .catch(() => {
         /* audit-write failures intentionally swallowed */

--- a/dist/src/recall/router.js
+++ b/dist/src/recall/router.js
@@ -95,6 +95,8 @@ function inferConceptTagsFromQuery(query) {
 }
 const DEFAULT_K = 12;
 const T2_PER_ROUTE_K = 6;
+/** Score multiplier for chunks whose fact was superseded by a later chunk. */
+const SUPERSEDED_PENALTY = 0.2;
 const STRUCTURED_ROUTES = [
     "anchor",
     "entity_ref",
@@ -356,6 +358,20 @@ export async function recall(deps, input) {
         }
         else {
             all.push(c);
+        }
+    }
+    // Down-weight chunks whose underlying fact was superseded by a later chunk
+    // (P1#3). They stay recallable — for audit / "what did I used to think" — but
+    // lose to the current truth. One batched lookup on superseded_by.
+    if (all.length > 0) {
+        const sup = await deps.pool.query(`SELECT id FROM semantic.chunks WHERE id = ANY($1::uuid[]) AND superseded_by IS NOT NULL`, [all.map((c) => c.chunkId)]);
+        if (sup.rowCount && sup.rowCount > 0) {
+            const supSet = new Set(sup.rows.map((r) => r.id));
+            for (const c of all) {
+                if (supSet.has(c.chunkId)) {
+                    c.combinedScore *= SUPERSEDED_PENALTY;
+                }
+            }
         }
     }
     const reranked = mmrRerank(all, k);

--- a/dist/src/recall/working-set.js
+++ b/dist/src/recall/working-set.js
@@ -145,6 +145,17 @@ export function clearAllWorkingSets() {
     REGISTRY.clear();
 }
 /**
+ * Evict a chunk from every live working set. Called on memory edit/forget so a
+ * curated-away or rewritten chunk can't keep surfacing from any session's T0.
+ * (`WorkingSet.evict` existed but had no caller — stale T0 entries used to age
+ * out only by LRU until this fan-out was wired.)
+ */
+export function evictFromAllWorkingSets(chunkId) {
+    for (const ws of REGISTRY.values()) {
+        ws.evict(chunkId);
+    }
+}
+/**
  * Profile chunks (`kind='profile'`) are the "core memory" pattern borrowed
  * from MemGPT/Letta: per-agent (and optionally per-entity) summaries that
  * stay resident in T0 across every recall, instead of being one of many

--- a/dist/src/storage/migrate.js
+++ b/dist/src/storage/migrate.js
@@ -63,15 +63,23 @@ export async function migrate(pool) {
             throw new Error(`[memory-postgres] migration failed on ${filename}: ${error.message}`, { cause: error });
         }
     }
-    // HNSW index is dim-locked, so we defer until embedding probe writes the
-    // dimension to audit.plugin_meta. Returns whether we still need to do it.
+    // Enable pgvectorscale if its files are installed (the custom image). On a
+    // plain pgvector image this is a guarded no-op. Lets ensureHnswIndex pick
+    // DiskANN, which — unlike HNSW — indexes >2000-dim vectors.
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE").catch(() => undefined);
+    // The vector index is dim-locked, so we defer until the embedding probe
+    // writes the dimension to audit.plugin_meta. Returns whether it's still owed.
     const hnswDeferred = !(await ensureHnswIndex(pool));
     return { applied, skipped, hnswDeferred };
 }
 /**
- * Create the HNSW vector index on semantic.chunks once we know the embedding
- * dimension. Returns true when the index now exists, false if dim is still
- * unknown (caller should retry after embedding probe).
+ * Create the ANN vector index on semantic.chunks once we know the embedding
+ * dimension. Prefers pgvectorscale's DiskANN when the `vectorscale` extension
+ * is present — its SBQ-compressed layout indexes high-dim vectors (e.g. 4096-d
+ * Qwen3-Embedding-8B), whereas pgvector's HNSW is capped at 2000 dims by the
+ * 8 KB index-tuple page limit. Falls back to HNSW (≤2000). Returns true when an
+ * index now exists; false if the dim is still unknown, or it's >2000 and only
+ * HNSW is available (recall then runs as an exact scan until DiskANN is added).
  */
 export async function ensureHnswIndex(pool) {
     const meta = await pool.query("SELECT value FROM audit.plugin_meta WHERE key = 'embedding.dims'");
@@ -79,23 +87,30 @@ export async function ensureHnswIndex(pool) {
     if (typeof dims !== "number" || dims <= 0) {
         return false;
     }
-    // Check if index already exists.
+    // Either index method already present → done.
     const existing = await pool.query(`SELECT 1 FROM pg_indexes
-       WHERE schemaname = 'semantic'
-         AND tablename  = 'chunks'
-         AND indexname  = 'chunks_hnsw'`);
+       WHERE schemaname = 'semantic' AND tablename = 'chunks'
+         AND indexname IN ('chunks_hnsw', 'chunks_diskann')`);
     if (existing.rowCount && existing.rowCount > 0) {
         return true;
     }
-    // pgvector HNSW requires the column to be declared with a fixed dimension.
-    // We migrated `embedding` as VECTOR (any dim) so the schema file can ship
-    // before dims are known; here we promote it to VECTOR(N) once we have N
-    // and add the HNSW index. Existing rows are preserved through a USING cast.
+    const vs = await pool.query("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'");
+    const useDiskann = (vs.rowCount ?? 0) > 0;
+    if (!useDiskann && dims > 2000) {
+        // HNSW can't index this dim and DiskANN isn't installed; leave it unindexed
+        // (recall falls back to exact scan). Install pgvectorscale to enable it.
+        return false;
+    }
+    // Both methods need a fixed-dimension column. We ship `embedding` as VECTOR
+    // (any dim) so the schema file can land before dims are known; here we
+    // promote it to VECTOR(N) and build the index. Existing rows survive the cast.
+    const method = useDiskann ? "diskann" : "hnsw";
+    const indexName = useDiskann ? "chunks_diskann" : "chunks_hnsw";
     await pool.query(`
     ALTER TABLE semantic.chunks
       ALTER COLUMN embedding TYPE VECTOR(${dims}) USING embedding::VECTOR(${dims});
-    CREATE INDEX IF NOT EXISTS chunks_hnsw
-      ON semantic.chunks USING hnsw (embedding vector_cosine_ops);
+    CREATE INDEX IF NOT EXISTS ${indexName}
+      ON semantic.chunks USING ${method} (embedding vector_cosine_ops);
   `);
     return true;
 }

--- a/dist/src/storage/schema/63-chunks-updated-at.sql
+++ b/dist/src/storage/schema/63-chunks-updated-at.sql
@@ -1,0 +1,7 @@
+-- semantic.chunks.updated_at — marks agent-driven curation time, set by the
+-- edit operations (updateChunk / forgetChunk). The edit path referenced this
+-- column but it was never defined, so memory_update / memory_forget threw
+-- `column "updated_at" does not exist` at runtime. Nullable (null = never
+-- edited); ADD COLUMN IF NOT EXISTS is a fast metadata-only change and stays
+-- idempotent across existing deployments.
+ALTER TABLE semantic.chunks ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;

--- a/dist/src/storage/schema/64-chunks-superseded-by.sql
+++ b/dist/src/storage/schema/64-chunks-superseded-by.sql
@@ -1,0 +1,6 @@
+-- semantic.chunks.superseded_by — points at the later chunk whose fact replaced
+-- this one (set by reconcile when a preference value changes). Recall
+-- down-weights superseded chunks so the current truth wins, while the old chunk
+-- stays recallable for audit / "what did I used to think". Nullable; plain UUID
+-- (no FK) so a hard-delete of the newer chunk can't cascade-block the older one.
+ALTER TABLE semantic.chunks ADD COLUMN IF NOT EXISTS superseded_by UUID;

--- a/dist/src/storage/schema/65-recall-returned-chunks.sql
+++ b/dist/src/storage/schema/65-recall-returned-chunks.sql
@@ -1,0 +1,5 @@
+-- audit.recall_decisions.returned_chunk_ids — the chunks a recall actually
+-- returned. Lets a later memory_get (citation follow-up) credit the recall that
+-- surfaced the chunk with a relevance signal (P0#2). Nullable array; older rows
+-- stay NULL and are simply never matched.
+ALTER TABLE audit.recall_decisions ADD COLUMN IF NOT EXISTS returned_chunk_ids UUID[];

--- a/dist/src/structured/reconcile.js
+++ b/dist/src/structured/reconcile.js
@@ -72,7 +72,7 @@ export async function reconcile(pool, input) {
             out.eventIds.push(id);
         }
         for (const p of input.result.preferences) {
-            const { id, deduped } = await upsertPreference(client, p);
+            const { id, deduped } = await upsertPreference(client, p, input.chunkId);
             if (deduped) {
                 out.dedupCount += 1;
             }
@@ -189,7 +189,7 @@ async function upsertEvent(client, ev, actorId, targetId) {
     return { id, deduped: false };
 }
 /* ------------------------------- preferences ------------------------------- */
-async function upsertPreference(client, p) {
+async function upsertPreference(client, p, chunkId) {
     const existing = await client.query(`SELECT id, value, evidence_count FROM structured.preferences
        WHERE scope = $1 AND key = $2 AND invalidated_at IS NULL
        LIMIT 1`, [p.scope, p.key]);
@@ -203,6 +203,14 @@ async function upsertPreference(client, p) {
         }
         // Supersede: invalidate old, write new linked.
         await client.query("UPDATE structured.preferences SET invalidated_at = now() WHERE id = $1", [row.id]);
+        // Mark the old preference's source chunk(s) as superseded by this chunk so
+        // recall down-weights the now-outdated fact (P1#3). Provenance links the
+        // old preference id → its originating chunk.
+        await client.query(`UPDATE semantic.chunks SET superseded_by = $1
+         WHERE id IN (SELECT chunk_id FROM structured.provenance
+                        WHERE item_kind = 'preference' AND item_id = $2 AND chunk_id IS NOT NULL)
+           AND id <> $1
+           AND superseded_by IS NULL`, [chunkId, row.id]);
         const id = randomUUID();
         await client.query(`INSERT INTO structured.preferences
          (id, scope, key, value, rule_text, evidence_count, confidence, supersedes)

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -10,6 +10,7 @@ import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
+import { recordCitationFollowup } from "./recall/relevance.js";
 import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
 import { getPool } from "./storage/pool.js";
@@ -358,6 +359,11 @@ export function buildGetTool(args) {
                 };
             }
             const c = outcome.chunk;
+            // P0#2: a citation follow-up (memory_get on a recalled chunk) is a
+            // positive relevance signal for the recall that surfaced it. Fire-and-
+            // forget; never block the read.
+            void recordCitationFollowup(pool, agentId, c.chunkId, cfg.scoring.recall.relevanceFollowupWindowMs)
+                .catch(() => undefined);
             const cm = (await getActiveCommitmentsByChunk(pool, [c.chunkId], agentId))[0] ?? null;
             const flag = cm?.requiresConfirmation
                 ? `\n⚠ action-sensitive (${cm.kind}) — confirm with the user before acting on this.`

--- a/dist/src/tools.js
+++ b/dist/src/tools.js
@@ -9,6 +9,7 @@ import { resolveConfig, validateConfig } from "./config.js";
 import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
+import { buildResidualExtractor } from "./ingest/residual.js";
 import { recall } from "./recall/router.js";
 import { recordCitationFollowup } from "./recall/relevance.js";
 import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
@@ -437,7 +438,7 @@ export function buildStoreTool(args) {
         async execute(_toolCallId, params) {
             const p = params;
             const { cfg, pool, embedding } = await setup(pluginConfigOf(args.config));
-            const outcome = await ingestOne({ cfg, pool, embedding }, {
+            const outcome = await ingestOne({ cfg, pool, embedding, llmResidual: buildResidualExtractor(cfg) }, {
                 text: p.text,
                 source: "manual",
                 kind: "fact",

--- a/index.ts
+++ b/index.ts
@@ -123,6 +123,7 @@ async function handleDashboardCommand(
 }
 
 import { startTranscriptWatcherDaemon, type TranscriptWatcherHandle } from "./src/workers/transcript-watcher.js";
+import { buildResidualExtractor } from "./src/ingest/residual.js";
 import { startShadowComparator } from "./src/workers/shadow-comparator.js";
 import { evaluateGuards, runDailyAnalyzer } from "./src/workers/tuning.js";
 import { ingestCompactionSummary } from "./src/workers/compaction-ingest.js";
@@ -559,6 +560,7 @@ export default definePluginEntry({
               cfg,
               pool,
               embedding,
+              llmResidual: buildResidualExtractor(cfg),
               watcher,
               logger: { info: (m) => api.logger.info(m), warn: (m) => api.logger.warn(m) },
             });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -615,6 +615,41 @@
           }
         }
       },
+      "residual": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Stage 4 LLM residual extractor — deep extraction (preferences) for the regex long tail, fired on low-confidence chunks. Off by default. Fail-soft on errors; RPM + daily-token guards keep a free-tier model safe.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "maxRpm": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Requests/minute cap (the broker rotates keys; this stops bursts like a transcript replay). Default 8."
+          },
+          "dailyTokenBudget": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Daily residual token budget; deep extraction pauses for the day past it. Default 50000."
+          },
+          "model": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["format"],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": ["openai", "gemini"]
+              },
+              "baseUrl": { "type": "string" },
+              "model": { "type": "string" },
+              "apiKeyEnv": { "type": "string" }
+            }
+          }
+        }
+      },
       "reflection": {
         "type": "object",
         "additionalProperties": false,

--- a/src/cache/qa.ts
+++ b/src/cache/qa.ts
@@ -279,6 +279,26 @@ export async function invalidateCachedAnswer(
   );
 }
 
+/**
+ * Invalidate every cached answer derived from a given source chunk/doc. Called
+ * from the chunk-invalidation path so a forgotten/rewritten chunk stops serving
+ * a stale answer — without this the QA cache's 90-day TTL outlives the fact.
+ * Matches on `source_doc_id`, the direct provenance link. Returns the count
+ * invalidated.
+ */
+export async function invalidateCachedAnswersByDoc(
+  pool: Pool,
+  sourceDocId: string,
+  reason: string,
+): Promise<number> {
+  const r = await pool.query(
+    `UPDATE cache.qa SET invalidated = true, invalidated_reason = $2
+       WHERE source_doc_id = $1 AND NOT invalidated`,
+    [sourceDocId, reason],
+  );
+  return r.rowCount ?? 0;
+}
+
 export async function recordCacheFeedback(
   pool: Pool,
   id: string,

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,6 +149,7 @@ export type MemoryPostgresConfig = {
    * and pointing `model` at an OpenAI-compat or native-Gemini endpoint.
    */
   reflection?: ReflectionConfig;
+  residual?: ResidualConfig;
   /**
    * Moderator service (Phase C). When enabled, hooks openclaw's
    * Telegram `message_received` event and runs an orchestrator-worker
@@ -196,6 +197,19 @@ export type ReflectionConfig = {
   maxInputChars?: number;
   /** LLM endpoint. Two supported formats — see below. */
   model: ReflectionModelConfig;
+};
+
+/** Stage 4 LLM residual extractor (deep extraction for the regex long tail). */
+export type ResidualConfig = {
+  /** Master switch. Default false (deterministic-only ingest). */
+  enabled?: boolean;
+  /** Requests/minute cap — the broker rotates keys, this stops a burst (e.g.
+   *  transcript replay) from spamming a free-tier model. Default 8. */
+  maxRpm?: number;
+  /** Daily residual token budget; deep extraction pauses for the day past it. Default 50000. */
+  dailyTokenBudget?: number;
+  /** LLM endpoint (reuses the reflection model shape). Defaults to credbroker gemini-2.5-flash. */
+  model?: ReflectionModelConfig;
 };
 
 export type ReflectionModelConfig = {
@@ -335,6 +349,7 @@ export type ResolvedMemoryPostgresConfig = {
   transcriptWatchers: ResolvedTranscriptWatcher[];
   shadowComparators: ResolvedShadowComparator[];
   reflection: ResolvedReflectionConfig;
+  residual: ResolvedResidualConfig;
   moderator: ResolvedModeratorConfig;
 };
 
@@ -357,6 +372,18 @@ export type ResolvedReflectionConfig = {
   intervalMs: number;
   lookbackHours: number;
   maxInputChars: number;
+  model: {
+    format: "openai" | "gemini";
+    baseUrl: string;
+    model: string;
+    apiKeyEnv?: string;
+  };
+};
+
+export type ResolvedResidualConfig = {
+  enabled: boolean;
+  maxRpm: number;
+  dailyTokenBudget: number;
   model: {
     format: "openai" | "gemini";
     baseUrl: string;
@@ -495,6 +522,7 @@ export function resolveConfig(raw: MemoryPostgresConfig): ResolvedMemoryPostgres
     transcriptWatchers: (raw.transcriptWatchers ?? []).map(resolveTranscriptWatcher),
     shadowComparators: (raw.shadowComparators ?? []).map(resolveShadowComparator),
     reflection: resolveReflectionConfig(raw.reflection, credbroker),
+    residual: resolveResidualConfig(raw.residual, credbroker),
     moderator: resolveModeratorConfig(raw.moderator, credbroker),
   };
 }
@@ -564,6 +592,28 @@ function resolveModeratorConfig(
       apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
     },
     publishSkillsDir,
+  };
+}
+
+function resolveResidualConfig(
+  raw: ResidualConfig | undefined,
+  credbroker: ResolvedCredbrokerConfig,
+): ResolvedResidualConfig {
+  const block = raw ?? ({} as ResidualConfig);
+  const modelBlock = block.model ?? ({} as ReflectionModelConfig);
+  // Default to gemini (the credbroker only proxies gemini); honour an explicit openai.
+  const format = modelBlock.format === "openai" ? "openai" : "gemini";
+  const credbrokerFallback = format === "gemini" ? credbroker.geminiUrl : null;
+  return {
+    enabled: bool(block.enabled, false),
+    maxRpm: Math.max(1, num(block.maxRpm, 8)),
+    dailyTokenBudget: Math.max(0, num(block.dailyTokenBudget, 50_000)),
+    model: {
+      format,
+      baseUrl: isString(modelBlock.baseUrl) ? modelBlock.baseUrl : (credbrokerFallback ?? ""),
+      model: isString(modelBlock.model) ? modelBlock.model : "gemini-2.5-flash",
+      apiKeyEnv: isString(modelBlock.apiKeyEnv) ? modelBlock.apiKeyEnv : undefined,
+    },
   };
 }
 

--- a/src/edit/invalidate.ts
+++ b/src/edit/invalidate.ts
@@ -1,0 +1,36 @@
+/**
+ * Unified chunk invalidation — the single fan-out run after any memory edit
+ * (update / forget; future supersede hangs off the same entry point). Keeps the
+ * four cache tiers from serving a fact that just changed:
+ *
+ *   T0  in-process working sets  → evict the chunk from every session
+ *   T1  cache.hot_chunks         → drop the chunk's hot entry
+ *   T2  cache.recall             → broad bust (UNLOGGED, cheap)
+ *   QA  cache.qa                 → invalidate answers derived from the chunk
+ *
+ * Before this, update/forget busted recall + hot_chunks but left T0 stale (its
+ * evict() had no caller) and never touched the QA cache — the most dangerous
+ * gap: same question, stale answer, for up to the cache's 90-day TTL.
+ *
+ * Every step is fail-soft: an invalidation hiccup must not break the edit that
+ * triggered it (the data write already committed).
+ */
+
+import type { Pool } from "pg";
+import { evictFromAllWorkingSets } from "../recall/working-set.js";
+import { invalidateCachedAnswersByDoc } from "../cache/qa.js";
+
+export async function invalidateChunk(pool: Pool, chunkId: string, reason: string): Promise<void> {
+  // T0 — in-process, synchronous.
+  evictFromAllWorkingSets(chunkId);
+  // T1 — drop the chunk's hot-cache entry.
+  await pool
+    .query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [chunkId])
+    .catch(() => undefined);
+  // T2 — broad bust of the query-result cache (UNLOGGED, ephemeral).
+  await pool
+    .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
+    .catch(() => undefined);
+  // QA — answers derived from this chunk.
+  await invalidateCachedAnswersByDoc(pool, chunkId, reason).catch(() => undefined);
+}

--- a/src/edit/operations.ts
+++ b/src/edit/operations.ts
@@ -23,6 +23,7 @@ import type { Pool } from "pg";
 import pgvector from "pgvector/pg";
 import type { ResolvedMemoryPostgresConfig } from "../config.js";
 import type { EmbeddingClient } from "../embedding/client.js";
+import { invalidateChunk } from "./invalidate.js";
 
 export type EditDeps = {
   cfg: ResolvedMemoryPostgresConfig;
@@ -109,15 +110,9 @@ export async function updateChunk(
     )
     .catch(() => { /* audit-write failures must not break the edit */ });
 
-  // Invalidate cache.recall entries that might have surfaced this chunk
-  // with stale text. Cheap broad invalidation; cache.recall is UNLOGGED.
-  await deps.pool
-    .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
-    .catch(() => undefined);
-  // Drop hot_chunks for this chunk so T1 doesn't keep the old warmth.
-  await deps.pool
-    .query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-    .catch(() => undefined);
+  // Invalidate every cache tier (T0 working sets, hot_chunks, recall, QA) that
+  // might still serve the now-stale text.
+  await invalidateChunk(deps.pool, params.chunkId, "edit_update");
 
   return { ok: true, chunkId: params.chunkId, reEmbedded };
 }
@@ -158,8 +153,6 @@ export async function forgetChunk(
     ]);
     await deps.pool.query(`DELETE FROM semantic.chunk_indexes WHERE chunk_id = $1`, [params.chunkId])
       .catch(() => undefined);
-    await deps.pool.query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-      .catch(() => undefined);
   } else {
     await deps.pool.query(
       `UPDATE semantic.chunks
@@ -168,13 +161,9 @@ export async function forgetChunk(
         WHERE id = $1 AND agent_id = $2`,
       [params.chunkId, params.agentId],
     );
-    await deps.pool.query(`DELETE FROM cache.hot_chunks WHERE chunk_id = $1`, [params.chunkId])
-      .catch(() => undefined);
   }
-  // Bust cache.recall broadly — cheap, UNLOGGED.
-  await deps.pool
-    .query(`UPDATE cache.recall SET invalidated = true WHERE invalidated = false`)
-    .catch(() => undefined);
+  // Invalidate every cache tier (T0 working sets, hot_chunks, recall, QA).
+  await invalidateChunk(deps.pool, params.chunkId, mode === "tombstone" ? "forget_tombstone" : "forget_trash");
 
   await deps.pool
     .query(

--- a/src/ingest/pipeline.ts
+++ b/src/ingest/pipeline.ts
@@ -103,6 +103,14 @@ export type IngestOutcome = {
 
 const DEFAULT_KIND = "fact";
 
+/* ----------------------------- residual gating ---------------------------- */
+// Stage 4 LLM residual fires when deterministic extraction is weak by COMBINED
+// CONFIDENCE (this subsumes the old empty-only gate). Two guards bound the cost
+// of deep extraction. Tunable; promote to config if the residual gets wired.
+const RESIDUAL_CONFIDENCE_THRESHOLD = 0.7;
+const RESIDUAL_MAX_CHARS = 4000;
+const RESIDUAL_DAILY_TOKEN_BUDGET = 50_000;
+
 /* ------------------------- concept_tag derivation ------------------------- */
 /**
  * Stage 0 deterministic concept_tag derivation. No LLM, no embeddings.
@@ -158,6 +166,32 @@ function deriveConceptTags(text: string): string[] {
 }
 
 export const _conceptTagInternal = { deriveConceptTags };
+
+/** Average confidence across all extracted candidates; 0 when nothing fired. */
+function combinedConfidence(r: ExtractorResult): number {
+  const confs = [
+    ...r.entities.map((e) => e.confidence),
+    ...r.events.map((e) => e.confidence),
+    ...r.preferences.map((p) => p.confidence),
+    ...r.metrics.map((m) => m.confidence),
+    ...r.relations.map((x) => x.confidence),
+  ];
+  if (confs.length === 0) {return 0;}
+  return confs.reduce((a, b) => a + b, 0) / confs.length;
+}
+
+export const _residualInternal = { combinedConfidence };
+
+/** Residual LLM tokens already spent today (UTC day) — the daily-budget guard. */
+async function residualTokensSpentToday(pool: Pool): Promise<number> {
+  const r = await pool.query<{ sum: string | null }>(
+    `SELECT coalesce(sum(llm_tokens_used), 0)::text AS sum
+       FROM audit.ingest_decisions
+      WHERE ingest_path = 'llm_residual'
+        AND scored_at >= date_trunc('day', now())`,
+  );
+  return Number(r.rows[0]?.sum ?? 0);
+}
 
 /* ----------------------------- multi-key idx ------------------------------ */
 
@@ -280,21 +314,24 @@ export async function ingestOne(deps: IngestDeps, input: IngestInput): Promise<I
     }
   }
 
-  // ---------- Stage 4 LLM residual (only when both stages produced little) ----
-  const detWeak = det.metrics.length === 0
-    && det.events.length === 0
-    && det.preferences.length === 0
-    && det.relations.length === 0;
-  const sideWeak = !sidecar?.ok
-    || (sidecar.result.metrics.length === 0
-        && sidecar.result.events.length === 0
-        && sidecar.result.preferences.length === 0
-        && sidecar.result.relations.length === 0);
-  if (detWeak && sideWeak && deps.llmResidual) {
-    const r = await deps.llmResidual(text, input.signals ?? {});
-    llmTokensUsed += r.tokensUsed;
-    extractor = mergeExtractorResults(r.result, extractor);
-    path = "llm_residual";
+  // ---------- Stage 4 LLM residual ----------
+  // Fire on LOW CONFIDENCE, not just emptiness: a chunk where the regex
+  // extractors caught only a little, weakly, is exactly where the long tail
+  // (coreference, implicit preferences, cross-turn facts) hides. Two guards
+  // keep deep extraction from running away on cost — a per-chunk char cap and
+  // a daily token budget. (Inert until a residual model is bound to
+  // deps.llmResidual; the gate is ready for when it is.)
+  const detConf = combinedConfidence(det);
+  const sideConf = sidecar?.ok ? combinedConfidence(sidecar.result) : 0;
+  const weak = detConf < RESIDUAL_CONFIDENCE_THRESHOLD && sideConf < RESIDUAL_CONFIDENCE_THRESHOLD;
+  if (weak && deps.llmResidual && text.length <= RESIDUAL_MAX_CHARS) {
+    const spentToday = await residualTokensSpentToday(deps.pool).catch(() => 0);
+    if (spentToday < RESIDUAL_DAILY_TOKEN_BUDGET) {
+      const r = await deps.llmResidual(text, input.signals ?? {});
+      llmTokensUsed += r.tokensUsed;
+      extractor = mergeExtractorResults(r.result, extractor);
+      path = "llm_residual";
+    }
   }
 
   // ---------- Stage 3 cache + write semantic.chunks ----------

--- a/src/ingest/pipeline.ts
+++ b/src/ingest/pipeline.ts
@@ -109,7 +109,6 @@ const DEFAULT_KIND = "fact";
 // of deep extraction. Tunable; promote to config if the residual gets wired.
 const RESIDUAL_CONFIDENCE_THRESHOLD = 0.7;
 const RESIDUAL_MAX_CHARS = 4000;
-const RESIDUAL_DAILY_TOKEN_BUDGET = 50_000;
 
 /* ------------------------- concept_tag derivation ------------------------- */
 /**
@@ -326,7 +325,7 @@ export async function ingestOne(deps: IngestDeps, input: IngestInput): Promise<I
   const weak = detConf < RESIDUAL_CONFIDENCE_THRESHOLD && sideConf < RESIDUAL_CONFIDENCE_THRESHOLD;
   if (weak && deps.llmResidual && text.length <= RESIDUAL_MAX_CHARS) {
     const spentToday = await residualTokensSpentToday(deps.pool).catch(() => 0);
-    if (spentToday < RESIDUAL_DAILY_TOKEN_BUDGET) {
+    if (spentToday < deps.cfg.residual.dailyTokenBudget) {
       const r = await deps.llmResidual(text, input.signals ?? {});
       llmTokensUsed += r.tokensUsed;
       extractor = mergeExtractorResults(r.result, extractor);

--- a/src/ingest/residual.ts
+++ b/src/ingest/residual.ts
@@ -1,0 +1,99 @@
+/**
+ * Stage 4 LLM residual extractor — deep structured extraction for the long tail
+ * the deterministic regex extractors miss (implicit, natural-language facts).
+ *
+ * v1 extracts PREFERENCES only — durable likes/dislikes/choices stated in
+ * natural language ("switched to X", "can't stand Y"), which regex can't catch
+ * and which power preference recall + the supersede chain. Entities/relations
+ * (the graph dimension, needing entity-type allowlist validation) are a v2.
+ *
+ * Cost safety for a free-tier model behind the credbroker (which rotates keys):
+ *   - fail-soft: ANY error (429 / timeout / bad JSON) → empty result; the
+ *     ingest falls back to deterministic. Never throws into the ingest path.
+ *   - in-process RPM guard: caps requests/minute so a burst (e.g. transcript
+ *     replay of hundreds of chunks) can't spam the broker.
+ *   The daily token budget guard lives in the pipeline gate (deps.cfg.residual).
+ */
+import type { ResolvedMemoryPostgresConfig } from "../config.js";
+import { ReflectionClient } from "../embedding/reflection-client.js";
+import type { ExtractorResult, PreferenceCandidate } from "../structured/types.js";
+
+export type LlmResidual = (
+  text: string,
+  signals: Record<string, unknown>,
+) => Promise<{ result: ExtractorResult; tokensUsed: number }>;
+
+function emptyResult(): ExtractorResult {
+  return { entities: [], events: [], preferences: [], metrics: [], relations: [], commitments: [], extractorVersion: "vresidual-1" };
+}
+
+const SYSTEM_PROMPT = `You extract durable PREFERENCES from a single chat message into JSON.
+A preference is a lasting like, dislike, choice, or rule the user expressed or clearly implied
+("switched to dark mode", "can't stand meetings before noon", "always books aisle seats").
+Do NOT extract one-off facts, events, questions, or anything you have to guess at.
+
+Output ONLY this JSON object, no prose, no code fences:
+{"preferences":[{"key":"<short snake_case topic>","value":"<the preference, concise>","confidence":<0..1>}]}
+Use an empty array when nothing qualifies. confidence reflects how clearly it was stated.`;
+
+type RawPref = { key?: unknown; value?: unknown; confidence?: unknown };
+
+/** Parse the model's JSON into PreferenceCandidates, tolerating fences/prose. */
+export function parseResidualPreferences(text: string): PreferenceCandidate[] {
+  let obj: { preferences?: RawPref[] };
+  try {
+    const m = text.match(/\{[\s\S]*\}/); // first {...} block
+    if (!m) {return [];}
+    obj = JSON.parse(m[0]);
+  } catch {
+    return [];
+  }
+  const out: PreferenceCandidate[] = [];
+  for (const p of obj.preferences ?? []) {
+    if (typeof p?.key !== "string" || !p.key.trim()) {continue;}
+    const v = p.value;
+    if (v == null || (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean")) {continue;}
+    const conf = typeof p.confidence === "number" ? Math.max(0, Math.min(1, p.confidence)) : 0.6;
+    out.push({ scope: "global", key: p.key.trim().toLowerCase().slice(0, 64), value: v, confidence: conf });
+  }
+  return out.slice(0, 8);
+}
+
+// In-process requests-per-minute guard (free-tier RPM safety).
+let rpmWindowStart = 0;
+let rpmCount = 0;
+function withinRpm(maxRpm: number, nowMs: number): boolean {
+  if (nowMs - rpmWindowStart >= 60_000) {
+    rpmWindowStart = nowMs;
+    rpmCount = 0;
+  }
+  if (rpmCount >= maxRpm) {return false;}
+  rpmCount += 1;
+  return true;
+}
+
+/**
+ * Build the residual extractor, or `undefined` when disabled/unconfigured (the
+ * pipeline then runs deterministic-only, unchanged). `clientOverride` is for
+ * tests. Wire the result into `IngestDeps.llmResidual`.
+ */
+export function buildResidualExtractor(
+  cfg: ResolvedMemoryPostgresConfig,
+  clientOverride?: Pick<ReflectionClient, "chat">,
+): LlmResidual | undefined {
+  const r = cfg.residual;
+  if (!r.enabled || !r.model.baseUrl) {return undefined;}
+  const client = clientOverride ?? new ReflectionClient({
+    baseUrl: r.model.baseUrl,
+    model: r.model.model,
+    format: r.model.format,
+    apiKey: r.model.apiKeyEnv ? process.env[r.model.apiKeyEnv] : undefined,
+  });
+  return async (text) => {
+    if (!withinRpm(r.maxRpm, Date.now())) {return { result: emptyResult(), tokensUsed: 0 };}
+    const resp = await client.chat({ systemPrompt: SYSTEM_PROMPT, userPrompt: text, maxOutputTokens: 400, temperature: 0.1 });
+    if (!resp.ok) {return { result: emptyResult(), tokensUsed: 0 };} // fail-soft: 429 / timeout / error
+    const preferences = parseResidualPreferences(resp.text);
+    return { result: { ...emptyResult(), preferences }, tokensUsed: resp.inputTokens + resp.outputTokens };
+  };
+}

--- a/src/recall/relevance.ts
+++ b/src/recall/relevance.ts
@@ -1,0 +1,35 @@
+/**
+ * P0#2 — close the recall relevance loop.
+ *
+ * `audit.recall_decisions.relevance_estimate` starts NULL ("pending"); the
+ * weekly tuning loop should learn from real follow-up signals instead of a
+ * hardcoded guess. The cleanest positive signal: the agent follows a recall
+ * citation — it calls memory_get on a chunk a recent recall returned. That
+ * recall surfaced something the agent then chose to read in full → relevant.
+ *
+ * We credit the single most-recent still-pending recall (same agent, within
+ * the follow-up window) that actually returned this chunk.
+ */
+import type { Pool } from "pg";
+
+export async function recordCitationFollowup(
+  pool: Pool,
+  agentId: string,
+  chunkId: string,
+  windowMs: number,
+): Promise<void> {
+  if (windowMs <= 0) {return;}
+  await pool.query(
+    `UPDATE audit.recall_decisions SET relevance_estimate = 1.0
+       WHERE id = (
+         SELECT id FROM audit.recall_decisions
+          WHERE agent_id = $1
+            AND relevance_estimate IS NULL
+            AND ts > now() - make_interval(secs => $2)
+            AND $3 = ANY(returned_chunk_ids)
+          ORDER BY ts DESC
+          LIMIT 1
+       )`,
+    [agentId, windowMs / 1000, chunkId],
+  );
+}

--- a/src/recall/router.ts
+++ b/src/recall/router.ts
@@ -157,6 +157,8 @@ export type RecallOutput = {
 
 const DEFAULT_K = 12;
 const T2_PER_ROUTE_K = 6;
+/** Score multiplier for chunks whose fact was superseded by a later chunk. */
+const SUPERSEDED_PENALTY = 0.2;
 
 export type RecallDeps = {
   cfg: ResolvedMemoryPostgresConfig;
@@ -496,6 +498,22 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
       }
     } else {
       all.push(c);
+    }
+  }
+
+  // Down-weight chunks whose underlying fact was superseded by a later chunk
+  // (P1#3). They stay recallable — for audit / "what did I used to think" — but
+  // lose to the current truth. One batched lookup on superseded_by.
+  if (all.length > 0) {
+    const sup = await deps.pool.query<{ id: string }>(
+      `SELECT id FROM semantic.chunks WHERE id = ANY($1::uuid[]) AND superseded_by IS NOT NULL`,
+      [all.map((c) => c.chunkId)],
+    );
+    if (sup.rowCount && sup.rowCount > 0) {
+      const supSet = new Set(sup.rows.map((r) => r.id));
+      for (const c of all) {
+        if (supSet.has(c.chunkId)) {c.combinedScore *= SUPERSEDED_PENALTY;}
+      }
     }
   }
 

--- a/src/recall/router.ts
+++ b/src/recall/router.ts
@@ -318,6 +318,7 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
       llmTokensUsed: 0,
       score,
       latencyMs: Date.now() - start,
+      returnedChunkIds: t0Hits.map((c) => c.chunkId),
     });
     return {
       results: t0Hits,
@@ -350,6 +351,7 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
       llmTokensUsed: 0,
       score,
       latencyMs: Date.now() - start,
+      returnedChunkIds: filtered.map((c) => c.chunkId),
     });
     return {
       results: filtered,
@@ -573,6 +575,7 @@ export async function recall(deps: RecallDeps, input: RecallInput): Promise<Reca
     llmTokensUsed: 0,
     score,
     latencyMs: Date.now() - start,
+    returnedChunkIds: filtered.map((c) => c.chunkId),
   });
 
   return {
@@ -602,6 +605,7 @@ async function auditRecall(
     llmTokensUsed: number;
     score: number;
     latencyMs: number;
+    returnedChunkIds: string[];
   },
 ): Promise<void> {
   const id = randomUUID();
@@ -610,8 +614,8 @@ async function auditRecall(
       `INSERT INTO audit.recall_decisions
         (id, query_text, hit_tier, candidates, returned,
          agent_session_id, agent_id, llm_tokens_used, embed_calls, latency_ms,
-         score, scored_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now())`,
+         score, returned_chunk_ids, scored_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::uuid[], now())`,
       [
         id,
         input.query,
@@ -624,6 +628,7 @@ async function auditRecall(
         partial.embedCalls,
         partial.latencyMs,
         partial.score,
+        partial.returnedChunkIds,
       ],
     )
     .catch(() => {

--- a/src/recall/working-set.ts
+++ b/src/recall/working-set.ts
@@ -158,6 +158,18 @@ export function clearAllWorkingSets(): void {
 }
 
 /**
+ * Evict a chunk from every live working set. Called on memory edit/forget so a
+ * curated-away or rewritten chunk can't keep surfacing from any session's T0.
+ * (`WorkingSet.evict` existed but had no caller — stale T0 entries used to age
+ * out only by LRU until this fan-out was wired.)
+ */
+export function evictFromAllWorkingSets(chunkId: string): void {
+  for (const ws of REGISTRY.values()) {
+    ws.evict(chunkId);
+  }
+}
+
+/**
  * Profile chunks (`kind='profile'`) are the "core memory" pattern borrowed
  * from MemGPT/Letta: per-agent (and optionally per-entity) summaries that
  * stay resident in T0 across every recall, instead of being one of many

--- a/src/storage/migrate.ts
+++ b/src/storage/migrate.ts
@@ -89,16 +89,25 @@ export async function migrate(pool: Pool): Promise<MigrationResult> {
     }
   }
 
-  // HNSW index is dim-locked, so we defer until embedding probe writes the
-  // dimension to audit.plugin_meta. Returns whether we still need to do it.
+  // Enable pgvectorscale if its files are installed (the custom image). On a
+  // plain pgvector image this is a guarded no-op. Lets ensureHnswIndex pick
+  // DiskANN, which — unlike HNSW — indexes >2000-dim vectors.
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vectorscale CASCADE").catch(() => undefined);
+
+  // The vector index is dim-locked, so we defer until the embedding probe
+  // writes the dimension to audit.plugin_meta. Returns whether it's still owed.
   const hnswDeferred = !(await ensureHnswIndex(pool));
   return { applied, skipped, hnswDeferred };
 }
 
 /**
- * Create the HNSW vector index on semantic.chunks once we know the embedding
- * dimension. Returns true when the index now exists, false if dim is still
- * unknown (caller should retry after embedding probe).
+ * Create the ANN vector index on semantic.chunks once we know the embedding
+ * dimension. Prefers pgvectorscale's DiskANN when the `vectorscale` extension
+ * is present — its SBQ-compressed layout indexes high-dim vectors (e.g. 4096-d
+ * Qwen3-Embedding-8B), whereas pgvector's HNSW is capped at 2000 dims by the
+ * 8 KB index-tuple page limit. Falls back to HNSW (≤2000). Returns true when an
+ * index now exists; false if the dim is still unknown, or it's >2000 and only
+ * HNSW is available (recall then runs as an exact scan until DiskANN is added).
  */
 export async function ensureHnswIndex(pool: Pool): Promise<boolean> {
   const meta = await pool.query<{ value: { dims?: number } }>(
@@ -107,24 +116,33 @@ export async function ensureHnswIndex(pool: Pool): Promise<boolean> {
   const dims = meta.rows[0]?.value?.dims;
   if (typeof dims !== "number" || dims <= 0) {return false;}
 
-  // Check if index already exists.
+  // Either index method already present → done.
   const existing = await pool.query(
     `SELECT 1 FROM pg_indexes
-       WHERE schemaname = 'semantic'
-         AND tablename  = 'chunks'
-         AND indexname  = 'chunks_hnsw'`,
+       WHERE schemaname = 'semantic' AND tablename = 'chunks'
+         AND indexname IN ('chunks_hnsw', 'chunks_diskann')`,
   );
   if (existing.rowCount && existing.rowCount > 0) {return true;}
 
-  // pgvector HNSW requires the column to be declared with a fixed dimension.
-  // We migrated `embedding` as VECTOR (any dim) so the schema file can ship
-  // before dims are known; here we promote it to VECTOR(N) once we have N
-  // and add the HNSW index. Existing rows are preserved through a USING cast.
+  const vs = await pool.query("SELECT 1 FROM pg_extension WHERE extname = 'vectorscale'");
+  const useDiskann = (vs.rowCount ?? 0) > 0;
+
+  if (!useDiskann && dims > 2000) {
+    // HNSW can't index this dim and DiskANN isn't installed; leave it unindexed
+    // (recall falls back to exact scan). Install pgvectorscale to enable it.
+    return false;
+  }
+
+  // Both methods need a fixed-dimension column. We ship `embedding` as VECTOR
+  // (any dim) so the schema file can land before dims are known; here we
+  // promote it to VECTOR(N) and build the index. Existing rows survive the cast.
+  const method = useDiskann ? "diskann" : "hnsw";
+  const indexName = useDiskann ? "chunks_diskann" : "chunks_hnsw";
   await pool.query(`
     ALTER TABLE semantic.chunks
       ALTER COLUMN embedding TYPE VECTOR(${dims}) USING embedding::VECTOR(${dims});
-    CREATE INDEX IF NOT EXISTS chunks_hnsw
-      ON semantic.chunks USING hnsw (embedding vector_cosine_ops);
+    CREATE INDEX IF NOT EXISTS ${indexName}
+      ON semantic.chunks USING ${method} (embedding vector_cosine_ops);
   `);
   return true;
 }

--- a/src/storage/schema/63-chunks-updated-at.sql
+++ b/src/storage/schema/63-chunks-updated-at.sql
@@ -1,0 +1,7 @@
+-- semantic.chunks.updated_at — marks agent-driven curation time, set by the
+-- edit operations (updateChunk / forgetChunk). The edit path referenced this
+-- column but it was never defined, so memory_update / memory_forget threw
+-- `column "updated_at" does not exist` at runtime. Nullable (null = never
+-- edited); ADD COLUMN IF NOT EXISTS is a fast metadata-only change and stays
+-- idempotent across existing deployments.
+ALTER TABLE semantic.chunks ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;

--- a/src/storage/schema/64-chunks-superseded-by.sql
+++ b/src/storage/schema/64-chunks-superseded-by.sql
@@ -1,0 +1,6 @@
+-- semantic.chunks.superseded_by — points at the later chunk whose fact replaced
+-- this one (set by reconcile when a preference value changes). Recall
+-- down-weights superseded chunks so the current truth wins, while the old chunk
+-- stays recallable for audit / "what did I used to think". Nullable; plain UUID
+-- (no FK) so a hard-delete of the newer chunk can't cascade-block the older one.
+ALTER TABLE semantic.chunks ADD COLUMN IF NOT EXISTS superseded_by UUID;

--- a/src/storage/schema/65-recall-returned-chunks.sql
+++ b/src/storage/schema/65-recall-returned-chunks.sql
@@ -1,0 +1,5 @@
+-- audit.recall_decisions.returned_chunk_ids — the chunks a recall actually
+-- returned. Lets a later memory_get (citation follow-up) credit the recall that
+-- surfaced the chunk with a relevance signal (P0#2). Nullable array; older rows
+-- stay NULL and are simply never matched.
+ALTER TABLE audit.recall_decisions ADD COLUMN IF NOT EXISTS returned_chunk_ids UUID[];

--- a/src/structured/reconcile.ts
+++ b/src/structured/reconcile.ts
@@ -103,7 +103,7 @@ export async function reconcile(pool: Pool, input: ReconcileInput): Promise<Reco
     }
 
     for (const p of input.result.preferences) {
-      const { id, deduped } = await upsertPreference(client, p);
+      const { id, deduped } = await upsertPreference(client, p, input.chunkId);
       if (deduped) {out.dedupCount += 1;}
       out.preferenceIds.push(id);
     }
@@ -257,6 +257,7 @@ async function upsertEvent(
 async function upsertPreference(
   client: PoolClient,
   p: PreferenceCandidate,
+  chunkId: string,
 ): Promise<{ id: string; deduped: boolean }> {
   const existing = await client.query<{ id: string; value: unknown; evidence_count: number }>(
     `SELECT id, value, evidence_count FROM structured.preferences
@@ -279,6 +280,17 @@ async function upsertPreference(
     await client.query(
       "UPDATE structured.preferences SET invalidated_at = now() WHERE id = $1",
       [row.id],
+    );
+    // Mark the old preference's source chunk(s) as superseded by this chunk so
+    // recall down-weights the now-outdated fact (P1#3). Provenance links the
+    // old preference id → its originating chunk.
+    await client.query(
+      `UPDATE semantic.chunks SET superseded_by = $1
+         WHERE id IN (SELECT chunk_id FROM structured.provenance
+                        WHERE item_kind = 'preference' AND item_id = $2 AND chunk_id IS NOT NULL)
+           AND id <> $1
+           AND superseded_by IS NULL`,
+      [chunkId, row.id],
     );
     const id = randomUUID();
     await client.query(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,6 +12,7 @@ import { resolveConfig, validateConfig } from "./config.js";
 import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
+import { buildResidualExtractor } from "./ingest/residual.js";
 import { recall } from "./recall/router.js";
 import { recordCitationFollowup } from "./recall/relevance.js";
 import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
@@ -522,7 +523,7 @@ export function buildStoreTool(args: { config: OpenClawConfig; sessionKey?: stri
       const p = params as StoreParams;
       const { cfg, pool, embedding } = await setup(pluginConfigOf(args.config));
       const outcome = await ingestOne(
-        { cfg, pool, embedding },
+        { cfg, pool, embedding, llmResidual: buildResidualExtractor(cfg) },
         {
           text: p.text,
           source: "manual",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -13,6 +13,7 @@ import { buildEmbeddingClientFromConfig } from "./embedding/client.js";
 import { forgetChunk, getChunk, updateChunk } from "./edit/operations.js";
 import { ingestOne } from "./ingest/pipeline.js";
 import { recall } from "./recall/router.js";
+import { recordCitationFollowup } from "./recall/relevance.js";
 import { getActiveCommitmentsByChunk } from "./structured/commitments.js";
 import { ensureHnswIndex, migrate } from "./storage/migrate.js";
 import { getPool } from "./storage/pool.js";
@@ -434,6 +435,11 @@ export function buildGetTool(args: { config: OpenClawConfig; sessionKey?: string
         };
       }
       const c = outcome.chunk;
+      // P0#2: a citation follow-up (memory_get on a recalled chunk) is a
+      // positive relevance signal for the recall that surfaced it. Fire-and-
+      // forget; never block the read.
+      void recordCitationFollowup(pool, agentId, c.chunkId, cfg.scoring.recall.relevanceFollowupWindowMs)
+        .catch(() => undefined);
       const cm = (await getActiveCommitmentsByChunk(pool, [c.chunkId], agentId))[0] ?? null;
       const flag = cm?.requiresConfirmation
         ? `\n⚠ action-sensitive (${cm.kind}) — confirm with the user before acting on this.`

--- a/src/workers/transcript-watcher.ts
+++ b/src/workers/transcript-watcher.ts
@@ -25,6 +25,7 @@ import type {
 } from "../config.js";
 import type { EmbeddingClient } from "../embedding/client.js";
 import { ingestOne, type IngestInput, type IngestOutcome } from "../ingest/pipeline.js";
+import type { LlmResidual } from "../ingest/residual.js";
 
 /* --------------------------------- types --------------------------------- */
 
@@ -46,6 +47,8 @@ export type TranscriptWatcherDeps = {
   cfg: ResolvedMemoryPostgresConfig;
   pool: Pool;
   embedding: EmbeddingClient;
+  /** Optional Stage 4 deep-extraction hook (off unless residual.enabled). */
+  llmResidual?: LlmResidual;
   watcher: ResolvedTranscriptWatcher;
   logger?: { info: (m: string) => void; warn: (m: string) => void };
 };

--- a/test/golden/baseline.json
+++ b/test/golden/baseline.json
@@ -1,0 +1,24 @@
+{
+  "metrics": {
+    "cases": 7,
+    "recallAt5": 1,
+    "mrr": 1,
+    "p50ms": 16,
+    "p95ms": 20,
+    "tierDistribution": {
+      "t2_hybrid": 6,
+      "t2_anchor": 1
+    },
+    "routesExercised": [
+      "anchor",
+      "category",
+      "concept_tag",
+      "entity_ref",
+      "fulltext",
+      "graph_walk",
+      "semantic",
+      "time_bucket",
+      "trgm"
+    ]
+  }
+}

--- a/test/golden/run-golden.mjs
+++ b/test/golden/run-golden.mjs
@@ -1,0 +1,411 @@
+/**
+ * Golden retrieval regression harness (P0#1).
+ *
+ * The self-tuning loop and every recall change need a correctness anchor:
+ * "did we surface the RIGHT chunk?", not just "was it cheap?". This harness
+ * seeds a fixed corpus into a throwaway Postgres, runs a labelled set of
+ * (query → expected chunk) cases across the recall routes, and reports
+ * recall@5 / MRR / tier distribution / p50-p95 latency. A committed
+ * baseline.json turns it into a CI gate: a >2% recall@5 drop fails the run.
+ *
+ * Hermetic by design — a deterministic 16-dim stub embedder, no ollama, no
+ * network. It exercises the deterministic routes (anchor / trgm / time_bucket /
+ * concept_tag / entity_ref / fulltext) faithfully; true semantic-quality runs
+ * against the real embedder are a later mode (--real-embed, not yet wired).
+ *
+ * Usage (one-time):  docker exec nextclaw-pg createdb -U nextclaw nextclaw_golden
+ *   node test/golden/run-golden.mjs [--update-baseline]
+ *
+ * WARNING: drops + recreates the semantic/structured/cache/cold/audit schemas
+ * in the target DB. It MUST be a dedicated golden DB, never the gateway's live
+ * memory store. Two guards enforce this (see assertSafeTarget + the real-data
+ * check): the run aborts if the target matches any Postgres url in
+ * openclaw.json, or if the target already holds non-stub chunks.
+ */
+
+import { resolveConfig } from "../../dist/src/config.js";
+import { EmbeddingClient } from "../../dist/src/embedding/client.js";
+import { ingestOne } from "../../dist/src/ingest/pipeline.js";
+import { recall } from "../../dist/src/recall/router.js";
+import { migrate, ensureHnswIndex, recordEmbeddingDims } from "../../dist/src/storage/migrate.js";
+import { getPool, closeAllPools } from "../../dist/src/storage/pool.js";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const BASELINE_PATH = path.join(HERE, "baseline.json");
+const LASTRUN_PATH = path.join(HERE, "last-run.json");
+
+const OPENCLAW_JSON = process.env["OPENCLAW_CONFIG"] ?? "/home/ubuntu/.openclaw/openclaw.json";
+const PG_URL =
+  process.env["OPENCLAW_MEMORY_PG_URL"] ??
+  // Dedicated golden DB — NEVER the gateway's live store (…/nextclaw).
+  "postgres://nextclaw:nextclaw@127.0.0.1:55432/nextclaw_golden";
+const UPDATE_BASELINE = process.argv.includes("--update-baseline");
+
+/** "host:port/db" identity of a connection url, ignoring credentials. */
+function dbIdentity(url) {
+  const m = String(url).match(/@([^/]+)\/([^?\s"']+)/);
+  return m ? `${m[1]}/${m[2]}` : String(url);
+}
+
+/**
+ * Guard 1: refuse to run if the target is a DB the live gateway uses. This
+ * harness DROPs schemas — pointing it at the gateway's memory store would
+ * destroy real memory (it once did). We compare the target against every
+ * postgres url referenced in openclaw.json.
+ */
+function assertSafeTarget(targetUrl) {
+  const target = dbIdentity(targetUrl);
+  let cfgText = "";
+  try {
+    cfgText = readFileSync(OPENCLAW_JSON, "utf8");
+  } catch {
+    return; // no config readable → can't cross-check; data-level guard still applies
+  }
+  for (const u of cfgText.match(/postgres:\/\/[^"\s]+/g) ?? []) {
+    if (dbIdentity(u) === target) {
+      throw new Error(
+        `REFUSING TO RUN: target ${target} is referenced in ${OPENCLAW_JSON} ` +
+          `(the live gateway memory store). Use a dedicated golden DB.`,
+      );
+    }
+  }
+}
+const RECALL_DROP_GATE = 0.02; // fail if recall@5 falls >2% below baseline
+const TOP_K = 5;
+
+/** Deterministic 16-dim embedder: char-frequency vector, L2-normalised. */
+class StubEmbeddingClient extends EmbeddingClient {
+  constructor() {
+    super({ baseUrl: "http://stub", model: "stub-embed:16" });
+  }
+  async embed(req) {
+    const embeddings = req.inputs.map((s) => {
+      const v = Array.from({ length: 16 }, () => 0);
+      for (let i = 0; i < s.length; i += 1) {
+        v[i % 16] += s.charCodeAt(i) / 1024;
+      }
+      const norm = Math.sqrt(v.reduce((a, x) => a + x * x, 0)) || 1;
+      return v.map((x) => x / norm);
+    });
+    return { embeddings, model: "stub-embed:16", dims: 16, latencyMs: 0 };
+  }
+  async probe() {
+    return { ok: true, dims: 16, latencyMs: 0 };
+  }
+}
+
+const DAY_A = new Date("2026-05-02T08:00:00Z"); // default ingest day → time_bucket 2026-05-02
+const DAY_B = new Date("2026-05-01T18:00:00Z"); // the one "yesterday" chunk → 2026-05-01
+
+/**
+ * Seed corpus. Each entry has a stable `key`; the actual chunk UUID is captured
+ * from ingestOne's return value so golden cases can reference chunks by key.
+ * Texts are deliberately distinctive so each route has an unambiguous target.
+ */
+const SEED = [
+  {
+    key: "anchor",
+    input: {
+      text: "Deploy notes: finished the staging rollout and smoke-tested the new release.",
+      source: "session",
+      anchors: { cwd: "/srv/staging-app", branch: "release" },
+      now: DAY_A,
+    },
+  },
+  {
+    key: "pr",
+    input: {
+      text: "Reviewed and merged the fix for the cache stampede under concurrent recall.",
+      source: "session",
+      anchors: { pr: "4821" },
+      now: DAY_A,
+    },
+  },
+  {
+    key: "trgm",
+    input: {
+      text: "We standardized on pgvector for embedding storage with HNSW indexing.",
+      source: "manual",
+      now: DAY_A,
+    },
+  },
+  {
+    key: "time",
+    input: {
+      text: "Daily standup: shipped the authentication refactor and closed three tickets.",
+      source: "session",
+      now: DAY_B,
+    },
+  },
+  {
+    key: "semantic",
+    input: {
+      text: "The lake run this morning was 5 kilometers along the north trail.",
+      source: "session",
+      now: DAY_A,
+    },
+  },
+  {
+    key: "concept",
+    input: {
+      text: "We added rate-limiting to the public API gateway during last sprint.",
+      source: "manual",
+      now: DAY_A,
+    },
+  },
+  {
+    key: "entity",
+    input: {
+      text: "Met with @lin to plan the Aurora project roadmap for next quarter.",
+      source: "session",
+      now: DAY_A,
+    },
+  },
+  // Distractors so top-5 is not trivially the whole corpus.
+  {
+    key: "distract1",
+    input: { text: "Bought groceries and refilled the coffee beans on the way home.", source: "session", now: DAY_A },
+  },
+  {
+    key: "distract2",
+    input: { text: "The quarterly budget spreadsheet needs another review column.", source: "manual", now: DAY_A },
+  },
+];
+
+function pct(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor(p * sorted.length));
+  return sorted[idx];
+}
+
+async function bootstrap(pool) {
+  await pool.query(`
+    DROP SCHEMA IF EXISTS semantic CASCADE;
+    DROP SCHEMA IF EXISTS structured CASCADE;
+    DROP SCHEMA IF EXISTS cache CASCADE;
+    DROP SCHEMA IF EXISTS cold CASCADE;
+    DROP SCHEMA IF EXISTS audit CASCADE;
+  `);
+  await migrate(pool);
+  await recordEmbeddingDims(pool, 16, "stub-embed:16");
+  await ensureHnswIndex(pool);
+}
+
+async function seedCorpus(cfg, pool, embedding) {
+  const ids = {};
+  for (const { key, input } of SEED) {
+    const out = await ingestOne({ cfg, pool, embedding }, input);
+    if (!out.chunkId) {
+      throw new Error(`seed '${key}' did not produce a chunkId (decision=${out.decision})`);
+    }
+    ids[key] = out.chunkId;
+  }
+  return ids;
+}
+
+/** Read the actual index value the deterministic extractor wrote for a chunk. */
+async function indexValue(pool, chunkId, kind) {
+  const r = await pool.query(
+    "SELECT value FROM semantic.chunk_indexes WHERE chunk_id = $1 AND kind = $2 ORDER BY value LIMIT 1",
+    [chunkId, kind],
+  );
+  return r.rows[0]?.value ?? null;
+}
+
+async function buildGoldenCases(pool, ids) {
+  // entity_ref + concept_tag values are resolved from what actually landed in
+  // chunk_indexes, so the harness never guesses the extractor's exact output.
+  const entityVal = await indexValue(pool, ids.entity, "entity_ref");
+  const conceptVal = await indexValue(pool, ids.concept, "concept_tag");
+
+  const cases = [
+    {
+      id: "anchor:cwd",
+      route: "anchor",
+      input: { query: "where did the staging deploy land", anchors: { cwd: "/srv/staging-app" }, maxResults: TOP_K },
+      expect: ids.anchor,
+    },
+    {
+      id: "anchor:pr",
+      route: "anchor",
+      input: { query: "that PR about the cache stampede", anchors: { pr: "4821" }, maxResults: TOP_K },
+      expect: ids.pr,
+    },
+    {
+      id: "trgm:typo",
+      route: "trgm",
+      input: { query: "pgvecter hnsw indexing", maxResults: TOP_K }, // misspelled on purpose
+      expect: ids.trgm,
+    },
+    {
+      id: "time_bucket",
+      route: "time_bucket",
+      input: { query: "what shipped that day", timeBucket: "2026-05-01", maxResults: TOP_K },
+      expect: ids.time,
+    },
+    {
+      id: "semantic:lexical",
+      route: "semantic",
+      input: { query: "morning lake run kilometers north trail", maxResults: TOP_K },
+      expect: ids.semantic,
+    },
+  ];
+
+  if (conceptVal) {
+    cases.push({
+      id: "concept_tag",
+      route: "concept_tag",
+      input: { query: "api gateway throttling", conceptTags: [conceptVal], maxResults: TOP_K },
+      expect: ids.concept,
+    });
+  } else {
+    console.warn("  ⚠ concept_tag case skipped — no concept_tag index on the seed chunk");
+  }
+
+  if (entityVal) {
+    cases.push({
+      id: "entity_ref",
+      route: "entity_ref",
+      input: { query: "what about Lin and Aurora", entityIds: [entityVal], maxResults: TOP_K },
+      expect: ids.entity,
+    });
+  } else {
+    console.warn("  ⚠ entity_ref case skipped — no entity_ref index on the seed chunk");
+  }
+
+  // graph_walk (2-hop) needs a relation-edge fixture between two entities;
+  // deferred to a v2 golden subset. Logged, not silently dropped.
+  console.warn("  ⚠ graph_walk route not yet covered (needs a relation fixture) — TODO v2");
+
+  return cases;
+}
+
+async function runCases(cfg, pool, embedding, cases) {
+  const perCase = [];
+  const latencies = [];
+  const tierCounts = {};
+  const routesSeen = new Set();
+
+  for (const c of cases) {
+    const t0 = Date.now();
+    const r = await recall({ cfg, pool, embedding }, c.input);
+    const ms = Date.now() - t0;
+    latencies.push(ms);
+    tierCounts[r.hitTier] = (tierCounts[r.hitTier] ?? 0) + 1;
+    for (const rt of r.routesRun ?? []) routesSeen.add(rt);
+
+    const idsTop = (r.results ?? []).slice(0, TOP_K).map((x) => x.chunkId);
+    const rank = idsTop.indexOf(c.expect); // 0-based; -1 = miss
+    const hit = rank >= 0;
+    perCase.push({
+      id: c.id,
+      route: c.route,
+      hit,
+      rank: hit ? rank + 1 : null,
+      rr: hit ? 1 / (rank + 1) : 0,
+      hitTier: r.hitTier,
+      routesRun: r.routesRun,
+      returned: (r.results ?? []).length,
+      latencyMs: ms,
+    });
+  }
+
+  const n = perCase.length;
+  const recallAt5 = n ? perCase.filter((c) => c.hit).length / n : 0;
+  const mrr = n ? perCase.reduce((a, c) => a + c.rr, 0) / n : 0;
+  const sortedLat = [...latencies].sort((a, b) => a - b);
+
+  return {
+    metrics: {
+      cases: n,
+      recallAt5: Number(recallAt5.toFixed(4)),
+      mrr: Number(mrr.toFixed(4)),
+      p50ms: pct(sortedLat, 0.5),
+      p95ms: pct(sortedLat, 0.95),
+      tierDistribution: tierCounts,
+      routesExercised: [...routesSeen].sort(),
+    },
+    perCase,
+  };
+}
+
+function report(result) {
+  const m = result.metrics;
+  console.log("\n=== Golden retrieval report ===");
+  console.log(`  cases:     ${m.cases}`);
+  console.log(`  recall@5:  ${m.recallAt5}`);
+  console.log(`  MRR:       ${m.mrr}`);
+  console.log(`  latency:   p50=${m.p50ms}ms  p95=${m.p95ms}ms`);
+  console.log(`  tiers:     ${JSON.stringify(m.tierDistribution)}`);
+  console.log(`  routes:    ${m.routesExercised.join(", ")}`);
+  console.log("  per-case:");
+  for (const c of result.perCase) {
+    const mark = c.hit ? "✓" : "✗";
+    console.log(
+      `    ${mark} ${c.id.padEnd(18)} route=${String(c.route).padEnd(12)} ` +
+        `rank=${c.rank ?? "-"} tier=${c.hitTier} ${c.latencyMs}ms`,
+    );
+  }
+}
+
+function gate(result) {
+  writeFileSync(LASTRUN_PATH, JSON.stringify(result, null, 2));
+
+  if (UPDATE_BASELINE || !existsSync(BASELINE_PATH)) {
+    writeFileSync(BASELINE_PATH, JSON.stringify({ metrics: result.metrics }, null, 2));
+    console.log(`\n  baseline ${UPDATE_BASELINE ? "updated" : "written"} → ${path.relative(process.cwd(), BASELINE_PATH)}`);
+    return 0;
+  }
+
+  const base = JSON.parse(readFileSync(BASELINE_PATH, "utf8")).metrics;
+  const drop = base.recallAt5 - result.metrics.recallAt5;
+  console.log(`\n  baseline recall@5=${base.recallAt5}  current=${result.metrics.recallAt5}  Δ=${(-drop).toFixed(4)}`);
+  if (drop > RECALL_DROP_GATE) {
+    console.error(`  ✗ REGRESSION: recall@5 dropped ${drop.toFixed(4)} (> ${RECALL_DROP_GATE} gate)`);
+    return 1;
+  }
+  console.log("  ✓ within gate");
+  return 0;
+}
+
+async function main() {
+  assertSafeTarget(PG_URL); // guard 1 — never the gateway's live memory DB
+  console.log(`Golden harness → ${PG_URL}`);
+  console.log("(resets semantic/structured/cache/cold/audit schemas in that DB)");
+  const cfg = resolveConfig({
+    postgres: { url: PG_URL },
+    embedding: { provider: "stub", model: "stub-embed:16" },
+  });
+  const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 15_000 });
+  const embedding = new StubEmbeddingClient();
+
+  // Guard 2 — never DROP a DB that already holds real (non-stub) memory.
+  const real = await pool
+    .query("SELECT count(*)::int AS n FROM semantic.chunks WHERE embedding_model IS DISTINCT FROM 'stub-embed:16'")
+    .catch(() => ({ rows: [{ n: 0 }] })); // table absent on a fresh golden DB → fine
+  if (real.rows[0].n > 0) {
+    throw new Error(
+      `REFUSING TO RUN: target holds ${real.rows[0].n} non-stub chunks — real memory, not a golden fixture.`,
+    );
+  }
+
+  await bootstrap(pool);
+  const ids = await seedCorpus(cfg, pool, embedding);
+  console.log(`  seeded ${Object.keys(ids).length} chunks`);
+  const cases = await buildGoldenCases(pool, ids);
+  const result = await runCases(cfg, pool, embedding, cases);
+  report(result);
+  const code = gate(result);
+
+  await closeAllPools();
+  process.exit(code);
+}
+
+main().catch(async (err) => {
+  console.error("golden harness failed:", err);
+  await closeAllPools().catch(() => {});
+  process.exit(2);
+});

--- a/test/invalidate.live.test.ts
+++ b/test/invalidate.live.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Chunk invalidation fan-out — a memory edit must clear every cache tier so a
+ * forgotten / rewritten chunk can't keep surfacing.
+ *
+ * Guards three fixes:
+ *   - WorkingSet.evict() is actually called now (was dead code → T0 leaked).
+ *   - QA answers derived from the chunk are invalidated (was never busted →
+ *     same question, stale answer, for up to the 90-day TTL).
+ *   - forgetChunk/updateChunk no longer error on the missing `updated_at`
+ *     column (migration 63 adds it).
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { getPool, closeAllPools } from "../src/storage/pool.js";
+import { migrate } from "../src/storage/migrate.js";
+import { workingSetFor, clearAllWorkingSets } from "../src/recall/working-set.js";
+import { storeCachedAnswer } from "../src/cache/qa.js";
+import { forgetChunk, type EditDeps } from "../src/edit/operations.js";
+
+const PG_URL = process.env["OPENCLAW_MEMORY_PG_URL"];
+const describeLive = PG_URL ? describe : describe.skip;
+const poolCfg = { url: PG_URL ?? "postgres://x", poolMax: 4, statementTimeoutMs: 15_000 };
+
+describeLive("chunk invalidation fan-out (live PG)", () => {
+  beforeAll(async () => {
+    const pool = await getPool(poolCfg);
+    await pool.query(`DROP SCHEMA IF EXISTS semantic CASCADE; DROP SCHEMA IF EXISTS structured CASCADE;
+      DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS cold CASCADE; DROP SCHEMA IF EXISTS audit CASCADE;`);
+    await migrate(pool);
+  }, 60_000);
+
+  afterAll(async () => {
+    clearAllWorkingSets();
+    await closeAllPools();
+  });
+
+  it("forgetChunk evicts T0, drops hot_chunks, and invalidates derived QA answers", async () => {
+    const pool = await getPool(poolCfg);
+    const chunkId = randomUUID();
+    await pool.query(
+      `INSERT INTO semantic.chunks
+         (id, source, kind, text, text_hash, embedding, embedding_model, agent_id, retention_class, importance)
+       VALUES ($1,'manual','fact','favorite extension is pgvector',$2,'[0.1,0.2,0.3]'::vector,'stub-embed:16','main','standard',0.5)`,
+      [chunkId, "hash_" + chunkId],
+    );
+
+    const ws = workingSetFor(undefined, 50, "main", "default");
+    ws.add({ chunkId, source: "manual", sourceRef: null, text: "favorite extension is pgvector",
+      rawScore: 0.5, normScore: 0.5, hits: ["semantic"], combinedScore: 0.5 });
+    await pool.query(`INSERT INTO cache.hot_chunks (user_scope, chunk_id, expires_at, warmth_score)
+      VALUES ('default',$1, now()+interval '1 day', 1.0)`, [chunkId]);
+    const qaId = await storeCachedAnswer(pool, {
+      agentId: "main", questionText: "favorite extension?",
+      questionEmbedding: [0.1, 0.2, 0.3, 0.4], embeddingModel: "stub-embed:16",
+      answerText: "pgvector", sourceDocId: chunkId,
+    });
+
+    expect(ws.snapshot().some((e) => e.chunkId === chunkId)).toBe(true);
+
+    const r = await forgetChunk({ pool } as unknown as EditDeps, { chunkId, agentId: "main", reason: "test" });
+    expect(r.ok).toBe(true);
+
+    // T0: evicted from the in-process working set.
+    expect(ws.snapshot().some((e) => e.chunkId === chunkId)).toBe(false);
+    // T1: hot_chunks dropped.
+    const hot = await pool.query<{ n: number }>(`SELECT count(*)::int n FROM cache.hot_chunks WHERE chunk_id=$1`, [chunkId]);
+    expect(hot.rows[0].n).toBe(0);
+    // QA: derived answer invalidated.
+    const qa = await pool.query<{ invalidated: boolean }>(`SELECT invalidated FROM cache.qa WHERE id=$1`, [qaId]);
+    expect(qa.rows[0].invalidated).toBe(true);
+  });
+});

--- a/test/relevance.live.test.ts
+++ b/test/relevance.live.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Recall relevance loop (P0#2) — audit.recall_decisions.relevance_estimate is
+ * filled from a real downstream signal (a citation follow-up) instead of a
+ * hardcoded guess. recall records returned_chunk_ids; a later memory_get on a
+ * recalled chunk credits the recall that surfaced it.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { resolveConfig } from "../src/config.js";
+import { EmbeddingClient, type EmbedRequest, type EmbedResult } from "../src/embedding/client.js";
+import { getPool, closeAllPools } from "../src/storage/pool.js";
+import { migrate } from "../src/storage/migrate.js";
+import { recall } from "../src/recall/router.js";
+import { recordCitationFollowup } from "../src/recall/relevance.js";
+
+const PG_URL = process.env["OPENCLAW_MEMORY_PG_URL"];
+const describeLive = PG_URL ? describe : describe.skip;
+
+class StubEmbed extends EmbeddingClient {
+  constructor() { super({ baseUrl: "http://stub", model: "stub-embed:16" }); }
+  override async embed(req: EmbedRequest): Promise<EmbedResult> {
+    const embeddings = req.inputs.map((s) => {
+      const v = Array.from({ length: 16 }, () => 0);
+      for (let i = 0; i < s.length; i += 1) { v[i % 16] += s.charCodeAt(i) / 1024; }
+      const n = Math.sqrt(v.reduce((a, x) => a + x * x, 0)) || 1;
+      return v.map((x) => x / n);
+    });
+    return { embeddings, model: "stub-embed:16", dims: 16, latencyMs: 0 };
+  }
+  override async probe() { return { ok: true as const, dims: 16, latencyMs: 0 }; }
+}
+
+describeLive("recall relevance loop (live PG)", () => {
+  const cfg = resolveConfig({ postgres: { url: PG_URL ?? "postgres://x" }, embedding: { provider: "stub", model: "stub-embed:16" } });
+  const emb = new StubEmbed();
+
+  beforeAll(async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    await pool.query(`DROP SCHEMA IF EXISTS semantic CASCADE; DROP SCHEMA IF EXISTS structured CASCADE;
+      DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS cold CASCADE; DROP SCHEMA IF EXISTS audit CASCADE;`);
+    await migrate(pool);
+  }, 60_000);
+
+  afterAll(async () => { await closeAllPools(); });
+
+  it("records returned_chunk_ids and fills relevance_estimate on a citation follow-up", async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    const text = "unique relevance marker token alpha";
+    const [e] = (await emb.embed({ inputs: [text] })).embeddings;
+    const X = randomUUID();
+    await pool.query(
+      `INSERT INTO semantic.chunks (id,source,kind,text,text_hash,embedding,embedding_model,agent_id,retention_class,importance)
+       VALUES ($1,'manual','fact',$2,$3,$4::vector,'stub-embed:16','main','standard',0.5)`,
+      [X, text, "hash_" + X, "[" + e.join(",") + "]"]);
+
+    const r = await recall({ cfg, pool, embedding: emb }, { query: text, maxResults: 5, agentId: "main" });
+    expect(r.results.some((c) => c.chunkId === X)).toBe(true);
+
+    const rd = (await pool.query<{ id: string; relevance_estimate: number | null; returned_chunk_ids: string[] | null }>(
+      `SELECT id, relevance_estimate, returned_chunk_ids FROM audit.recall_decisions ORDER BY ts DESC LIMIT 1`)).rows[0];
+    expect(rd.relevance_estimate).toBeNull();
+    expect(rd.returned_chunk_ids ?? []).toContain(X);
+
+    await recordCitationFollowup(pool, "main", X, 3_600_000);
+
+    const after = (await pool.query<{ relevance_estimate: number | null }>(
+      `SELECT relevance_estimate FROM audit.recall_decisions WHERE id=$1`, [rd.id])).rows[0];
+    expect(Number(after.relevance_estimate)).toBe(1.0);
+  });
+});

--- a/test/residual-extractor.test.ts
+++ b/test/residual-extractor.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Stage 4 LLM residual extractor (P2#6 wiring) — pure unit tests (no PG, no
+ * network). Covers the JSON parser and the gate/fail-soft behaviour with a
+ * mock chat client.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseResidualPreferences, buildResidualExtractor } from "../src/ingest/residual.js";
+import { resolveConfig } from "../src/config.js";
+
+describe("parseResidualPreferences", () => {
+  it("parses a clean JSON object (lowercases the key)", () => {
+    expect(parseResidualPreferences('{"preferences":[{"key":"Coffee","value":"light roast","confidence":0.9}]}'))
+      .toEqual([{ scope: "global", key: "coffee", value: "light roast", confidence: 0.9 }]);
+  });
+  it("tolerates code fences / surrounding prose, defaults confidence", () => {
+    expect(parseResidualPreferences('sure:\n```json\n{"preferences":[{"key":"seat","value":"aisle"}]}\n```'))
+      .toEqual([{ scope: "global", key: "seat", value: "aisle", confidence: 0.6 }]);
+  });
+  it("returns [] on non-JSON and drops malformed entries", () => {
+    expect(parseResidualPreferences("not json")).toEqual([]);
+    expect(parseResidualPreferences('{"preferences":[{"value":"no key"},{"key":"ok","value":"v"}]}'))
+      .toEqual([{ scope: "global", key: "ok", value: "v", confidence: 0.6 }]);
+  });
+});
+
+describe("buildResidualExtractor", () => {
+  const cfg = resolveConfig({
+    postgres: { url: "postgres://x" }, embedding: { provider: "stub", model: "m" },
+    residual: { enabled: true, model: { format: "gemini", baseUrl: "http://stub", model: "g" } },
+  });
+
+  it("is undefined when residual is disabled (deterministic-only)", () => {
+    const off = resolveConfig({ postgres: { url: "postgres://x" }, embedding: { provider: "stub", model: "m" } });
+    expect(buildResidualExtractor(off)).toBeUndefined();
+  });
+
+  it("calls the model and maps preferences", async () => {
+    const mock = { chat: async () => ({ ok: true as const, text: '{"preferences":[{"key":"coffee","value":"light","confidence":0.8}]}', inputTokens: 10, outputTokens: 5, latencyMs: 1 }) };
+    const fn = buildResidualExtractor(cfg, mock)!;
+    const r = await fn("I switched to light roast", {});
+    expect(r.result.preferences).toEqual([{ scope: "global", key: "coffee", value: "light", confidence: 0.8 }]);
+    expect(r.tokensUsed).toBe(15);
+  });
+
+  it("fails soft on a model error (e.g. 429) — empty result, 0 tokens", async () => {
+    const mock = { chat: async () => ({ ok: false as const, error: "HTTP 429", latencyMs: 1 }) };
+    const fn = buildResidualExtractor(cfg, mock)!;
+    const r = await fn("anything", {});
+    expect(r.result.preferences).toEqual([]);
+    expect(r.tokensUsed).toBe(0);
+  });
+});

--- a/test/residual.live.test.ts
+++ b/test/residual.live.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Confidence-gated LLM residual (P2#6) — Stage 4 deep extraction fires when the
+ * deterministic extractors are weak by COMBINED CONFIDENCE (not just empty),
+ * bounded by a per-chunk char cap and a daily token budget.
+ *
+ * NOTE: inert in production until a residual model is bound to deps.llmResidual;
+ * this exercises the gate with a mock.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { resolveConfig } from "../src/config.js";
+import { EmbeddingClient, type EmbedRequest, type EmbedResult } from "../src/embedding/client.js";
+import { getPool, closeAllPools } from "../src/storage/pool.js";
+import { migrate } from "../src/storage/migrate.js";
+import { ingestOne, _residualInternal } from "../src/ingest/pipeline.js";
+import type { ExtractorResult } from "../src/structured/types.js";
+
+const PG_URL = process.env["OPENCLAW_MEMORY_PG_URL"];
+const describeLive = PG_URL ? describe : describe.skip;
+
+class StubEmbed extends EmbeddingClient {
+  constructor() { super({ baseUrl: "http://stub", model: "stub-embed:16" }); }
+  override async embed(req: EmbedRequest): Promise<EmbedResult> {
+    return { embeddings: req.inputs.map(() => Array.from({ length: 16 }, (_, i) => (i + 1) / 16)), model: "stub-embed:16", dims: 16, latencyMs: 0 };
+  }
+  override async probe() { return { ok: true as const, dims: 16, latencyMs: 0 }; }
+}
+const residualResult = (): ExtractorResult =>
+  ({ entities: [], events: [], preferences: [], metrics: [], relations: [], commitments: [], extractorVersion: "residual" });
+
+describe("residual confidence gate (unit)", () => {
+  it("combinedConfidence averages candidate confidences, 0 when empty", () => {
+    const cc = _residualInternal.combinedConfidence;
+    expect(cc({ entities: [{ confidence: 0.8 }], events: [], preferences: [], metrics: [], relations: [] } as unknown as ExtractorResult)).toBe(0.8);
+    expect(cc({ entities: [], events: [], preferences: [], metrics: [], relations: [] } as unknown as ExtractorResult)).toBe(0);
+  });
+});
+
+describeLive("residual gating (live PG)", () => {
+  const cfg = resolveConfig({ postgres: { url: PG_URL ?? "postgres://x" }, embedding: { provider: "stub", model: "stub-embed:16" } });
+  const emb = new StubEmbed();
+  const weakText = "The afternoon discussion wandered across several unrelated subjects without reaching any firm conclusion.";
+
+  beforeAll(async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    await pool.query(`DROP SCHEMA IF EXISTS semantic CASCADE; DROP SCHEMA IF EXISTS structured CASCADE;
+      DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS cold CASCADE; DROP SCHEMA IF EXISTS audit CASCADE;`);
+    await migrate(pool);
+  }, 60_000);
+
+  afterAll(async () => { await closeAllPools(); });
+
+  it("fires the residual on a low-confidence chunk", async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    let calls = 0;
+    const out = await ingestOne(
+      { cfg, pool, embedding: emb, llmResidual: async () => { calls += 1; return { result: residualResult(), tokensUsed: 120 }; } },
+      { text: weakText, source: "manual", now: new Date("2026-06-12T09:00:00Z") });
+    expect(out.decision).toBe("accepted");
+    expect(calls).toBe(1);
+    expect(out.ingestPath).toBe("llm_residual");
+  });
+
+  it("skips the residual when the daily token budget is exceeded", async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    await pool.query(
+      `INSERT INTO audit.ingest_decisions (id, ts, source, decision, routes, ingest_path, llm_tokens_used, agent_id, scored_at)
+       VALUES (gen_random_uuid(), now(), 'test', 'accepted', '{}'::text[], 'llm_residual', 60000, 'main', now())`);
+    let calls = 0;
+    const out = await ingestOne(
+      { cfg, pool, embedding: emb, llmResidual: async () => { calls += 1; return { result: residualResult(), tokensUsed: 120 }; } },
+      { text: weakText + " A slightly different wording to dodge dedup entirely here.", source: "manual", now: new Date("2026-06-12T09:01:00Z") });
+    expect(calls).toBe(0);
+    expect(out.ingestPath).not.toBe("llm_residual");
+  });
+});

--- a/test/supersede.live.test.ts
+++ b/test/supersede.live.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Supersede down-weight (P1#3) — when a later chunk asserts a fact that
+ * contradicts an earlier one (a preference value change), the earlier chunk is
+ * marked `superseded_by` and recall down-weights it so the current truth wins,
+ * while the old chunk stays recallable for audit.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { resolveConfig } from "../src/config.js";
+import { EmbeddingClient, type EmbedRequest, type EmbedResult } from "../src/embedding/client.js";
+import { getPool, closeAllPools } from "../src/storage/pool.js";
+import { migrate } from "../src/storage/migrate.js";
+import { reconcile } from "../src/structured/reconcile.js";
+import { recall } from "../src/recall/router.js";
+import type { ExtractorResult } from "../src/structured/types.js";
+
+const PG_URL = process.env["OPENCLAW_MEMORY_PG_URL"];
+const describeLive = PG_URL ? describe : describe.skip;
+
+class StubEmbed extends EmbeddingClient {
+  constructor() { super({ baseUrl: "http://stub", model: "stub-embed:16" }); }
+  override async embed(req: EmbedRequest): Promise<EmbedResult> {
+    const embeddings = req.inputs.map((s) => {
+      const v = Array.from({ length: 16 }, () => 0);
+      for (let i = 0; i < s.length; i += 1) { v[i % 16] += s.charCodeAt(i) / 1024; }
+      const n = Math.sqrt(v.reduce((a, x) => a + x * x, 0)) || 1;
+      return v.map((x) => x / n);
+    });
+    return { embeddings, model: "stub-embed:16", dims: 16, latencyMs: 0 };
+  }
+  override async probe() { return { ok: true as const, dims: 16, latencyMs: 0 }; }
+}
+
+const ER = (prefs: ExtractorResult["preferences"]): ExtractorResult =>
+  ({ entities: [], events: [], preferences: prefs, metrics: [], relations: [], commitments: [], extractorVersion: "test-1" });
+
+describeLive("supersede down-weight (live PG)", () => {
+  const cfg = resolveConfig({ postgres: { url: PG_URL ?? "postgres://x" }, embedding: { provider: "stub", model: "stub-embed:16" } });
+  const emb = new StubEmbed();
+
+  beforeAll(async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    await pool.query(`DROP SCHEMA IF EXISTS semantic CASCADE; DROP SCHEMA IF EXISTS structured CASCADE;
+      DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS cold CASCADE; DROP SCHEMA IF EXISTS audit CASCADE;`);
+    await migrate(pool);
+  }, 60_000);
+
+  afterAll(async () => { await closeAllPools(); });
+
+  it("marks the old chunk superseded and ranks the current fact above it", async () => {
+    const pool = await getPool({ url: cfg.postgres.url, poolMax: 4, statementTimeoutMs: 20_000 });
+    const textA = "favorite database extension is pgvector specialmarker";
+    const textB = "favorite database extension is pgtrgm specialmarker";
+    const [eA] = (await emb.embed({ inputs: [textA] })).embeddings;
+    const [eB] = (await emb.embed({ inputs: [textB] })).embeddings;
+    const A = randomUUID(), B = randomUUID();
+    const ins = (id: string, text: string, vec: number[], hash: string) => pool.query(
+      `INSERT INTO semantic.chunks (id,source,kind,text,text_hash,embedding,embedding_model,agent_id,retention_class,importance)
+       VALUES ($1,'manual','fact',$2,$3,$4::vector,'stub-embed:16','main','standard',0.5)`,
+      [id, text, hash, "[" + vec.join(",") + "]"]);
+    await ins(A, textA, eA, "hA");
+    await ins(B, textB, eB, "hB");
+
+    await reconcile(pool, { chunkId: A, rawExcerpt: textA, result: ER([{ scope: "global", key: "fav_ext", value: "pgvector", confidence: 0.9 }]), agentId: "main" });
+    const supBefore = (await pool.query<{ superseded_by: string | null }>(`SELECT superseded_by FROM semantic.chunks WHERE id=$1`, [A])).rows[0].superseded_by;
+    expect(supBefore).toBeNull();
+
+    await reconcile(pool, { chunkId: B, rawExcerpt: textB, result: ER([{ scope: "global", key: "fav_ext", value: "pgtrgm", confidence: 0.9 }]), agentId: "main" });
+    const supAfter = (await pool.query<{ superseded_by: string | null }>(`SELECT superseded_by FROM semantic.chunks WHERE id=$1`, [A])).rows[0].superseded_by;
+    expect(supAfter).toBe(B);
+
+    const r = await recall({ cfg, pool, embedding: emb }, { query: "favorite database extension specialmarker", maxResults: 5 });
+    const ids = r.results.map((c) => c.chunkId);
+    const idxA = ids.indexOf(A), idxB = ids.indexOf(B);
+    expect(idxB).toBeGreaterThanOrEqual(0);
+    expect(idxA === -1 || idxB < idxA).toBe(true);
+  });
+});


### PR DESCRIPTION
Built, tested, and deployed across one session. Every commit builds; each feature has a committed test; the golden recall regression stays at recall@5=1 throughout.

## High-dim recall — pgvectorscale (DiskANN)
The embedder is Qwen3-Embedding-8B (4096-d), past pgvector's 2000-d HNSW cap, so semantic recall ran as an exact seq scan. pgvectorscale's StreamingDiskANN indexes it (`chunks_diskann`) with **no re-embed**. `migrate.ts` builds diskann when the `vectorscale` extension is present, else falls back to HNSW. Image recipe: `dev/vectorscale.Dockerfile` (pgvector/pgvector:pg16 + official pgvectorscale .deb).

## Correctness (P0/P1)
- **P1#4** — unified `invalidateChunk(chunkId)` fans out to all four cache tiers (T0 working sets / hot_chunks / recall / QA). Fixes three latent bugs: `WorkingSet.evict` was dead code (T0 leaked), the QA cache was never invalidated (stale answers up to its 90-day TTL), and `updateChunk`/`forgetChunk` crashed on a missing `updated_at` column.
- **P1#3** — supersede down-weight: when a later chunk contradicts a preference, reconcile marks the old chunk `superseded_by` and recall applies a 0.2× penalty so the current truth wins.
- **P0#2** — recall relevance loop: recall records `returned_chunk_ids`; a citation follow-up (memory_get) fills `relevance_estimate` for the tuning loop.
- **P0#1** — golden retrieval regression harness (hermetic 16-d stub, two guards against ever running on the live DB) + committed baseline.

## Extraction (P2#6)
- Confidence-gated LLM residual (fires on low combined confidence, not just empty) + per-chunk char cap + daily token budget.
- Wired to **gemini-2.5-flash via the credbroker** (key rotation). v1 extracts preferences from natural language the regex extractors miss; entities/relations are v2. Fail-soft on any 429/error, in-process RPM cap. Config-gated (`residual.enabled`, default off). Verified against real gemini.

## Migrations
`63-chunks-updated-at` · `64-chunks-superseded-by` · `65-recall-returned-chunks` — all `ADD COLUMN IF NOT EXISTS`, metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)